### PR TITLE
ci(docs): separate building docs and creating PyPI distribution

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
         [
             "@semantic-release/exec",
             {
-                "publishCmd": "bash deploy.sh ${nextRelease.version}"
+                "publishCmd": "bash deploy.sh"
             }
         ]
     ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,17 @@ jobs:
     - "3.6"
     install:
     - pip install -r dev-requirements.txt
+    - pip install -r requirements.txt 
     - npm install @semantic-release/exec
     script:
     - git config --global user.email "releases@ladybug.tools"
     - git config --global user.name "ladybugbot"
     - npx semantic-release
+  - stage: docs
+    if: branch = master AND (NOT type IN (pull_request))
+    script:
+    - sphinx-apidoc -f -e -d 4 -o ./docs ./honeybee_radiance
+    - sphinx-build -b html ./docs ./docs/_build/docs
     deploy:
       provider: pages
       skip_cleanup: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,26 +1,6 @@
 #!/bin/sh
 
-deploy_to_pypi() {
-  echo "Building distribution"
-  python setup.py sdist bdist_wheel
-  echo "Pushing new version to PyPi"
-  twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 
-}
-
-build_docs() {
-  echo "Building documentation files"
-  sphinx-apidoc -f -e -d 4 -o ./docs ./honeybee_radiance
-  sphinx-build -b html ./docs ./docs/_build/docs -D release=$1 -D version=$1
-}
-
-
-if [ -n "$1" ]
-then
-  NEXT_RELEASE_VERSION=$1
-else
-  echo "A release version must be supplied"
-  exit 1
-fi
-
-deploy_to_pypi
-build_docs $NEXT_RELEASE_VERSION
+echo "Building distribution"
+python setup.py sdist bdist_wheel
+echo "Pushing new version to PyPi"
+twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 


### PR DESCRIPTION
I noticed the the online documentation for honeybee-radiance has been overwritten after the last
commit which was a chore(). This change should fix that issue from now on.
