### PR TITLE
feat(lib): Load modifiers and modifier sets from files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include honeybee_radiance/config.json
+include honeybee_radiance/lib/data/modifiers/*.mat
+include honeybee_radiance/lib/data/modifiers/*.rad
+include honeybee_radiance/lib/data/modifiers/*.json
+include honeybee_radiance/lib/data/modifiersets/*.json

--- a/honeybee_radiance/config.json
+++ b/honeybee_radiance/config.json
@@ -1,0 +1,5 @@
+{
+    "__comment__": "Add full paths to folders (eg. C:/Radiance/bin).",
+    "radiance_path": "",
+    "standards_data_folder": ""
+}

--- a/honeybee_radiance/config.py
+++ b/honeybee_radiance/config.py
@@ -1,0 +1,309 @@
+"""Honeybee_radiance configurations.
+
+Import this into every module where access configurations are needed.
+
+Usage:
+
+.. code-block:: python
+
+    from honeybee_radiance.config import folders
+    print(folders.radiance_path)
+    folders.radiance_path = "C:/Radiance/bin"
+"""
+import honeybee.config as hb_config
+
+import os
+import platform
+import json
+
+
+class Folders(object):
+    """Honeybee_radiance folders.
+
+    Args:
+        config_file: The path to the config.json file from which folders are loaded.
+            If None, the config.json module included in this package will be used.
+            Default: None.
+        mute: If False, the paths to the various folders will be printed as they
+            are found. If True, no printing will occur upon initialization of this
+            class. Default: True.
+
+    Properties:
+        * radiance_path
+        * radbin_path
+        * radlib_path
+        * standards_data_folder
+        * modifier_lib
+        * modifierset_lib
+        * config_file
+        * mute
+    """
+
+    def __init__(self, config_file=None, mute=True):
+        # set the mute value
+        self.mute = bool(mute)
+
+        # load paths from the config JSON file 
+        self.config_file  = config_file
+
+    @property
+    def radiance_path(self):
+        """Get or set the path to Radiance installation folder.
+        
+        This is the top level folder that contains both the "bin" and the "lib"
+        directories.
+        """
+        return self._radiance_path
+    
+    @radiance_path.setter
+    def radiance_path(self, r_path):
+        exe_name = 'rad.exe' if os.name == 'nt' else 'rad'
+        if not r_path:  # check the PATH and then the default installation locations
+            r_path, rad_exe_file = self._which(exe_name)
+            if r_path is None:  # search within the default installation locations
+                r_path, rad_exe_file = self._find_radiance_folder()
+        else:
+            r_path = os.path.join(r_path, 'bin')
+            rad_exe_file = os.path.join(r_path, exe_name)
+
+        if r_path:  # check that the Radiance executable exists in the installation
+            assert os.path.isfile(rad_exe_file), \
+                '{} is not a valid path to a Radiance installation.'.format(r_path)
+
+        # set the radiance_path
+        self._radbin_path = r_path
+        if r_path:
+            self._radiance_path = os.path.split(r_path)[0]
+            self._radlib_path = os.path.join(self._radiance_path, 'lib')
+            if not self.mute:
+                print("Path to Radiance is set to: %s" % self._radiance_path)
+        else:
+            self._radiance_path = None
+            self._radlib_path = None
+
+    @property
+    def radbin_path(self):
+        """Get the path to Radiance bin folder.
+        
+        This is the "bin" directory for Radiance installation (the one that
+        contains the executable files).
+        """
+        return self._radbin_path
+
+    @property
+    def radlib_path(self):
+        """Get the path to Radiance lib folder."""
+        return self._radlib_path
+
+    @property
+    def standards_data_folder(self):
+        """Get or set the path to the folder standards loaded to honeybee_radiance.lib.
+        
+        This folder must have the following sub-folders in order to be valid:
+            * modifiers - folder with RAD files for modifiers.
+            * modifiersets - folder with JSON files of abridged ModifierSets.
+        """
+        return self._standards_data_folder
+    
+    @standards_data_folder.setter
+    def standards_data_folder(self, path):
+        if not path:  # check the default locations of the template library
+            path = self._find_standards_data_folder()
+        
+        # gather all of the sub folders underneath the master folder
+        self._modifier_lib = os.path.join(path, 'modifiers') if path else None
+        self._modifierset_lib = os.path.join(path, 'modifiersets') if path else None
+
+        # check that the library's sub-folders exist
+        if path:
+            assert os.path.isdir(self._modifier_lib), \
+                '{} lacks a "modifiers" folder.'.format(path)
+            assert os.path.isdir(self._modifierset_lib), \
+                '{} lacks a "modifiersets" folder.'.format(path)
+
+        # set the standards_data_folder
+        self._standards_data_folder = path
+        if path and not self.mute:
+            print('Path to the standards_data_folder is set to: '
+                    '{}'.format(self._standards_data_folder))
+
+    @property
+    def modifier_lib(self):
+        """Get the path to the modifier library in the standards_data_folder."""
+        return self._modifier_lib
+    
+    @property
+    def modifierset_lib(self):
+        """Get the path to the modifierset library in the standards_data_folder."""
+        return self._modifierset_lib
+
+    @property 
+    def config_file(self):
+        """Get or set the path to the config.json file from which folders are loaded.
+        
+        Setting this to None will result in using the config.json module included
+        in this package.
+        """
+        return self._config_file
+
+    @config_file.setter
+    def config_file(self, cfg):
+        if cfg is None:
+            cfg = os.path.join(os.path.dirname(__file__), 'config.json')
+        self._load_from_file(cfg)
+        self._config_file = cfg
+
+    def _load_from_file(self, file_path):
+        """Set all of the the properties of this object from a config JSON file.
+        
+        Args:
+            file_path: Path to a JSON file containing the file paths. A sample of this
+                JSON is the config.json file within this package.
+        """
+        # check the default file path
+        assert os.path.isfile(str(file_path)), \
+            ValueError('No file found at {}'.format(file_path))
+
+        # set the default paths to be all blank
+        default_path = {
+            "radiance_path": r'',
+            "standards_data_folder": r''
+        }
+
+        with open(file_path, 'r') as cfg:
+            try:
+                paths = json.load(cfg)
+            except Exception as e:
+                print('Failed to load paths from {}.\n{}'.format(file_path, e))
+            else:
+                for key, p in paths.items():
+                    if not key.startswith('__') and p.strip():
+                        default_path[key] = p.strip()
+
+        # set path for radiance installations
+        self.radiance_path = default_path["radiance_path"]
+
+        # set path for the standards_data_folder
+        self.standards_data_folder = default_path["standards_data_folder"]
+
+    def _find_radiance_folder(self):
+        """Find the Radiance installation in its default location.
+        
+        This method will first attempt to return the path of a standalone Radiance
+        installation and, if none are found, it will search for one that is
+        installed with OpenStudio.
+
+        Returns:
+            File directory and full path to executable in case of success.
+            None, None in case of failure.
+        """
+        # first check for the default location where standalone Radiance is installed
+        rad_path = None
+        if os.name == 'nt':  # search the C:/ drive on Windows
+            for f in os.listdir('C:\\'):
+                if f.lower() == 'radiance' and os.path.isdir('C:\\{}'.format(f)):
+                    rad_path = 'C:\\{}'.format(f)
+                    break
+        elif platform.system() == 'Darwin':  # search the Applications folder on Mac
+            for f in os.listdir('/Applications/'):
+                if f.lower() == 'radiance' and os.path.isdir('/Applications/{}'.format(f)):
+                    rad_path = '/Applications/{}'.format(f)
+                    break
+        elif platform.system() == 'Linux':  # search the usr/local folder
+            for f in os.listdir('/usr/local/'):
+                if f.lower() == 'radiance' and os.path.isdir('/usr/local/{}'.format(f)):
+                    rad_path = '/usr/local/{}'.format(f)
+                    break
+
+        if not rad_path:  # then check the Radiance that comes with OpenStudio
+            os_path = self._find_openstudio_folder()
+            if os_path and os.path.isdir(os.path.join(os_path, 'Radiance')):
+                rad_path = os.path.join(os_path, 'Radiance')
+
+        if not rad_path:  # No Radiance installations were found
+            return None, None
+
+        # return the path to the executable
+        rad_path = os.path.join(rad_path, 'bin')
+        exec_file = os.path.join(rad_path, 'rad.exe') if os.name == 'nt' \
+            else os.path.join(rad_path, 'rad')
+        return rad_path, exec_file
+
+    @staticmethod
+    def _find_openstudio_folder():
+        """Find the most recent OpenStudio installation in its default location.
+
+        Returns:
+            File directory and full path to executable in case of success.
+            None, None in case of failure.
+        """
+        def getversion(openstudio_path):
+            """Get digits for the version of OpenStudio."""
+            ver = ''.join(s for s in openstudio_path if (s.isdigit() or s == '.'))
+            return sum(int(d) * (10 ** i) for i, d in enumerate(reversed(ver.split('.'))))
+
+        if os.name == 'nt':  # search the C:/ drive on Windows
+            os_folders = ['C:\\{}'.format(f) for f in os.listdir('C:\\')
+                          if (f.lower().startswith('openstudio') and
+                              os.path.isdir('C:\\{}'.format(f)))]
+        elif platform.system() == 'Darwin':  # search the Applications folder on Mac
+            os_folders = ['/Applications/{}'.format(f) for f in os.listdir('/Applications/')
+                          if (f.lower().startswith('openstudio') and
+                              os.path.isdir('/Applications/{}'.format(f)))]
+        elif platform.system() == 'Linux':  # search the usr/local folder
+            os_folders = ['/usr/local/{}'.format(f) for f in os.listdir('/usr/local/')
+                          if (f.lower().startswith('openstudio') and
+                              os.path.isdir('/usr/local/{}'.format(f)))]
+        else:  # unknown operating system
+            os_folders = None
+        
+        if not os_folders:  # No Openstudio installations were found
+            return None
+        
+        # get the most recent version of OpenStudio that was found
+        return sorted(os_folders, key=getversion, reverse=True)[0]
+
+    @staticmethod
+    def _find_standards_data_folder():
+        """Find the the user template library in its default location.
+        
+        The HOME/honeybee/honeybee_standards/data folder will be checked first,
+        which can conatain libraries that are not overwritten with the update of the
+        honeybee_energy package. If no such folder is found, this method defaults to
+        the lib/library/ folder within this package.
+        """
+        # first check the default sim folder folder, where permanent libraries live
+        home_folder = os.getenv('HOME') or os.path.expanduser('~')
+        lib_folder = os.path.join(home_folder, 'honeybee', 'honeybee_standards', 'data')
+        if os.path.isdir(lib_folder):
+            return lib_folder
+        else:  # default to the library folder that installs with this Python package
+            return os.path.join(os.path.dirname(__file__), 'lib', 'data')
+
+    @staticmethod
+    def _which(program):
+        """Find an executable program in the PATH by name.
+
+        Args:
+            program: Full file name for the program (e.g. energyplus.exe)
+
+        Returns:
+            File directory and full path to program in case of success.
+            None, None in case of failure.
+        """
+        def is_exe(fpath):
+            # Return true if the file exists and is executable
+            return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+        # check for the file in all path in environment
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path.strip('"'), program)  # strip "" in Windows
+            if is_exe(exe_file):
+                return path, exe_file
+
+        # couldn't find it in the PATH! return None :|
+        return None, None
+
+
+"""Object possesing all key folders within the configuration."""
+folders = Folders(mute=True)

--- a/honeybee_radiance/lib/_loadmodifiers.py
+++ b/honeybee_radiance/lib/_loadmodifiers.py
@@ -1,0 +1,43 @@
+"""Load all modifiers from the IDF libraries."""
+from honeybee_radiance.config import folders
+from honeybee_radiance.reader import string_to_dicts
+from honeybee_radiance.mutil import dict_to_modifier, modifier_class_from_type_string
+
+import os
+import json
+
+
+# empty dictionaries to hold rad-loaded modifiers
+_rad_modifiers = {}
+
+
+# load modifiers from the default and user-supplied files
+for f in os.listdir(folders.modifier_lib):
+    f_path = os.path.join(folders.modifier_lib, f)
+    if os.path.isfile(f_path):
+        if f_path.endswith('.mat') or f_path.endswith('.rad'):
+            with open(f_path) as f:
+                try:
+                    rad_dicts = string_to_dicts(f.read())
+                    for mod_dict in rad_dicts:
+                        mod = dict_to_modifier(mod_dict)
+                        mod.lock()
+                        _rad_modifiers[mod.name] = mod
+                except ValueError:
+                    pass  # empty rad file with no modifiers in them
+        if f_path.endswith('.json'):
+            with open(f_path) as json_file:
+                data = json.load(json_file)
+            for mod_name in data:
+                try:
+                    mod_dict = data[mod_name]
+                    m_class = modifier_class_from_type_string(mod_dict['type'].lower())
+                    mod = m_class.from_dict(mod_dict)
+                    mod.lock()
+                    _rad_modifiers[mod_name] = mod
+                except Exception:
+                    raise ValueError(
+                        'Honeybee JSON file {} is not formatted correctly for inclusion '
+                        'in the honeybee_radiance modifier library.\nJSONs must be '
+                        'formatted with modifier names as keys and modifier dictionaries'
+                        ' as values'.format(f_path))

--- a/honeybee_radiance/lib/_loadmodifiersets.py
+++ b/honeybee_radiance/lib/_loadmodifiersets.py
@@ -1,0 +1,32 @@
+"""Load all modifier sets from the JSON libraries."""
+from honeybee_radiance.config import folders
+from honeybee_radiance.modifierset import ModifierSet
+
+from ._loadmodifiers import _rad_modifiers
+
+import os
+import json
+
+
+# empty dictionaries to hold json-loaded modifier sets
+_json_modifier_sets = {}
+
+
+# load modifier sets from the default and user-supplied files
+for f in os.listdir(folders.modifierset_lib):
+    f_path = os.path.join(folders.modifierset_lib, f)
+    if os.path.isfile(f_path) and f_path.endswith('.json'):
+        with open(f_path, 'r') as json_file:
+            mod_set_dict = json.load(json_file)
+        for mod_set_name in mod_set_dict:
+            try:
+                modifierset = ModifierSet.from_dict_abridged(
+                    mod_set_dict[mod_set_name], _rad_modifiers)
+                modifierset.lock()
+                _json_modifier_sets[mod_set_name] = modifierset
+            except Exception:
+                raise ValueError(
+                        'Honeybee JSON file {} is not formatted correctly for inclusion '
+                        'in the honeybee_radiance modifier set library.\nJSONs must be '
+                        'formatted with ModifierSet names as keys and abridged '
+                        'ModifierSet dictionaries as values'.format(f_path))

--- a/honeybee_radiance/lib/data/__init__.py
+++ b/honeybee_radiance/lib/data/__init__.py
@@ -1,0 +1,1 @@
+"""Library of Energyplus(IDF) and Honeybee (JSON) objects used by honeybee-energy."""

--- a/honeybee_radiance/lib/data/modifiers/default.mat
+++ b/honeybee_radiance/lib/data/modifiers/default.mat
@@ -1,0 +1,100 @@
+#   =========  DEFAULT HONEYBEE MODIFIERS =========
+# These modifiers are loaded into the honeybee_radiance library as defaults.
+# Editing these modifiers will edit the defaults used across all of
+# honeybee_radiance as long as the names of the modifiers are kept.
+
+
+void plastic generic_floor_0.20
+0
+0
+5 0.2 0.2 0.2 0.0 0.0
+
+void plastic generic_wall_0.50
+0
+0
+5 0.5 0.5 0.5 0.0 0.0
+
+void plastic generic_ceiling_0.80
+0
+0
+5 0.8 0.8 0.8 0.0 0.0
+
+void plastic generic_opaque_door_0.50
+0
+0
+5 0.5 0.5 0.5 0.0 0.0
+
+void plastic generic_interior_shade_0.50
+0
+0
+5 0.5 0.5 0.5 0.0 0.0
+
+void plastic generic_exterior_shade_0.35
+0
+0
+5 0.35 0.35 0.35 0.0 0.0
+
+void plastic generic_context_0.20
+0
+0
+5 0.2 0.2 0.2 0.0 0.0
+
+void glass generic_interior_window_vis_0.88
+0
+0
+3 0.9584154328610596 0.9584154328610596 0.9584154328610596
+
+void glass generic_exterior_window_vis_0.64
+0
+0
+3 0.6975761815384331 0.6975761815384331 0.6975761815384331
+
+void glass generic_exterior_screened_window_vis_0.32
+0
+0
+3 0.34901895091031854 0.34901895091031854 0.34901895091031854
+
+void glass generic_interior_window_sol_0.77
+0
+0
+3 0.8389405447251757 0.8389405447251757 0.8389405447251757
+
+void glass generic_exterior_window_sol_0.37
+0
+0
+3 0.4035231572885182 0.4035231572885182 0.4035231572885182
+
+void glass generic_exterior_screened_window_sol_0.19
+0
+0
+3 0.2072595906234098 0.2072595906234098 0.2072595906234098
+
+void plastic generic_floor_exterior_side_0.50
+0
+0
+5 0.5 0.5 0.5 0.0 0.0
+
+void plastic generic_wall_exterior_side_0.35
+0
+0
+5 0.35 0.35 0.35 0.0 0.0
+
+void plastic generic_ceiling_exterior_side_0.35
+0
+0
+5 0.35 0.35 0.35 0.0 0.0
+
+void glass air_boundary
+0
+0
+3 1.0 1.0 1.0
+
+void plastic black
+0
+0
+5 0.0 0.0 0.0 0.0 0.0
+
+void glow white_glow
+0
+0
+4 1.0 1.0 1.0 0.0

--- a/honeybee_radiance/lib/data/modifiers/user_library.mat
+++ b/honeybee_radiance/lib/data/modifiers/user_library.mat
@@ -1,0 +1,3 @@
+#   =============  USER CUSTOM MODIFIERS =============
+# Paste Radiance modifiers here to have them loaded into the honeybee_radiance
+# modifier library.

--- a/honeybee_radiance/lib/data/modifiersets/default.json
+++ b/honeybee_radiance/lib/data/modifiersets/default.json
@@ -1,0 +1,162 @@
+{
+    "Generic_Interior_Visible_Modifier_Set": {
+        "type": "ModifierSetAbridged",
+        "name": "Generic_Interior_Visible_Modifier_Set",
+        "wall_set": {
+            "interior_modifier": "generic_wall_0.50",
+            "exterior_modifier": "generic_wall_0.50",
+            "type": "WallSetAbridged"
+        },
+        "floor_set": {
+            "interior_modifier": "generic_floor_0.20",
+            "exterior_modifier": "generic_floor_0.20",
+            "type": "FloorSetAbridged"
+        },
+        "roof_ceiling_set": {
+            "interior_modifier": "generic_ceiling_0.80",
+            "exterior_modifier": "generic_ceiling_0.80",
+            "type": "RoofCeilingSetAbridged"
+        },
+        "aperture_set": {
+            "interior_modifier": "generic_interior_window_vis_0.88",
+            "skylight_modifier": "generic_exterior_window_vis_0.64",
+            "operable_modifier": "generic_exterior_window_vis_0.64",
+            "type": "ApertureSetAbridged",
+            "window_modifier": "generic_exterior_window_vis_0.64"
+        },
+        "door_set": {
+            "exterior_modifier": "generic_opaque_door_0.50",
+            "interior_modifier": "generic_opaque_door_0.50",
+            "overhead_modifier": "generic_opaque_door_0.50",
+            "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
+            "interior_glass_modifier": "generic_interior_window_vis_0.88",
+            "type": "DoorSetAbridged"
+        },
+        "shade_set": {
+            "interior_modifier": "generic_interior_shade_0.50",
+            "exterior_modifier": "generic_exterior_shade_0.35",
+            "type": "ShadeSetAbridged"
+        },
+        "air_boundary_modifier": "air_boundary"
+    },
+    "Generic_Interior_Solar_Modifier_Set": {
+        "type": "ModifierSetAbridged",
+        "name": "Generic_Interior_Solar_Modifier_Set",
+        "wall_set": {
+            "interior_modifier": "generic_wall_0.50",
+            "exterior_modifier": "generic_wall_0.50",
+            "type": "WallSetAbridged"
+        },
+        "floor_set": {
+            "interior_modifier": "generic_floor_0.20",
+            "exterior_modifier": "generic_floor_0.20",
+            "type": "FloorSetAbridged"
+        },
+        "roof_ceiling_set": {
+            "interior_modifier": "generic_ceiling_0.80",
+            "exterior_modifier": "generic_ceiling_0.80",
+            "type": "RoofCeilingSetAbridged"
+        },
+        "aperture_set": {
+            "interior_modifier": "generic_interior_window_sol_0.77",
+            "skylight_modifier": "generic_exterior_window_sol_0.37",
+            "operable_modifier": "generic_exterior_window_sol_0.37",
+            "type": "ApertureSetAbridged",
+            "window_modifier": "generic_exterior_window_sol_0.37"
+        },
+        "door_set": {
+            "exterior_modifier": "generic_opaque_door_0.50",
+            "interior_modifier": "generic_opaque_door_0.50",
+            "overhead_modifier": "generic_opaque_door_0.50",
+            "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
+            "interior_glass_modifier": "generic_interior_window_vis_0.88",
+            "type": "DoorSetAbridged"
+        },
+        "shade_set": {
+            "interior_modifier": "generic_interior_shade_0.50",
+            "exterior_modifier": "generic_exterior_shade_0.35",
+            "type": "ShadeSetAbridged"
+        },
+        "air_boundary_modifier": "air_boundary"
+    },
+    "Generic_Exterior_Visible_Modifier_Set": {
+        "type": "ModifierSetAbridged",
+        "name": "Generic_Exterior_Visible_Modifier_Set",
+        "wall_set": {
+            "interior_modifier": "generic_wall_0.50",
+            "exterior_modifier": "generic_wall_exterior_side_0.35",
+            "type": "WallSetAbridged"
+        },
+        "floor_set": {
+            "interior_modifier": "generic_floor_0.20",
+            "exterior_modifier": "generic_floor_exterior_side_0.50",
+            "type": "FloorSetAbridged"
+        },
+        "roof_ceiling_set": {
+            "interior_modifier": "generic_ceiling_0.80",
+            "exterior_modifier": "generic_ceiling_exterior_side_0.35",
+            "type": "RoofCeilingSetAbridged"
+        },
+        "aperture_set": {
+            "interior_modifier": "generic_interior_window_vis_0.88",
+            "skylight_modifier": "generic_exterior_window_vis_0.64",
+            "operable_modifier": "generic_exterior_window_vis_0.64",
+            "type": "ApertureSetAbridged",
+            "window_modifier": "generic_exterior_window_vis_0.64"
+        },
+        "door_set": {
+            "exterior_modifier": "generic_opaque_door_0.50",
+            "interior_modifier": "generic_opaque_door_0.50",
+            "overhead_modifier": "generic_opaque_door_0.50",
+            "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
+            "interior_glass_modifier": "generic_interior_window_vis_0.88",
+            "type": "DoorSetAbridged"
+        },
+        "shade_set": {
+            "interior_modifier": "generic_interior_shade_0.50",
+            "exterior_modifier": "generic_exterior_shade_0.35",
+            "type": "ShadeSetAbridged"
+        },
+        "air_boundary_modifier": "air_boundary"
+    },
+    "Generic_Exterior_Solar_Modifier_Set": {
+        "type": "ModifierSetAbridged",
+        "name": "Generic_Exterior_Solar_Modifier_Set",
+        "wall_set": {
+            "interior_modifier": "generic_wall_0.50",
+            "exterior_modifier": "generic_wall_exterior_side_0.35",
+            "type": "WallSetAbridged"
+        },
+        "floor_set": {
+            "interior_modifier": "generic_floor_0.20",
+            "exterior_modifier": "generic_floor_exterior_side_0.50",
+            "type": "FloorSetAbridged"
+        },
+        "roof_ceiling_set": {
+            "interior_modifier": "generic_ceiling_0.80",
+            "exterior_modifier": "generic_ceiling_exterior_side_0.35",
+            "type": "RoofCeilingSetAbridged"
+        },
+        "aperture_set": {
+            "interior_modifier": "generic_interior_window_sol_0.77",
+            "skylight_modifier": "generic_exterior_window_sol_0.37",
+            "operable_modifier": "generic_exterior_window_sol_0.37",
+            "type": "ApertureSetAbridged",
+            "window_modifier": "generic_exterior_window_sol_0.37"
+        },
+        "door_set": {
+            "exterior_modifier": "generic_opaque_door_0.50",
+            "interior_modifier": "generic_opaque_door_0.50",
+            "overhead_modifier": "generic_opaque_door_0.50",
+            "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
+            "interior_glass_modifier": "generic_interior_window_vis_0.88",
+            "type": "DoorSetAbridged"
+        },
+        "shade_set": {
+            "interior_modifier": "generic_interior_shade_0.50",
+            "exterior_modifier": "generic_exterior_shade_0.35",
+            "type": "ShadeSetAbridged"
+        },
+        "air_boundary_modifier": "air_boundary"
+    }
+}

--- a/honeybee_radiance/lib/modifiers.py
+++ b/honeybee_radiance/lib/modifiers.py
@@ -4,68 +4,187 @@ Default values are generic values to set the initial visible / solar reflectance
 transmittance values in your model. There is no guarantee that these values exactly
 match what you are trying to model.
 """
+from ..modifier.material import Plastic, Glass, Glow
+from ._loadmodifiers import _rad_modifiers
 
-from honeybee_radiance.modifier.material import Plastic, Glass, Glow
+
+# establish variables for the default modifiers used across the library
+# and auto-generate modifiers if they were not loaded from default.mat
 
 # generic opaque modifiers - visible and solar
-generic_floor = Plastic.from_single_reflectance('generic_floor_0.20', 0.2)
-generic_wall = Plastic.from_single_reflectance('generic_wall_0.50', 0.5)
-generic_ceiling = Plastic.from_single_reflectance('generic_ceiling_0.80', 0.8)
-generic_door = Plastic.from_single_reflectance('generic_opaque_door_0.50', 0.5)
+try:
+    generic_floor = _rad_modifiers['generic_floor_0.20']
+except KeyError:
+    generic_floor = Plastic.from_single_reflectance('generic_floor_0.20', 0.2)
+    generic_floor.lock()
+    _rad_modifiers['generic_floor_0.20'] = generic_floor
+
+try:
+    generic_wall = _rad_modifiers['generic_wall_0.50']
+except KeyError:
+    generic_wall = Plastic.from_single_reflectance('generic_wall_0.50', 0.5)
+    generic_wall.lock()
+    _rad_modifiers['generic_wall_0.50'] = generic_wall
+
+try:
+    generic_ceiling = _rad_modifiers['generic_ceiling_0.80']
+except KeyError:
+    generic_ceiling = Plastic.from_single_reflectance('generic_ceiling_0.80', 0.8)
+    generic_ceiling.lock()
+    _rad_modifiers['generic_ceiling_0.80'] = generic_ceiling
+
+try:
+    generic_door = _rad_modifiers['generic_opaque_door_0.50']
+except KeyError:
+    generic_door = Plastic.from_single_reflectance('generic_opaque_door_0.50', 0.5)
+    generic_door.lock()
+    _rad_modifiers['generic_opaque_door_0.50'] = generic_door
+
 
 # generic shade modifiers - visible and solar
-generic_interior_shade = \
-    Plastic.from_single_reflectance('generic_interior_shade_0.50', 0.50)
-generic_exterior_shade = \
-    Plastic.from_single_reflectance('generic_exterior_shade_0.35', 0.35)
-generic_context = Plastic.from_single_reflectance('generic_context_0.20', 0.2)
+try:
+    generic_interior_shade = _rad_modifiers['generic_interior_shade_0.50']
+except KeyError:
+    generic_interior_shade = Plastic.from_single_reflectance(
+        'generic_interior_shade_0.50', 0.50)
+    generic_interior_shade.lock()
+    _rad_modifiers['generic_interior_shade_0.50'] = generic_interior_shade
+
+try:
+    generic_exterior_shade = _rad_modifiers['generic_exterior_shade_0.35']
+except KeyError:
+    generic_exterior_shade = Plastic.from_single_reflectance(
+        'generic_exterior_shade_0.35', 0.35)
+    generic_exterior_shade.lock()
+    _rad_modifiers['generic_exterior_shade_0.35'] = generic_exterior_shade
+
+try:
+    generic_context = _rad_modifiers['generic_context_0.20']
+except KeyError:
+    generic_context = Plastic.from_single_reflectance('generic_context_0.20', 0.2)
+    generic_context.lock()
+    _rad_modifiers['generic_context_0.20'] = generic_context
+
 
 # generic glass modifiers - visible
-generic_interior_window = \
-    Glass.from_single_transmittance('generic_interior_window_vis_0.88', 0.88)
-generic_exterior_window = \
-    Glass.from_single_transmittance('generic_exterior_window_vis_0.64', 0.64)
-generic_exterior_window_insect_screen = \
-    Glass.from_single_transmittance('generic_exterior_screened_window_vis_0.32', 0.32)
+try:
+    generic_interior_window = _rad_modifiers['generic_interior_window_vis_0.88']
+except KeyError:
+    generic_interior_window = Glass.from_single_transmittance(
+        'generic_interior_window_vis_0.88', 0.88)
+    generic_interior_window.lock()
+    _rad_modifiers['generic_interior_window_vis_0.88'] = generic_interior_window
+
+try:
+    generic_exterior_window = _rad_modifiers['generic_exterior_window_vis_0.64']
+except KeyError:
+    generic_exterior_window = Glass.from_single_transmittance(
+        'generic_exterior_window_vis_0.64', 0.64)
+    generic_exterior_window.lock()
+    _rad_modifiers['generic_exterior_window_vis_0.64'] = generic_exterior_window
+
+try:
+    generic_exterior_window_insect_screen = \
+        _rad_modifiers['generic_exterior_screened_window_vis_0.32']
+except KeyError:
+    generic_exterior_window_insect_screen = \
+        Glass.from_single_transmittance(
+            'generic_exterior_screened_window_vis_0.32', 0.32)
+    generic_exterior_window_insect_screen.lock()
+    _rad_modifiers['generic_exterior_screened_window_vis_0.32'] = \
+        generic_exterior_window_insect_screen
+
 
 # generic glass modifiers - solar
-generic_interior_window_solar = \
-    Glass.from_single_transmittance('generic_interior_window_sol_0.77', 0.77)
-generic_exterior_window_solar = \
-    Glass.from_single_transmittance('generic_exterior_window_sol_0.37', 0.37)
-generic_exterior_window_insect_screen_solar = \
-    Glass.from_single_transmittance('generic_exterior_screened_window_sol_0.19', 0.19)
+try:
+    generic_interior_window_solar = _rad_modifiers['generic_interior_window_sol_0.77']
+except KeyError:
+    generic_interior_window_solar = Glass.from_single_transmittance(
+        'generic_interior_window_sol_0.77', 0.77)
+    generic_interior_window_solar.lock()
+    _rad_modifiers['generic_interior_window_sol_0.77'] = generic_interior_window_solar
+
+try:
+    generic_exterior_window_solar = _rad_modifiers['generic_exterior_window_sol_0.37']
+except KeyError:
+    generic_exterior_window_solar = Glass.from_single_transmittance(
+        'generic_exterior_window_sol_0.37', 0.37)
+    generic_exterior_window_solar.lock()
+    _rad_modifiers['generic_exterior_window_sol_0.37'] = generic_exterior_window_solar
+
+try:
+    generic_exterior_window_insect_screen_solar = \
+        _rad_modifiers['generic_exterior_screened_window_sol_0.19']
+except KeyError:
+    generic_exterior_window_insect_screen_solar = \
+        Glass.from_single_transmittance(
+            'generic_exterior_screened_window_sol_0.19', 0.19)
+    generic_exterior_window_insect_screen_solar.lock()
+    _rad_modifiers['generic_exterior_screened_window_sol_0.19'] = \
+        generic_exterior_window_insect_screen_solar
+
 
 # generic exterior side opaque modifiers - visible and solar
-generic_floor_exterior = \
-    Plastic.from_single_reflectance('generic_floor_exterior_side_0.50', 0.5)
-generic_wall_exterior = \
-    Plastic.from_single_reflectance('generic_wall_exterior_side_0.35', 0.35)
-generic_roof_exterior = \
-    Plastic.from_single_reflectance('generic_ceiling_exterior_side_0.35', 0.35)
+try:
+    generic_floor_exterior = _rad_modifiers['generic_floor_exterior_side_0.50']
+except KeyError:
+    generic_floor_exterior = Plastic.from_single_reflectance(
+        'generic_floor_exterior_side_0.50', 0.5)
+    generic_floor_exterior.lock()
+    _rad_modifiers['generic_floor_exterior_side_0.50'] = generic_floor_exterior
+
+try:
+    generic_wall_exterior = _rad_modifiers['generic_wall_exterior_side_0.35']
+except KeyError:
+    generic_wall_exterior = Plastic.from_single_reflectance(
+        'generic_wall_exterior_side_0.35', 0.35)
+    generic_wall_exterior.lock()
+    _rad_modifiers['generic_wall_exterior_side_0.35'] = generic_wall_exterior
+
+try:
+    generic_roof_exterior = _rad_modifiers['generic_ceiling_exterior_side_0.35']
+except KeyError:
+    generic_roof_exterior = Plastic.from_single_reflectance(
+        'generic_ceiling_exterior_side_0.35', 0.35)
+    generic_roof_exterior.lock()
+    _rad_modifiers['generic_ceiling_exterior_side_0.35'] = generic_roof_exterior
+
 
 # special types of modifiers used within various simulation processes
-air_boundary = Glass.from_single_transmissivity('air_boundary', 1.0)
-black = Plastic.from_single_reflectance('black', 0.0)  # used in multiphase daylight
-white_glow = Glow('white_glow', 1.0, 1.0, 1.0, 0.0)  # used in multi-phase daylight
+try:
+    air_boundary = _rad_modifiers['air_boundary']
+except KeyError:
+    air_boundary = Glass.from_single_transmissivity('air_boundary', 1.0)
+    air_boundary.lock()
+    _rad_modifiers['air_boundary'] = air_boundary
 
-# lock all of the modifiers for editing
-generic_floor.lock()
-generic_wall.lock()
-generic_ceiling.lock()
-generic_door.lock()
-generic_interior_shade.lock()
-generic_exterior_shade.lock()
-generic_context.lock()
-generic_interior_window.lock()
-generic_exterior_window.lock()
-generic_exterior_window_insect_screen.lock()
-generic_interior_window_solar.lock()
-generic_exterior_window_solar.lock()
-generic_exterior_window_insect_screen_solar.lock()
-generic_floor_exterior.lock()
-generic_wall_exterior.lock()
-generic_roof_exterior.lock()
-air_boundary.lock()
-black.lock()
-white_glow.lock()
+try:  # used in multiphase daylight
+    black = _rad_modifiers['black']
+except KeyError:
+    black = Plastic.from_single_reflectance('black', 0.0)
+    black.lock()
+    _rad_modifiers['black'] = black
+
+try:  # used in multiphase daylight
+    white_glow = _rad_modifiers['white_glow']
+except KeyError:
+    white_glow = Glow('white_glow', 1.0, 1.0, 1.0, 0.0)
+    white_glow.lock()
+    _rad_modifiers['white_glow'] = white_glow
+
+
+# make lists of modifier names to look up items in the library
+MODIFIERS = tuple(_rad_modifiers.keys())
+
+
+def modifier_by_name(modifier_name):
+    """Get a modifier from the library given the modifier name.
+
+    Args:
+        modifier_name: A text string for the name of the modifier.
+    """
+    try:
+        return _rad_modifiers[modifier_name]
+    except KeyError:
+        raise ValueError(
+            '"{}" was not found in the radiancemodifier library.'.format(modifier_name))

--- a/honeybee_radiance/lib/modifiersets.py
+++ b/honeybee_radiance/lib/modifiersets.py
@@ -1,43 +1,86 @@
 """Collection of modifier sets."""
 from ..modifierset import ModifierSet
+from ._loadmodifiersets import _json_modifier_sets
 import honeybee_radiance.lib.modifiers as modifiers
 
-# create the generic interior visible set
-generic_modifier_set_visible = ModifierSet('Generic_Interior_Visible_Modifier_Set')
 
-# create the generic interior solar set
-generic_modifier_set_solar = ModifierSet('Generic_Interior_Solar_Modifier_Set')
-generic_modifier_set_solar.aperture_set.window_modifier = \
-    modifiers.generic_exterior_window_solar
-generic_modifier_set_solar.aperture_set.skylight_modifier = \
-    modifiers.generic_exterior_window_solar
-generic_modifier_set_solar.aperture_set.operable_modifier = \
-    modifiers.generic_exterior_window_solar
-generic_modifier_set_solar.aperture_set.interior_modifier = \
-    modifiers.generic_interior_window_solar
+# establish variables for the default modifier sets used across the library
+# and auto-generate modifier sets if they were not loaded from default.idf
 
-# create the generic exterior visible set
-generic_modifier_set_visible_exterior = \
-    ModifierSet('Generic_Exterior_Visible_Modifier_Set')
-generic_modifier_set_visible_exterior.wall_set.exterior_modifier = \
-    modifiers.generic_wall_exterior
-generic_modifier_set_visible_exterior.floor_set.exterior_modifier = \
-    modifiers.generic_floor_exterior
-generic_modifier_set_visible_exterior.roof_ceiling_set.exterior_modifier = \
-    modifiers.generic_roof_exterior
+try:  # create the generic interior visible set
+    generic_modifier_set_visible = \
+        _json_modifier_sets['Generic_Interior_Visible_Modifier_Set']
+except KeyError:
+    generic_modifier_set_visible = ModifierSet('Generic_Interior_Visible_Modifier_Set')
+    generic_modifier_set_visible.lock()
+    _json_modifier_sets['Generic_Interior_Visible_Modifier_Set'] = \
+        generic_modifier_set_visible
 
-# create the generic exterior solar set
-generic_modifier_set_solar_exterior = generic_modifier_set_solar.duplicate()
-generic_modifier_set_solar_exterior.name = 'Generic_Exterior_Solar_Modifier_Set'
-generic_modifier_set_solar_exterior.wall_set.exterior_modifier = \
-    modifiers.generic_wall_exterior
-generic_modifier_set_solar_exterior.floor_set.exterior_modifier = \
-    modifiers.generic_floor_exterior
-generic_modifier_set_solar_exterior.roof_ceiling_set.exterior_modifier = \
-    modifiers.generic_roof_exterior
 
-# lock all of the modifier sets for editing
-generic_modifier_set_visible.lock()
-generic_modifier_set_solar.lock()
-generic_modifier_set_visible_exterior.lock()
-generic_modifier_set_solar_exterior.lock()
+try:  # create the generic interior solar set
+    generic_modifier_set_solar = \
+        _json_modifier_sets['Generic_Interior_Solar_Modifier_Set']
+except KeyError:
+    generic_modifier_set_solar = ModifierSet('Generic_Interior_Solar_Modifier_Set')
+    generic_modifier_set_solar.aperture_set.window_modifier = \
+        modifiers.generic_exterior_window_solar
+    generic_modifier_set_solar.aperture_set.skylight_modifier = \
+        modifiers.generic_exterior_window_solar
+    generic_modifier_set_solar.aperture_set.operable_modifier = \
+        modifiers.generic_exterior_window_solar
+    generic_modifier_set_solar.aperture_set.interior_modifier = \
+        modifiers.generic_interior_window_solar
+    generic_modifier_set_solar.lock()
+    _json_modifier_sets['Generic_Interior_Solar_Modifier_Set'] = \
+        generic_modifier_set_solar
+
+
+try:  # create the generic exterior visible set
+    generic_modifier_set_visible_exterior = \
+        _json_modifier_sets['Generic_Exterior_Visible_Modifier_Set']
+except KeyError:
+    generic_modifier_set_visible_exterior = \
+        ModifierSet('Generic_Exterior_Visible_Modifier_Set')
+    generic_modifier_set_visible_exterior.wall_set.exterior_modifier = \
+        modifiers.generic_wall_exterior
+    generic_modifier_set_visible_exterior.floor_set.exterior_modifier = \
+        modifiers.generic_floor_exterior
+    generic_modifier_set_visible_exterior.roof_ceiling_set.exterior_modifier = \
+        modifiers.generic_roof_exterior
+    generic_modifier_set_visible_exterior.lock()
+    _json_modifier_sets['Generic_Exterior_Visible_Modifier_Set'] = \
+        generic_modifier_set_visible_exterior
+
+
+try:  # create the generic exterior solar set
+    generic_modifier_set_solar_exterior = \
+        _json_modifier_sets['Generic_Exterior_Solar_Modifier_Set']
+except KeyError:
+    generic_modifier_set_solar_exterior = generic_modifier_set_solar.duplicate()
+    generic_modifier_set_solar_exterior.name = 'Generic_Exterior_Solar_Modifier_Set'
+    generic_modifier_set_solar_exterior.wall_set.exterior_modifier = \
+        modifiers.generic_wall_exterior
+    generic_modifier_set_solar_exterior.floor_set.exterior_modifier = \
+        modifiers.generic_floor_exterior
+    generic_modifier_set_solar_exterior.roof_ceiling_set.exterior_modifier = \
+        modifiers.generic_roof_exterior
+    generic_modifier_set_solar_exterior.lock()
+    _json_modifier_sets['Generic_Exterior_Solar_Modifier_Set'] = \
+        generic_modifier_set_solar_exterior
+
+
+# make lists of modifier sets to look up items in the library
+MODIFIER_SETS = tuple(_json_modifier_sets.keys())
+
+
+def modifier_set_by_name(modifier_set_name):
+    """Get a modifier_set from the library given its name.
+
+    Args:
+        modifier_set_name: A text string for the name of the ConstructionSet.
+    """
+    try:
+        return _json_modifier_sets[modifier_set_name]
+    except KeyError:
+        raise ValueError('"{}" was not found in the modifier set library.'.format(
+            modifier_set_name))

--- a/honeybee_radiance/modifierset.py
+++ b/honeybee_radiance/modifierset.py
@@ -2,6 +2,7 @@
 from __future__ import division
 
 from honeybee_radiance.modifier import Modifier
+from honeybee_radiance.mutil import dict_to_modifier  # imports all modifiers classes
 from honeybee_radiance.lib.modifiers import generic_floor, generic_wall, \
     generic_ceiling, generic_door, generic_exterior_window, generic_interior_window, \
     generic_exterior_shade, generic_interior_shade, air_boundary
@@ -345,15 +346,10 @@ class ModifierSet(object):
         assert data['type'] == 'ModifierSet', \
             'Expected ModifierSet. Got {}.'.format(data['type'])
         
-        try:  # ensure the putil module is imported, which imports all primitive modules
-            putil
-        except NameError:
-            import honeybee_radiance.putil as putil
-        
         # gather all modifier objects
         modifiers = {}
         for mod in data['modifiers']:
-            modifiers[mod['name']] = putil.dict_to_modifier(mod)
+            modifiers[mod['name']] = dict_to_modifier(mod)
 
         # build each of the sub-sets
         wall_set, floor_set, roof_ceiling_set, aperture_set, door_set, shade_set, \

--- a/honeybee_radiance/mutil.py
+++ b/honeybee_radiance/mutil.py
@@ -1,0 +1,56 @@
+"""Primitive utility functions."""
+import honeybee_radiance.modifier.material as material
+import honeybee_radiance.modifier.mixture as mixture
+import honeybee_radiance.modifier.pattern as pattern
+import honeybee_radiance.modifier.texture as texture
+from honeybee_radiance.primitive import Primitive
+
+
+def modifier_class_from_type_string(type_string):
+    """Get the class of any modifier using its 'type' string.
+
+    This function is equivalent to the primitive_class_from_type_string function
+    but it is only for modifiers (not geometry) and is slightly faster when one
+    is sure that the type_string is a modifier.
+
+    Note that this function returns the class itself and not a class instance.
+
+    Args:
+        type_string: Text for the name of a modifier module/class. This should
+            usually be lowercase and should be the same as the 'type' key used
+            in the dictionary representation of the modifier.
+    """
+    _mapper = {'bsdf': 'BSDF', 'brtdfunc': 'BRTDfunc'}
+    if type_string in Primitive.MATERIALTYPES:
+        target_module = material
+    elif type_string in Primitive.MIXTURETYPES:
+        target_module = mixture
+    elif type_string in Primitive.PATTERNTYPES:
+        target_module = pattern
+    elif type_string in Primitive.TEXTURETYPES:
+        target_module = texture
+    else:
+        raise ValueError('%s is not a Radiance modifier.' % type_string)
+
+    class_name = type_string.capitalize() if type_string not in _mapper \
+        else _mapper[type_string]
+    
+    return getattr(target_module, class_name)
+
+
+def dict_to_modifier(mdict):
+    """Convert a dictionary representation of any modifier to a class instance.
+
+    The returned object will have the correct class type and will not be the
+    generic Modifier base class. Note that this function is recursive and will
+    re-serialize modifiers of modifiers.
+    
+    Args:
+        mdict: A dictionary of any Radiance Modifier.
+    """
+    mod_class = modifier_class_from_type_string(mdict['type'])
+
+    if 'values' in mdict:
+        return mod_class.from_primitive_dict(mdict)
+    else:
+        return mod_class.from_dict(mdict)

--- a/honeybee_radiance/primitive.py
+++ b/honeybee_radiance/primitive.py
@@ -424,22 +424,23 @@ class Primitive(object):
     @staticmethod
     def filter_dict_input(input_dict):
         """Filter a dictionary of a Primitive to get modifier and dependency objects."""
-        try:  # ensure the putil module is imported, which imports all primitive modules
-            putil
+        try:  # see if the mutil module has already been imported
+            mutil
         except NameError:
-            import honeybee_radiance.putil as putil
+            # import the module here (instead of at top) to avoid a circular import
+            import honeybee_radiance.mutil as mutil  # imports all modifiers classes
 
         # try to get modifier
         if input_dict['modifier'] == 'void':
             modifier = 'void'
         else:
-            modifier = putil.dict_to_modifier(input_dict['modifier'])
+            modifier = mutil.dict_to_modifier(input_dict['modifier'])
 
         if 'dependencies' not in input_dict: 
             dependencies = []
         else:
             dependencies = [
-                putil.dict_to_modifier(dep) for dep in input_dict['dependencies']
+                mutil.dict_to_modifier(dep) for dep in input_dict['dependencies']
             ]
 
         return modifier, dependencies

--- a/honeybee_radiance/properties/_base.py
+++ b/honeybee_radiance/properties/_base.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """Base class of Radiance Properties for all planar geometry objects."""
 from ..modifier import Modifier
+from ..mutil import dict_to_modifier  # imports all modifiers classes
 from ..lib.modifiers import black
 from ..lib.modifiersets import generic_modifier_set_visible
 
@@ -150,15 +151,10 @@ class _GeometryRadianceProperties(object):
     @staticmethod
     def _restore_modifiers_from_dict(new_prop, data):
         """Restor modifiers from a data dictionary to a new properties object."""
-        try:  # ensure the putil module is imported, which imports all primitive modules
-            putil
-        except NameError:
-            import honeybee_radiance.putil as putil
-
         if 'modifier' in data and data['modifier'] is not None:
-            new_prop.modifier = putil.dict_to_modifier(data['modifier'])
+            new_prop.modifier = dict_to_modifier(data['modifier'])
         if 'modifier_blk' in data and data['modifier_blk'] is not None:
-            new_prop.modifier_blk = putil.dict_to_modifier(data['modifier_blk'])
+            new_prop.modifier_blk = dict_to_modifier(data['modifier_blk'])
         return new_prop
 
     def ToString(self):

--- a/honeybee_radiance/putil.py
+++ b/honeybee_radiance/putil.py
@@ -1,60 +1,7 @@
 """Primitive utility functions."""
-import honeybee_radiance.modifier.material as material
-import honeybee_radiance.modifier.mixture as mixture
-import honeybee_radiance.modifier.pattern as pattern
-import honeybee_radiance.modifier.texture as texture
+from honeybee_radiance.mutil import modifier_class_from_type_string
 import honeybee_radiance.geometry as geometry
 from honeybee_radiance.primitive import Primitive
-
-
-def modifier_class_from_type_string(type_string):
-    """Get the class of any modifier using its 'type' string.
-
-    This function is equivalent to the primitive_class_from_type_string function
-    but it is only for modifiers (not geometry) and is slightly faster when one
-    is sure that the type_string is a modifier.
-
-    Note that this function returns the class itself and not a class instance.
-
-    Args:
-        type_string: Text for the name of a modifier module/class. This should
-            usually be lowercase and should be the same as the 'type' key used
-            in the dictionary representation of the modifier.
-    """
-    _mapper = {'bsdf': 'BSDF', 'brtdfunc': 'BRTDfunc'}
-    if type_string in Primitive.MATERIALTYPES:
-        target_module = material
-    elif type_string in Primitive.MIXTURETYPES:
-        target_module = mixture
-    elif type_string in Primitive.PATTERNTYPES:
-        target_module = pattern
-    elif type_string in Primitive.TEXTURETYPES:
-        target_module = texture
-    else:
-        raise ValueError('%s is not a Radiance modifier.' % type_string)
-
-    class_name = type_string.capitalize() if type_string not in _mapper \
-        else _mapper[type_string]
-    
-    return getattr(target_module, class_name)
-
-
-def dict_to_modifier(mdict):
-    """Convert a dictionary representation of any modifier to a class instance.
-
-    The returned object will have the correct class type and will not be the
-    generic Modifier base class. Note that this function is recursive and will
-    re-serialize modifiers of modifiers.
-    
-    Args:
-        mdict: A dictionary of any Radiance Modifier.
-    """
-    mod_class = modifier_class_from_type_string(mdict['type'])
-
-    if 'values' in mdict:
-        return mod_class.from_primitive_dict(mdict)
-    else:
-        return mod_class.from_dict(mdict)
 
 
 def primitive_class_from_type_string(type_string):

--- a/honeybee_radiance/reader.py
+++ b/honeybee_radiance/reader.py
@@ -7,14 +7,14 @@ from honeybee_radiance_command.cutil import parse_radiance_options
 
 # TODO: Add support for comments [#] and commands [!]
 def parse_from_string(full_string):
-    """
-    separate a Radiance file string into multiple strings for each object.
+    """Separate a Radiance file string into multiple strings for each object.
 
     Args:
-        rad_fileString: Radiance data as a single string. The string can be multiline.
+        full_string: Radiance data as a single string. The string can be multiline.
 
     Returns:
-        A list of strings. Each string represents a different Radiance Object
+        A list of strings. Each string represents a different Radiance primitive
+        (geometry or modifier). Comments [#] and commands [!] are excluded.
     """
     raw_rad_objects = re.findall(
         r'^\s*([^0-9].*(\s*[\d.-]+.*)*)',
@@ -43,7 +43,7 @@ def parse_from_file(file_path):
         A list of strings. Each string represents a different Radiance object.
 
     Usage:
-        rad_objects = get_radiance_objects_from_file('some_file.rad')
+        rad_obj_strs = parse_from_file('some_file.rad')
     """
 
     assert os.path.isfile(file_path), "Can't find %s." % file_path

--- a/tests/assets/model/test_model.rad
+++ b/tests/assets/model/test_model.rad
@@ -4,15 +4,65 @@
 #   ============== MODIFIERS ==============
 
 
-void glass air_boundary
+void plastic outdoor_light_shelf_0.5
 0
 0
-3 1.0 1.0 1.0
+5 0.5 0.5 0.5 0.0 0.0
+
+void plastic generic_floor_0.20
+0
+0
+5 0.2 0.2 0.2 0.0 0.0
 
 void glass generic_interior_window_vis_0.88
 0
 0
 3 0.9584154328610596 0.9584154328610596 0.9584154328610596
+
+void glass air_boundary
+0
+0
+3 1.0 1.0 1.0
+
+void glass generic_exterior_window_vis_0.64
+0
+0
+3 0.6975761815384331 0.6975761815384331 0.6975761815384331
+
+void plastic indoor_light_shelf_0.70
+0
+0
+5 0.7 0.7 0.7 0.0 0.0
+
+void plastic generic_exterior_shade_0.35
+0
+0
+5 0.35 0.35 0.35 0.0 0.0
+
+void plastic generic_ceiling_0.80
+0
+0
+5 0.8 0.8 0.8 0.0 0.0
+
+void plastic DarkFloor
+0
+0
+5 0.1 0.1 0.1 0.0 0.0
+
+void plastic generic_context_0.20
+0
+0
+5 0.2 0.2 0.2 0.0 0.0
+
+void plastic generic_wall_0.50
+0
+0
+5 0.5 0.5 0.5 0.0 0.0
+
+void glass custom_triple_pane_0.3
+0
+0
+3 0.3272140103902576 0.3272140103902576 0.3272140103902576
 
 void plastic generic_interior_shade_0.50
 0
@@ -23,51 +73,6 @@ void plastic generic_opaque_door_0.50
 0
 0
 5 0.5 0.5 0.5 0.0 0.0
-
-void plastic IndoorLightShelf
-0
-0
-5 0.7 0.7 0.7 0.0 0.0
-
-void plastic generic_ceiling_0.80
-0
-0
-5 0.8 0.8 0.8 0.0 0.0
-
-void glass generic_exterior_window_vis_0.64
-0
-0
-3 0.6975761815384331 0.6975761815384331 0.6975761815384331
-
-void glass CustomTriplePane
-0
-0
-3 0.3272140103902576 0.3272140103902576 0.3272140103902576
-
-void plastic generic_floor_0.20
-0
-0
-5 0.2 0.2 0.2 0.0 0.0
-
-void plastic DarkFloor
-0
-0
-5 0.1 0.1 0.1 0.0 0.0
-
-void plastic generic_wall_0.50
-0
-0
-5 0.5 0.5 0.5 0.0 0.0
-
-void plastic OutdoorLightShelf
-0
-0
-5 0.5 0.5 0.5 0.0 0.0
-
-void plastic generic_exterior_shade_0.35
-0
-0
-5 0.35 0.35 0.35 0.0 0.0
 
 #   ================ ROOMS ================
 
@@ -92,7 +97,7 @@ generic_opaque_door_0.50 polygon FrontDoor
 0
 12 2.0 10.0 0.1 1.0 10.0 0.1 1.0 10.0 2.5 2.0 10.0 2.5
 
-CustomTriplePane polygon FrontAperture
+custom_triple_pane_0.3 polygon FrontAperture
 0
 0
 12 4.5 10.0 1.0 2.5 10.0 1.0 2.5 10.0 2.5 4.5 10.0 2.5
@@ -112,12 +117,12 @@ generic_exterior_window_vis_0.64 polygon TinyHouseZone_Back_Glz0
 0
 12 0.9188611699158102 0.0 0.5513167019494862 4.08113883008419 0.0 0.5513167019494862 4.08113883008419 0.0 2.448683298050514 0.9188611699158102 0.0 2.448683298050514
 
-OutdoorLightShelf polygon TinyHouseZone_Back_Glz0_OutOverhang0
+outdoor_light_shelf_0.5 polygon TinyHouseZone_Back_Glz0_OutOverhang0
 0
 0
 12 4.08113883008419 0.0 2.4486831980505146 0.91886116991581 0.0 2.4486831980505146 0.91886116991581 -0.5 2.4486831980505146 4.08113883008419 -0.5 2.4486831980505146
 
-IndoorLightShelf polygon TinyHouseZone_Back_Glz0_InOverhang0
+indoor_light_shelf_0.70 polygon TinyHouseZone_Back_Glz0_InOverhang0
 0
 0
 12 4.08113883008419 0.0 2.4486831980505137 0.91886116991581 0.0 2.4486831980505137 0.91886116991581 0.5 2.4486831980505137 4.08113883008419 0.5 2.4486831980505137

--- a/tests/material_glow_test.py
+++ b/tests/material_glow_test.py
@@ -74,3 +74,10 @@ def test_to_dict():
     assert mdict['type'] == 'glow'
     assert mdict['modifier'] == 'void'
 
+
+def test_to_from_dict():
+    mt = Glow.from_single_value('mt_test', 100000)
+    mdict = mt.to_dict()
+    new_mt = Glow.from_dict(mdict)
+    assert mt == new_mt
+    assert new_mt.to_dict() == mdict

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -224,7 +224,7 @@ def test_to_dict_single_zone():
     assert 'modifier_sets' in model_dict['properties']['radiance']
     assert 'global_modifier_set' in model_dict['properties']['radiance']
 
-    assert len(model_dict['properties']['radiance']['modifiers']) == 13
+    assert len(model_dict['properties']['radiance']['modifiers']) == 14
     assert len(model_dict['properties']['radiance']['modifier_sets']) == 1
 
     assert model_dict['rooms'][0]['faces'][0]['properties']['radiance']['modifier'] == \
@@ -298,8 +298,8 @@ def test_writer_to_rad():
     south_face.apertures[0].overhang(0.5, indoor=False)
     south_face.apertures[0].overhang(0.5, indoor=True)
     south_face.move_shades(Vector3D(0, 0, -0.5))
-    light_shelf_out = Plastic.from_single_reflectance('OutdoorLightShelf', 0.5)
-    light_shelf_in = Plastic.from_single_reflectance('IndoorLightShelf', 0.7)
+    light_shelf_out = Plastic.from_single_reflectance('outdoor_light_shelf_0.5', 0.5)
+    light_shelf_in = Plastic.from_single_reflectance('indoor_light_shelf_0.70', 0.7)
     south_face.apertures[0].outdoor_shades[0].properties.radiance.modifier = light_shelf_out
     south_face.apertures[0].indoor_shades[0].properties.radiance.modifier = light_shelf_in
 
@@ -313,7 +313,7 @@ def test_writer_to_rad():
     aperture_verts = [Point3D(4.5, 10, 1), Point3D(2.5, 10, 1),
                       Point3D(2.5, 10, 2.5), Point3D(4.5, 10, 2.5)]
     aperture = Aperture('Front Aperture', Face3D(aperture_verts))
-    triple_pane = Glass.from_single_transmittance('CustomTriplePane', 0.3)
+    triple_pane = Glass.from_single_transmittance('custom_triple_pane_0.3', 0.3)
     aperture.properties.radiance.modifier = triple_pane
     north_face.add_aperture(aperture)
 
@@ -330,6 +330,3 @@ def test_writer_to_rad():
 
     assert hasattr(model.to, 'rad')
     rad_string = model.to.rad(model)
-    model_file = './tests/assets/model/test_model.rad'
-    with open(model_file, 'w') as fp:
-        fp.write(rad_string)

--- a/tests/primitive_test.py
+++ b/tests/primitive_test.py
@@ -1,5 +1,9 @@
 """test primitive class."""
 from honeybee_radiance.primitive import Primitive
+from honeybee_radiance.putil import primitive_class_from_type_string, dict_to_primitive
+from honeybee_radiance.reader import parse_from_file, string_to_dicts
+from honeybee_radiance.geometry import Polygon, Sphere
+from honeybee_radiance.modifier.material import Plastic, Glass
 from .rad_string_collection import frit
 
 
@@ -25,3 +29,20 @@ def test_from_string():
 def test_to_radiance():
     p = Primitive.from_string(frit)
     assert ' '.join(p.to_radiance().split()) == ' '.join(frit.split())
+
+
+def test_primitive_class_from_type_string():
+    assert primitive_class_from_type_string('polygon') == Polygon
+    assert primitive_class_from_type_string('sphere') == Sphere
+    assert primitive_class_from_type_string('plastic') == Plastic
+    assert primitive_class_from_type_string('glass') == Glass
+
+
+def test_dict_to_primitive():
+    f_path = './tests/assets/model/test_model.rad'
+    with open(f_path) as f:
+        rad_dicts = string_to_dicts(f.read())
+        for rad_dict in rad_dicts:
+            prim_obj = dict_to_primitive(rad_dict)
+            assert isinstance(prim_obj, Primitive)
+            assert prim_obj.__class__ != Primitive  # ensure it's inherited type


### PR DESCRIPTION
This commit changes the libraries to load up from .rad, .mat, or .json files. The data follows a similar structure to honeybee_energy such that we can eventually combine these files with honeybee_energy into a single honeybee_standards repo.

It also adds a config file that allows users to change the folder from which the libraries load up.