### PR TITLE
fix(identifier): Change name property to identifier

### DIFF
--- a/honeybee_radiance/geometry/bubble.py
+++ b/honeybee_radiance/geometry/bubble.py
@@ -18,8 +18,9 @@ class Bubble(Sphere):
         4 xcent ycent zcent radius
 
     Args:
-        name: Geometry name as a string. Do not use white space or special
-            character.
+        identifier: Text string for a unique Geometry ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         center_pt: Sphere center point as (x, y, z) (Default: (0, 0 ,0)).
         radius: Bubble radius as a number (Default: 10).
         modifier: Geometry modifier (Default: "void").
@@ -28,7 +29,8 @@ class Bubble(Sphere):
             primitive is defined based on other primitives. (Default: [])
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * center_pt
         * radius
         * modifier

--- a/honeybee_radiance/geometry/cone.py
+++ b/honeybee_radiance/geometry/cone.py
@@ -24,8 +24,9 @@ class Cone(Geometry):
                 r0      r1
 
     Args:
-        name: Geometry name as a string. Do not use white space or special
-            character.
+        identifier: Text string for a unique Geometry ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         center_pt_start: Cone start center point as (x, y, z) (Default: (0, 0 ,0)).
         radius_start: Cone start radius as a number (Default: 10).
         center_pt_end: Cone end center point as (x, y, z) (Default: (0, 0 ,10)).
@@ -36,7 +37,8 @@ class Cone(Geometry):
             primitive is defined based on other primitives. (Default: [])
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * center_pt_start
         * radius_start
         * center_pt_end
@@ -48,10 +50,10 @@ class Cone(Geometry):
     """
     __slots__ = ('_center_pt_start', '_radius_start', '_center_pt_end', '_radius_end')
 
-    def __init__(self, name, center_pt_start=None, radius_start=10,
+    def __init__(self, identifier, center_pt_start=None, radius_start=10,
                  center_pt_end=None, radius_end=0, modifier=None, dependencies=None):
         """Radiance Cone."""
-        Geometry.__init__(self, name, modifier=modifier, dependencies=dependencies)
+        Geometry.__init__(self, identifier, modifier=modifier, dependencies=dependencies)
         self.center_pt_start = center_pt_start or (0, 0, 0)
         self.radius_start = radius_start if radius_start is not None else 10
         self.center_pt_end = center_pt_end or (0, 0, 10)
@@ -117,7 +119,8 @@ class Cone(Geometry):
             {
             "modifier": "",  # primitive modifier (Default: "void")
             "type": "cone",  # primitive type
-            "name": "",  # primitive name
+            "identifier": "",  # primitive identifier
+            "display_name": "",  # primitive display name
             "values": [],  # values
             "dependencies": []
             }
@@ -132,7 +135,7 @@ class Cone(Geometry):
         values = primitive_dict['values'][2]
 
         cls_ = cls(
-            name=primitive_dict['name'],
+            identifier=primitive_dict['identifier'],
             center_pt_start=values[0:3],
             radius_start=values[6],
             center_pt_end=values[3:6],
@@ -140,6 +143,9 @@ class Cone(Geometry):
             modifier=modifier,
             dependencies=dependencies
         )
+        if 'display_name' in primitive_dict and primitive_dict['display_name'] is not None:
+            cls_.display_name = primitive_dict['display_name']
+
         # this might look redundant but it is NOT. see glass for explanation.
         cls_.values = primitive_dict['values']
         return cls_
@@ -156,7 +162,8 @@ class Cone(Geometry):
             {
             "type": "cone",  # Geometry type
             "modifier": {} or "void",
-            "name": "",  # Geometry Name
+            "identifier": "",  # Geometry identifer
+            "display_name": "",  # Geometry display name
             "center_pt_start": (0, 0, 0),
             "radius_start": float,
             "center_pt_end": (0, 0, 10),
@@ -172,29 +179,37 @@ class Cone(Geometry):
             )
         modifier, dependencies = cls.filter_dict_input(data)
 
-        return cls(name=data["name"],
-                   center_pt_start=(data["center_pt_start"]),
-                   radius_start=data["radius_start"],
-                   center_pt_end=( data["center_pt_end"]),
-                   radius_end=data["radius_end"],
-                   modifier=modifier,
-                   dependencies=dependencies)
+        new_obj = cls(identifier=data["identifier"],
+                      center_pt_start=(data["center_pt_start"]),
+                      radius_start=data["radius_start"],
+                      center_pt_end=( data["center_pt_end"]),
+                      radius_end=data["radius_end"],
+                      modifier=modifier,
+                      dependencies=dependencies)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
 
     def to_dict(self):
         """Translate this object to a dictionary."""
-        return {
+        base = {
             "modifier": self.modifier.to_dict(),
             "type": self.__class__.__name__.lower(),
-            "name": self.name,
+            "identifier": self.identifier,
             "radius_start": self.radius_start,
             "center_pt_start": self.center_pt_start,
             "radius_end": self.radius_end,
             "center_pt_end": self.center_pt_end,
             'dependencies': [dp.to_dict() for dp in self.dependencies]
         }
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        return base
 
     def __copy__(self):
         mod, depend = self._dup_mod_and_depend()
-        return self.__class__(
-            self.name, self.center_pt_start, self.radius_start, self.center_pt_end,
+        new_obj = self.__class__(
+            self.identifier, self.center_pt_start, self.radius_start, self.center_pt_end,
             self.radius_end, mod, depend)
+        new_obj._display_name = self._display_name
+        return new_obj

--- a/honeybee_radiance/geometry/cup.py
+++ b/honeybee_radiance/geometry/cup.py
@@ -25,8 +25,9 @@ class Cup(Cone):
                 r0      r1
 
     Args:
-        name: Geometry name as a string. Do not use white space or special
-            character.
+        identifier: Text string for a unique Geometry ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         center_pt_start: Cup start center point as (x, y, z) (Default: (0, 0 ,0)).
         radius_start: Cup start radius as a number (Default: 10).
         center_pt_end: Cup end center point as (x, y, z) (Default: (0, 0 ,10)).
@@ -38,7 +39,8 @@ class Cup(Cone):
 
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * center_pt_start
         * radius_start
         * center_pt_end

--- a/honeybee_radiance/geometry/geometrybase.py
+++ b/honeybee_radiance/geometry/geometrybase.py
@@ -16,7 +16,8 @@ class Geometry(Primitive):
     """Base class for Radiance geometries.
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/geometry/ring.py
+++ b/honeybee_radiance/geometry/ring.py
@@ -23,8 +23,9 @@ class Ring(Geometry):
                 r0      r1
 
     Args:
-        name: Geometry name as a string. Do not use white space or special
-            character.
+        identifier: Text string for a unique Geometry ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         center_pt: Ring start center point as (x, y, z) (Default: (0, 0 ,0)).
         normal_vector: Surface normal as (x, y, z) (Default: (0, 0 ,1)).
         radius_inner: Ring inner radius as a number (Default: 5).
@@ -35,7 +36,8 @@ class Ring(Geometry):
             primitive is defined based on other primitives. (Default: [])
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * center_pt
         * normal_vector
         * radius_inner
@@ -46,10 +48,10 @@ class Ring(Geometry):
     """
     __slots__ = ('_center_pt', '_normal_vector', '_radius_inner', '_radius_outer')
 
-    def __init__(self, name, center_pt=None, normal_vector=None, radius_inner=5,
+    def __init__(self, identifier, center_pt=None, normal_vector=None, radius_inner=5,
                  radius_outer=10, modifier=None, dependencies=None):
         """Radiance Ring."""
-        Geometry.__init__(self, name, modifier=modifier)
+        Geometry.__init__(self, identifier, modifier=modifier)
         self.center_pt = center_pt or (0, 0, 0)
         self.normal_vector = normal_vector or (0, 0, 1)
         self.radius_inner = radius_inner if radius_inner is not None else 5
@@ -116,7 +118,8 @@ class Ring(Geometry):
             {
             "modifier": "",  # primitive modifier (Default is "void")
             "type": "ring",  # primitive type
-            "name": "",  # primitive name
+            "identifier": "",  # primitive identifier
+            "display_name": "",  # primitive display name
             "values": []  # values,
             "dependencies": []
             }
@@ -131,7 +134,7 @@ class Ring(Geometry):
         values = primitive_dict['values'][2]
 
         cls_ = cls(
-            name=primitive_dict['name'],
+            identifier=primitive_dict['identifier'],
             center_pt=values[0:3],
             normal_vector=values[3:6],
             radius_inner=values[6],
@@ -139,6 +142,9 @@ class Ring(Geometry):
             modifier=modifier,
             dependencies=dependencies
         )
+        if 'display_name' in primitive_dict and primitive_dict['display_name'] is not None:
+            cls_.display_name = primitive_dict['display_name']
+
         # this might look redundant but it is NOT. see glass for explanation.
         cls_.values = primitive_dict['values']
         return cls_
@@ -155,7 +161,8 @@ class Ring(Geometry):
             {
             "type": "ring",  # Geometry type
             "modifier": {} or "void",
-            "name": "",  # Geometry Name
+            "identifier": "",  # Geometry identifier
+            "display_name": "",  # Geometry display name
             "center_pt": (0, 0, 0),
             "normal_vector": (0, 0, 1),
             "radius_inner": float,
@@ -171,29 +178,37 @@ class Ring(Geometry):
             )
         modifier, dependencies = cls.filter_dict_input(data)
 
-        return cls(name=data["name"],
-                   center_pt=(data["center_pt"]),
-                   radius_inner=data["radius_inner"],
-                   normal_vector=(data["normal_vector"]),
-                   radius_outer=data["radius_outer"],
-                   modifier=modifier,
-                   dependencies=dependencies)
+        new_obj = cls(identifier=data["identifier"],
+                      center_pt=(data["center_pt"]),
+                      radius_inner=data["radius_inner"],
+                      normal_vector=(data["normal_vector"]),
+                      radius_outer=data["radius_outer"],
+                      modifier=modifier,
+                      dependencies=dependencies)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
 
     def to_dict(self):
         """Translate this object to a dictionary."""
-        return {
+        base = {
             "modifier": self.modifier.to_dict(),
             "type": self.__class__.__name__.lower(),
-            "name": self.name,
+            "identifier": self.identifier,
             "center_pt": self.center_pt,
             "normal_vector": self.normal_vector,
             "radius_inner": self.radius_inner,
             "radius_outer": self.radius_outer,
             'dependencies': [dp.to_dict() for dp in self.dependencies]
         }
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        return base
 
     def __copy__(self):
         mod, depend = self._dup_mod_and_depend()
-        return self.__class__(
-            self.name, self.center_pt, self.normal_vector, self.radius_inner,
+        new_obj = self.__class__(
+            self.identifier, self.center_pt, self.normal_vector, self.radius_inner,
             self.radius_outer, mod, depend)
+        new_obj._display_name = self._display_name
+        return new_obj

--- a/honeybee_radiance/geometry/source.py
+++ b/honeybee_radiance/geometry/source.py
@@ -21,8 +21,9 @@ class Source(Geometry):
         4 xdir ydir zdir angle
 
     Args:
-        name: Geometry name as a string. Do not use white space or special
-            character.
+        identifier: Text string for a unique Geometry ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         direction: A vector to set source direction (x, y, z) (Default: (0, 0 ,-1)).
         angle: Source solid angle (Default: 0.533).
         modifier: Geometry modifier (Default: "void").
@@ -31,7 +32,8 @@ class Source(Geometry):
             primitive is defined based on other primitives. (Default: [])
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * direction
         * angle
         * modifier
@@ -47,10 +49,10 @@ class Source(Geometry):
     """
     __slots__ = ('_direction', '_angle')
 
-    def __init__(self, name, direction=None, angle=0.533, modifier=None,
+    def __init__(self, identifier, direction=None, angle=0.533, modifier=None,
                  dependencies=None):
         """Radiance Source."""
-        Geometry.__init__(self, name, modifier=modifier, dependencies=dependencies)
+        Geometry.__init__(self, identifier, modifier=modifier, dependencies=dependencies)
         self.direction = direction or (0, 0, -1)
         self.angle = angle if angle is not None else 0.533
 
@@ -93,7 +95,8 @@ class Source(Geometry):
             {
             "modifier": "",  # primitive modifier (Default is "void")
             "type": "source",  # primitive type
-            "name": "",  # primitive name
+            "identifier": "",  # primitive identifier
+            "display_name": "",  # primitive display name
             "values": [],  # values
             "dependencies": []
             }
@@ -108,12 +111,15 @@ class Source(Geometry):
         values = primitive_dict['values'][2]
 
         cls_ = cls(
-            name=primitive_dict['name'],
+            identifier=primitive_dict['identifier'],
             direction=values[0:3],
             angle=values[3],
             modifier=modifier,
             dependencies=dependencies
         )
+        if 'display_name' in primitive_dict and primitive_dict['display_name'] is not None:
+            cls_.display_name = primitive_dict['display_name']
+
         # this might look redundant but it is NOT. see glass for explanation.
         cls_.values = primitive_dict['values']
         return cls_
@@ -130,7 +136,8 @@ class Source(Geometry):
             {
             "type": "source",  # Geometry type
             "modifier": {} or "void",
-            "name": "",  # Geometry Name
+            "identifier": "",  # Geometry identifier
+            "display_name": "",  # Geometry display name
             "direction": {"x": float, "y": float, "z": float},
             "angle": float,
             "dependencies": []
@@ -144,23 +151,32 @@ class Source(Geometry):
             )
         modifier, dependencies = cls.filter_dict_input(data)
 
-        return cls(name=data["name"],
-                   direction=(data["direction"]),
-                   angle=data["angle"],
-                   modifier=modifier,
-                   dependencies=dependencies)
+        new_obj = cls(identifier=data["identifier"],
+                      direction=(data["direction"]),
+                      angle=data["angle"],
+                      modifier=modifier,
+                      dependencies=dependencies)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
 
     def to_dict(self):
         """Translate this object to a dictionary."""
-        return {
+        base = {
             "modifier": self.modifier.to_dict(),
             "type": self.__class__.__name__.lower(),
-            "name": self.name,
+            "identifier": self.identifier,
             "direction": self.direction,
             "angle": self.angle,
             'dependencies': [dp.to_dict() for dp in self.dependencies]
         }
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        return base
 
     def __copy__(self):
         mod, depend = self._dup_mod_and_depend()
-        return self.__class__(self.name, self.direction, self.angle, mod, depend)
+        new_obj = self.__class__(
+            self.identifier, self.direction, self.angle, mod, depend)
+        new_obj._display_name = self._display_name
+        return new_obj

--- a/honeybee_radiance/geometry/tube.py
+++ b/honeybee_radiance/geometry/tube.py
@@ -21,8 +21,9 @@ class Tube(Cylinder):
                 rad
 
     Args:
-        name: Geometry name as a string. Do not use white spaces or special
-            characters.
+        identifier: Text string for a unique Geometry ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         center_pt_start: Tube start center point as (x, y, z)
             (Default: (0, 0 ,0)).
         center_pt_end: Tube end center point as (x, y, z) (Default: (0, 0 ,10)).
@@ -33,7 +34,8 @@ class Tube(Cylinder):
             primitive is defined based on other primitives. (Default: [])
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * center_pt_start
         * center_pt_end
         * radius

--- a/honeybee_radiance/lib/_loadmodifiers.py
+++ b/honeybee_radiance/lib/_loadmodifiers.py
@@ -22,22 +22,22 @@ for f in os.listdir(folders.modifier_lib):
                     for mod_dict in rad_dicts:
                         mod = dict_to_modifier(mod_dict)
                         mod.lock()
-                        _rad_modifiers[mod.name] = mod
+                        _rad_modifiers[mod.identifier] = mod
                 except ValueError:
                     pass  # empty rad file with no modifiers in them
         if f_path.endswith('.json'):
             with open(f_path) as json_file:
                 data = json.load(json_file)
-            for mod_name in data:
+            for mod_identifier in data:
                 try:
-                    mod_dict = data[mod_name]
+                    mod_dict = data[mod_identifier]
                     m_class = modifier_class_from_type_string(mod_dict['type'].lower())
                     mod = m_class.from_dict(mod_dict)
                     mod.lock()
-                    _rad_modifiers[mod_name] = mod
+                    _rad_modifiers[mod_identifier] = mod
                 except Exception:
                     raise ValueError(
                         'Honeybee JSON file {} is not formatted correctly for inclusion '
                         'in the honeybee_radiance modifier library.\nJSONs must be '
-                        'formatted with modifier names as keys and modifier dictionaries'
-                        ' as values'.format(f_path))
+                        'formatted with modifier identifiers as keys and modifier '
+                        'dictionaries as values'.format(f_path))

--- a/honeybee_radiance/lib/_loadmodifiersets.py
+++ b/honeybee_radiance/lib/_loadmodifiersets.py
@@ -18,15 +18,15 @@ for f in os.listdir(folders.modifierset_lib):
     if os.path.isfile(f_path) and f_path.endswith('.json'):
         with open(f_path, 'r') as json_file:
             mod_set_dict = json.load(json_file)
-        for mod_set_name in mod_set_dict:
+        for mod_set_id in mod_set_dict:
             try:
                 modifierset = ModifierSet.from_dict_abridged(
-                    mod_set_dict[mod_set_name], _rad_modifiers)
+                    mod_set_dict[mod_set_id], _rad_modifiers)
                 modifierset.lock()
-                _json_modifier_sets[mod_set_name] = modifierset
+                _json_modifier_sets[mod_set_id] = modifierset
             except Exception:
                 raise ValueError(
                         'Honeybee JSON file {} is not formatted correctly for inclusion '
                         'in the honeybee_radiance modifier set library.\nJSONs must be '
-                        'formatted with ModifierSet names as keys and abridged '
+                        'formatted with ModifierSet identifiers as keys and abridged '
                         'ModifierSet dictionaries as values'.format(f_path))

--- a/honeybee_radiance/lib/data/modifiersets/default.json
+++ b/honeybee_radiance/lib/data/modifiersets/default.json
@@ -1,7 +1,7 @@
 {
     "Generic_Interior_Visible_Modifier_Set": {
         "type": "ModifierSetAbridged",
-        "name": "Generic_Interior_Visible_Modifier_Set",
+        "identifier": "Generic_Interior_Visible_Modifier_Set",
         "wall_set": {
             "interior_modifier": "generic_wall_0.50",
             "exterior_modifier": "generic_wall_0.50",
@@ -41,7 +41,7 @@
     },
     "Generic_Interior_Solar_Modifier_Set": {
         "type": "ModifierSetAbridged",
-        "name": "Generic_Interior_Solar_Modifier_Set",
+        "identifier": "Generic_Interior_Solar_Modifier_Set",
         "wall_set": {
             "interior_modifier": "generic_wall_0.50",
             "exterior_modifier": "generic_wall_0.50",
@@ -81,7 +81,7 @@
     },
     "Generic_Exterior_Visible_Modifier_Set": {
         "type": "ModifierSetAbridged",
-        "name": "Generic_Exterior_Visible_Modifier_Set",
+        "identifier": "Generic_Exterior_Visible_Modifier_Set",
         "wall_set": {
             "interior_modifier": "generic_wall_0.50",
             "exterior_modifier": "generic_wall_exterior_side_0.35",
@@ -121,7 +121,7 @@
     },
     "Generic_Exterior_Solar_Modifier_Set": {
         "type": "ModifierSetAbridged",
-        "name": "Generic_Exterior_Solar_Modifier_Set",
+        "identifier": "Generic_Exterior_Solar_Modifier_Set",
         "wall_set": {
             "interior_modifier": "generic_wall_0.50",
             "exterior_modifier": "generic_wall_exterior_side_0.35",

--- a/honeybee_radiance/lib/modifiers.py
+++ b/honeybee_radiance/lib/modifiers.py
@@ -173,18 +173,19 @@ except KeyError:
     _rad_modifiers['white_glow'] = white_glow
 
 
-# make lists of modifier names to look up items in the library
+# make lists of modifier identifiers to look up items in the library
 MODIFIERS = tuple(_rad_modifiers.keys())
 
 
-def modifier_by_name(modifier_name):
-    """Get a modifier from the library given the modifier name.
+def modifier_by_identifier(modifier_identifier):
+    """Get a modifier from the library given the modifier identifier.
 
     Args:
-        modifier_name: A text string for the name of the modifier.
+        modifier_identifier: A text string for the identifier of the modifier.
     """
     try:
-        return _rad_modifiers[modifier_name]
+        return _rad_modifiers[modifier_identifier]
     except KeyError:
         raise ValueError(
-            '"{}" was not found in the radiancemodifier library.'.format(modifier_name))
+            '"{}" was not found in the radiancemodifier library.'.format(
+                modifier_identifier))

--- a/honeybee_radiance/lib/modifiersets.py
+++ b/honeybee_radiance/lib/modifiersets.py
@@ -57,7 +57,8 @@ try:  # create the generic exterior solar set
         _json_modifier_sets['Generic_Exterior_Solar_Modifier_Set']
 except KeyError:
     generic_modifier_set_solar_exterior = generic_modifier_set_solar.duplicate()
-    generic_modifier_set_solar_exterior.name = 'Generic_Exterior_Solar_Modifier_Set'
+    generic_modifier_set_solar_exterior.identifier = \
+        'Generic_Exterior_Solar_Modifier_Set'
     generic_modifier_set_solar_exterior.wall_set.exterior_modifier = \
         modifiers.generic_wall_exterior
     generic_modifier_set_solar_exterior.floor_set.exterior_modifier = \
@@ -73,14 +74,14 @@ except KeyError:
 MODIFIER_SETS = tuple(_json_modifier_sets.keys())
 
 
-def modifier_set_by_name(modifier_set_name):
-    """Get a modifier_set from the library given its name.
+def modifier_set_by_identifier(modifier_set_identifier):
+    """Get a modifier_set from the library given its identifier.
 
     Args:
-        modifier_set_name: A text string for the name of the ConstructionSet.
+        modifier_set_identifier: A text string for the identifier of the ConstructionSet.
     """
     try:
-        return _json_modifier_sets[modifier_set_name]
+        return _json_modifier_sets[modifier_set_identifier]
     except KeyError:
         raise ValueError('"{}" was not found in the modifier set library.'.format(
-            modifier_set_name))
+            modifier_set_identifier))

--- a/honeybee_radiance/modifier/material/antimatter.py
+++ b/honeybee_radiance/modifier/material/antimatter.py
@@ -26,8 +26,9 @@ class Antimatter(Material):
     volumes concerned for a correct rendering.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -39,7 +40,8 @@ class Antimatter(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/ashik2.py
+++ b/honeybee_radiance/modifier/material/ashik2.py
@@ -23,8 +23,9 @@ class Ashik2(Material):
         8 dred dgrn dblu sred sgrn sblu u-power v-power
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -36,7 +37,8 @@ class Ashik2(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/brtdfunc.py
+++ b/honeybee_radiance/modifier/material/brtdfunc.py
@@ -53,8 +53,9 @@ class BRTDfunc(Material):
     greater than one.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -66,7 +67,8 @@ class BRTDfunc(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/dielectric.py
+++ b/honeybee_radiance/modifier/material/dielectric.py
@@ -25,8 +25,9 @@ class Dielectric(Material):
         5 rtn gtn btn n hc
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -38,7 +39,8 @@ class Dielectric(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/illum.py
+++ b/honeybee_radiance/modifier/material/illum.py
@@ -23,8 +23,9 @@ class Illum(Material):
         3 red green blue
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -36,7 +37,8 @@ class Illum(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/interface.py
+++ b/honeybee_radiance/modifier/material/interface.py
@@ -21,8 +21,9 @@ class Interface(Material):
         8 rtn1 gtn1 btn1 n1 rtn2 gtn2 btn2 n2
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -34,7 +35,8 @@ class Interface(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/materialbase.py
+++ b/honeybee_radiance/modifier/material/materialbase.py
@@ -11,7 +11,8 @@ class Material(Modifier):
     """Base class for Radiance materials.
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/metal.py
+++ b/honeybee_radiance/modifier/material/metal.py
@@ -11,8 +11,9 @@ class Metal(Plastic):
     """Radiance metal material.
 
     Args:
-        name: Material name as a string. Do not use white space or special
-            character.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         r_reflectance: Reflectance for red. The value should be between 0 and 1
             (Default: 0).
         g_reflectance: Reflectance for green. The value should be between 0 and 1
@@ -31,7 +32,8 @@ class Metal(Plastic):
             primitive is defined based on other primitives. (Default: [])
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * r_reflectance
         * g_reflectance
         * b_reflectance

--- a/honeybee_radiance/modifier/material/metal2.py
+++ b/honeybee_radiance/modifier/material/metal2.py
@@ -13,8 +13,9 @@ class Metal2(Material):
     material color.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -26,7 +27,8 @@ class Metal2(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/metdata.py
+++ b/honeybee_radiance/modifier/material/metdata.py
@@ -13,8 +13,9 @@ class Metdata(Material):
     as plasdata, but the specular component is modified by the given material color.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -26,7 +27,8 @@ class Metdata(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/metfunc.py
+++ b/honeybee_radiance/modifier/material/metfunc.py
@@ -13,8 +13,9 @@ class Metfunc(Material):
     component is multiplied also by the material color.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -26,7 +27,8 @@ class Metfunc(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/mist.py
+++ b/honeybee_radiance/modifier/material/mist.py
@@ -58,8 +58,9 @@ class Mist(Material):
     not be illuminated correctly unless the line integrals consider enclosed geometry.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -71,7 +72,8 @@ class Mist(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/plasdata.py
+++ b/honeybee_radiance/modifier/material/plasdata.py
@@ -30,8 +30,9 @@ class Plasdata(Material):
     size may of course be ignored by the function.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -43,7 +44,8 @@ class Plasdata(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/plasfunc.py
+++ b/honeybee_radiance/modifier/material/plasfunc.py
@@ -31,8 +31,9 @@ class Plasfunc(Material):
     the surface normal is always altered to face the incoming ray.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -44,7 +45,8 @@ class Plasfunc(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/plastic2.py
+++ b/honeybee_radiance/modifier/material/plastic2.py
@@ -30,8 +30,9 @@ class Plastic2(Material):
         6 red green blue spec urough vrough
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -43,7 +44,8 @@ class Plastic2(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/prism1.py
+++ b/honeybee_radiance/modifier/material/prism1.py
@@ -29,8 +29,9 @@ class Prism1(Material):
     to the target light source.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -42,7 +43,8 @@ class Prism1(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/prism2.py
+++ b/honeybee_radiance/modifier/material/prism2.py
@@ -20,8 +20,9 @@ class Prism2(Material):
         n A1 A2 .. An
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -33,7 +34,8 @@ class Prism2(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/spotlight.py
+++ b/honeybee_radiance/modifier/material/spotlight.py
@@ -22,8 +22,9 @@ class Spotlight(Material):
         7 red green blue angle xdir ydir zdir
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -35,7 +36,8 @@ class Spotlight(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/trans2.py
+++ b/honeybee_radiance/modifier/material/trans2.py
@@ -21,8 +21,9 @@ class Trans2(Material):
         8 red green blue spec urough vrough trans tspec
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -34,7 +35,8 @@ class Trans2(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/transdata.py
+++ b/honeybee_radiance/modifier/material/transdata.py
@@ -22,8 +22,9 @@ class Transdata(Material):
         6+ red green blue rspec trans tspec A7 ..
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -35,7 +36,8 @@ class Transdata(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/material/transfunc.py
+++ b/honeybee_radiance/modifier/material/transfunc.py
@@ -25,8 +25,9 @@ class Transfunc(Material):
     hemisphere.
 
     Args:
-        name: Primitive name as a string. Cannot contain white spaces or special
-            characters.
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: "void").
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
@@ -38,7 +39,8 @@ class Transfunc(Material):
             defined based on other primitives. (Default: []).
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/mixture/mixdata.py
+++ b/honeybee_radiance/modifier/mixture/mixdata.py
@@ -19,6 +19,30 @@ class Mixdata(Mixture):
                 funcfile x1 x2 .. xn transform
         0
         m A1 A2 .. Am
+
+    Args:
+        identifier: Text string for a unique Mixture ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/mixture/mixfunc.py
+++ b/honeybee_radiance/modifier/mixture/mixfunc.py
@@ -24,6 +24,30 @@ class Mixfunc(Mixture):
     serves as a form of opacity control when used with a material.) Vname is the
     coefficient defined in funcfile that determines the influence of foreground. The
     background coefficient is always (1-vname).
+
+    Args:
+        identifier: Text string for a unique Mixture ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/mixture/mixpict.py
+++ b/honeybee_radiance/modifier/mixture/mixpict.py
@@ -22,6 +22,30 @@ class Mixpict(Mixture):
 
     The mixing coefficient function "func" takes three arguments, the red, green and
     blue values corresponding to the pixel at (u,v).
+
+    Args:
+        identifier: Text string for a unique Mixture ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/mixture/mixtext.py
+++ b/honeybee_radiance/modifier/mixture/mixtext.py
@@ -37,6 +37,29 @@ class Mixtext(Mixture):
                 Dx Dy Dz
                 [spacing]
 
+    Args:
+        identifier: Text string for a unique Mixture ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/mixture/mixturebase.py
+++ b/honeybee_radiance/modifier/mixture/mixturebase.py
@@ -13,7 +13,8 @@ class Mixture(Modifier):
     """Base class for Radiance mixtures.
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/modifierbase.py
+++ b/honeybee_radiance/modifier/modifierbase.py
@@ -16,7 +16,8 @@ class Modifier(Primitive):
     """Base class for Radiance modifiers.
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/modifier/pattern/brightdata.py
+++ b/honeybee_radiance/modifier/pattern/brightdata.py
@@ -19,6 +19,30 @@ class Brightdata(Pattern):
                 funcfile x1 x2 .. xn transform
         0
         m A1 A2 .. Am
+
+    Args:
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/pattern/brightfunc.py
+++ b/honeybee_radiance/modifier/pattern/brightfunc.py
@@ -17,6 +17,30 @@ class Brightfunc(Pattern):
         2+ refl funcfile transform
         0
         n A1 A2 .. An
+
+    Args:
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/pattern/brighttext.py
+++ b/honeybee_radiance/modifier/pattern/brighttext.py
@@ -51,6 +51,30 @@ class Brighttext(Pattern):
     purpose font such as hexbit4x1.fnt, calls for uniform spacing. Reasonable magnitudes
     for proportional spacing are between 0.1 (for tightly spaced characters) and 0.3 (for
     wide spacing).
+
+    Args:
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/pattern/colordata.py
+++ b/honeybee_radiance/modifier/pattern/colordata.py
@@ -26,6 +26,30 @@ class Colordata(Pattern):
                 funcfile x1 x2 .. xn transform
         0
         m A1 A2 .. Am
+
+    Args:
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/pattern/colorfunc.py
+++ b/honeybee_radiance/modifier/pattern/colorfunc.py
@@ -18,6 +18,29 @@ class Colorfunc(Pattern):
         0
         n A1 A2 .. An
 
+    Args:
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/pattern/colorpict.py
+++ b/honeybee_radiance/modifier/pattern/colorpict.py
@@ -24,6 +24,30 @@ class Colorpict(Pattern):
         0
         m A1 A2 .. Am
 
+    Args:
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
+
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/pattern/colortext.py
+++ b/honeybee_radiance/modifier/pattern/colortext.py
@@ -43,6 +43,30 @@ class Colortext(Pattern):
                 rfore gfore bfore
                 rback gback bback
                 [spacing]
+
+    Args:
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        modifier: Modifier. It can be primitive, mixture, texture or pattern.
+            (Default: "void").
+        values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
+            refer to a line number in the radiance primitve definitions and the
+            values in each array correspond to values occurring within each line.
+        is_opaque: A boolean to indicate whether this primitive is opaque.
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives that are
+            defined based on other primitives. (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * values
+        * modifier
+        * dependencies
+        * is_modifier
+        * is_material
+        * is_opaque
     """
     __slots__ = ()
 

--- a/honeybee_radiance/modifier/pattern/patternbase.py
+++ b/honeybee_radiance/modifier/pattern/patternbase.py
@@ -14,7 +14,8 @@ class Pattern(Modifier):
     Patterns are used to modify the reflectance of materials.
 
     Properties:
-        * name
+        * identifier
+        * display_name
         * values
         * modifier
         * dependencies

--- a/honeybee_radiance/properties/_base.py
+++ b/honeybee_radiance/properties/_base.py
@@ -122,7 +122,7 @@ class _GeometryRadianceProperties(object):
 
         Args:
             abridged_data: An Abridged dictionary (typically coming from a Model).
-            modifiers: A dictionary of modifiers with modifier names as keys,
+            modifiers: A dictionary of modifiers with modifier identifiers as keys,
                 which will be used to re-assign modifiers.
         """
         if 'modifier' in abridged_data and abridged_data['modifier'] is not None:
@@ -140,11 +140,11 @@ class _GeometryRadianceProperties(object):
                 Default: False.
         """
         if self._modifier is not None:
-            base['radiance']['modifier'] = \
-                self._modifier.name if abridged else self._modifier.to_dict()
+            base['radiance']['modifier'] = self._modifier.identifier if \
+                abridged else self._modifier.to_dict()
         if self._modifier_blk is not None:
-            base['radiance']['modifier_blk'] = \
-                self._modifier_blk.name if abridged else self._modifier_blk.to_dict()
+            base['radiance']['modifier_blk'] =  self._modifier_blk.identifier if \
+                abridged else self._modifier_blk.to_dict()
         return base
 
     @staticmethod
@@ -160,4 +160,4 @@ class _GeometryRadianceProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Base Radiance Properties:\n host: {}'.format(self.host.name)
+        return 'Base Radiance Properties:\n host: {}'.format(self.host.identifier)

--- a/honeybee_radiance/properties/aperture.py
+++ b/honeybee_radiance/properties/aperture.py
@@ -117,15 +117,15 @@ class ApertureRadianceProperties(_GeometryRadianceProperties):
         Args:
             abridged_data: A ApertureRadiancePropertiesAbridged dictionary (typically
                 coming from a Model) with the format below.
-            modifiers: A dictionary of modifiers with modifier names as keys,
+            modifiers: A dictionary of modifiers with modifier identifiers as keys,
                 which will be used to re-assign modifiers.
 
         .. code-block:: python
 
             {
             'type': 'ApertureRadiancePropertiesAbridged',
-            'modifier': str,  # A Honeybee Radiance Modifier name
-            'modifier_blk': str  # A Honeybee Radiance Modifier name
+            'modifier': str,  # A Honeybee Radiance Modifier identifier
+            'modifier_blk': str  # A Honeybee Radiance Modifier identifier
             }
         """
         self._apply_modifiers_from_dict(abridged_data, modifiers)
@@ -144,4 +144,4 @@ class ApertureRadianceProperties(_GeometryRadianceProperties):
         return self._add_modifiers_to_dict(base, abridged)
 
     def __repr__(self):
-        return 'Aperture Radiance Properties:\n host: {}'.format(self.host.name)
+        return 'Aperture Radiance Properties:\n host: {}'.format(self.host.identifier)

--- a/honeybee_radiance/properties/door.py
+++ b/honeybee_radiance/properties/door.py
@@ -118,15 +118,15 @@ class DoorRadianceProperties(_GeometryRadianceProperties):
         Args:
             abridged_data: A DoorRadiancePropertiesAbridged dictionary (typically
                 coming from a Model) with the format below.
-            modifiers: A dictionary of modifiers with modifier names as keys,
+            modifiers: A dictionary of modifiers with modifier identifiers as keys,
                 which will be used to re-assign modifiers.
 
         .. code-block:: python
 
             {
             'type': 'DoorRadiancePropertiesAbridged',
-            'modifier': str,  # A Honeybee Radiance Modifier name
-            'modifier_blk': str  # A Honeybee Radiance Modifier name
+            'modifier': str,  # A Honeybee Radiance Modifier identifier
+            'modifier_blk': str  # A Honeybee Radiance Modifier identifier
             }
         """
         self._apply_modifiers_from_dict(abridged_data, modifiers)
@@ -145,4 +145,4 @@ class DoorRadianceProperties(_GeometryRadianceProperties):
         return self._add_modifiers_to_dict(base, abridged)
 
     def __repr__(self):
-        return 'Door Radiance Properties:\n host: {}'.format(self.host.name)
+        return 'Door Radiance Properties:\n host: {}'.format(self.host.identifier)

--- a/honeybee_radiance/properties/face.py
+++ b/honeybee_radiance/properties/face.py
@@ -93,15 +93,15 @@ class FaceRadianceProperties(_GeometryRadianceProperties):
         Args:
             abridged_data: A FaceRadiancePropertiesAbridged dictionary (typically
                 coming from a Model) with the format below.
-            modifiers: A dictionary of modifiers with modifier names as keys,
+            modifiers: A dictionary of modifiers with modifier identifiers as keys,
                 which will be used to re-assign modifiers.
 
         .. code-block:: python
 
             {
             'type': 'FaceRadiancePropertiesAbridged',
-            'modifier': str,  # A Honeybee Radiance Modifier name
-            'modifier_blk': str  # A Honeybee Radiance Modifier name
+            'modifier': str,  # A Honeybee Radiance Modifier identifier
+            'modifier_blk': str  # A Honeybee Radiance Modifier identifier
             }
         """
         self._apply_modifiers_from_dict(abridged_data, modifiers)
@@ -120,4 +120,4 @@ class FaceRadianceProperties(_GeometryRadianceProperties):
         return self._add_modifiers_to_dict(base, abridged)
 
     def __repr__(self):
-        return 'Face Radiance Properties:\n host: {}'.format(self.host.name)
+        return 'Face Radiance Properties:\n host: {}'.format(self.host.identifier)

--- a/honeybee_radiance/properties/model.py
+++ b/honeybee_radiance/properties/model.py
@@ -161,37 +161,37 @@ class ModelRadianceProperties(object):
         """
         return generic_modifier_set_visible
 
-    def check_duplicate_modifier_names(self, raise_exception=True):
-        """Check that there are no duplicate Modifier names in the model."""
-        mod_names = set()
-        duplicate_names = set()
+    def check_duplicate_modifier_identifiers(self, raise_exception=True):
+        """Check that there are no duplicate Modifier identifiers in the model."""
+        mod_identifiers = set()
+        duplicate_identifiers = set()
         for mod in self.modifiers:
-            if mod.name not in mod_names:
-                mod_names.add(mod.name)
+            if mod.identifier not in mod_identifiers:
+                mod_identifiers.add(mod.identifier)
             else:
-                duplicate_names.add(mod.name)
-        if len(duplicate_names) != 0:
+                duplicate_identifiers.add(mod.identifier)
+        if len(duplicate_identifiers) != 0:
             if raise_exception:
                 raise ValueError(
                     'The model has the following duplicated modifier '
-                    'names:\n{}'.format('\n'.join(duplicate_names)))
+                    'identifiers:\n{}'.format('\n'.join(duplicate_identifiers)))
             return False
         return True
 
-    def check_duplicate_modifier_set_names(self, raise_exception=True):
-        """Check that there are no duplicate ModifierSet names in the model."""
-        mod_set_names = set()
-        duplicate_names = set()
+    def check_duplicate_modifier_set_identifiers(self, raise_exception=True):
+        """Check that there are no duplicate ModifierSet identifiers in the model."""
+        mod_set_identifiers = set()
+        duplicate_identifiers = set()
         for mod_set in self.modifier_sets + [self.global_modifier_set]:
-            if mod_set.name not in mod_set_names:
-                mod_set_names.add(mod_set.name)
+            if mod_set.identifier not in mod_set_identifiers:
+                mod_set_identifiers.add(mod_set.identifier)
             else:
-                duplicate_names.add(mod_set.name)
-        if len(duplicate_names) != 0:
+                duplicate_identifiers.add(mod_set.identifier)
+        if len(duplicate_identifiers) != 0:
             if raise_exception:
                 raise ValueError(
                     'The model has the following duplicated ModifierSet '
-                    'names:\n{}'.format('\n'.join(duplicate_names)))
+                    'identifiers:\n{}'.format('\n'.join(duplicate_identifiers)))
             return False
         return True
 
@@ -237,7 +237,7 @@ class ModelRadianceProperties(object):
         # add all ModifierSets to the dictionary
         base['radiance']['modifier_sets'] = []
         if include_global_modifier_set:
-            base['radiance']['global_modifier_set'] = self.global_modifier_set.name
+            base['radiance']['global_modifier_set'] = self.global_modifier_set.identifier
             base['radiance']['modifier_sets'].append(
                 self.global_modifier_set.to_dict(abridged=True, none_for_defaults=False))
         modifier_sets = self.modifier_sets
@@ -285,10 +285,10 @@ class ModelRadianceProperties(object):
         Returns:
             A tuple with two elements
 
-            -   modifiers: A dictionary with names of modifiers as keys and Python
+            -   modifiers: A dictionary with identifiers of modifiers as keys and Python
                 modifier objects as values.
 
-            -   modifier_sets: A dictionary with names of modifier sets as keys
+            -   modifier_sets: A dictionary with identifiers of modifier sets as keys
                 and Python modifier set objects as values.
         """
         assert 'radiance' in data['properties'], \
@@ -297,14 +297,14 @@ class ModelRadianceProperties(object):
         # process all modifiers in the ModelRadianceProperties dictionary
         modifiers = {}
         for mod in data['properties']['radiance']['modifiers']:
-            modifiers[mod['name']] = dict_to_modifier(mod)
+            modifiers[mod['identifier']] = dict_to_modifier(mod)
 
         # process all modifier sets in the ModelRadianceProperties dictionary
         modifier_sets = {}
         if 'modifier_sets' in data['properties']['radiance'] and \
                 data['properties']['radiance']['modifier_sets'] is not None:
             for m_set in data['properties']['radiance']['modifier_sets']:
-                modifier_sets[m_set['name']] = \
+                modifier_sets[m_set['identifier']] = \
                     ModifierSet.from_dict_abridged(m_set, modifiers)
 
         return modifiers, modifier_sets
@@ -407,4 +407,4 @@ class ModelRadianceProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Model Radiance Properties:\n host: {}'.format(self.host.name)
+        return 'Model Radiance Properties:\n host: {}'.format(self.host.identifier)

--- a/honeybee_radiance/properties/room.py
+++ b/honeybee_radiance/properties/room.py
@@ -84,14 +84,14 @@ class RoomRadianceProperties(object):
         Args:
             abridged_data: A RoomRadiancePropertiesAbridged dictionary (typically
                 coming from a Model) with the format below.
-            modifier_sets: A dictionary of ModifierSets with names of the sets
+            modifier_sets: A dictionary of ModifierSets with identifiers of the sets
                 as keys, which will be used to re-assign modifier_sets.
 
         .. code-block:: python
 
             {
             'type': 'RoomRadiancePropertiesAbridged',
-            'modifier_set': str,  # ModifierSet name
+            'modifier_set': str,  # ModifierSet identifier
             }
         """
         if 'modifier_set' in abridged_data and abridged_data['modifier_set'] is not None:
@@ -102,7 +102,7 @@ class RoomRadianceProperties(object):
 
         Args:
             abridged: Boolean for whether the full dictionary of the Room should
-                be written (False) or just the name of the the individual
+                be written (False) or just the identifier of the the individual
                 properties (True). Default: False.
         """
         base = {'radiance': {}}
@@ -112,7 +112,8 @@ class RoomRadianceProperties(object):
         # write the ModifierSet into the dictionary
         if self._modifier_set is not None:
             base['radiance']['modifier_set'] = \
-                self._modifier_set.name if abridged else self._modifier_set.to_dict()
+                self._modifier_set.identifier if abridged else \
+                self._modifier_set.to_dict()
 
         return base
 
@@ -131,4 +132,4 @@ class RoomRadianceProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Room Radiance Properties:\n host: {}'.format(self.host.name)
+        return 'Room Radiance Properties:\n host: {}'.format(self.host.identifier)

--- a/honeybee_radiance/properties/shade.py
+++ b/honeybee_radiance/properties/shade.py
@@ -94,15 +94,15 @@ class ShadeRadianceProperties(_GeometryRadianceProperties):
         Args:
             abridged_data: A ShadeRadiancePropertiesAbridged dictionary (typically
                 coming from a Model) with the format below.
-            modifiers: A dictionary of modifiers with modifier names as keys,
+            modifiers: A dictionary of modifiers with modifier identifiers as keys,
                 which will be used to re-assign modifiers.
 
         .. code-block:: python
 
             {
             'type': 'ShadeRadiancePropertiesAbridged',
-            'modifier': str,  # A Honeybee Radiance Modifier name
-            'modifier_blk': str  # A Honeybee Radiance Modifier name
+            'modifier': str,  # A Honeybee Radiance Modifier identifier
+            'modifier_blk': str  # A Honeybee Radiance Modifier identifier
             }
         """
         self._apply_modifiers_from_dict(abridged_data, modifiers)
@@ -131,4 +131,4 @@ class ShadeRadianceProperties(_GeometryRadianceProperties):
             return None
 
     def __repr__(self):
-        return 'Shade Radiance Properties:\n host: {}'.format(self.host.name)
+        return 'Shade Radiance Properties:\n host: {}'.format(self.host.identifier)

--- a/honeybee_radiance/reader.py
+++ b/honeybee_radiance/reader.py
@@ -71,7 +71,7 @@ def string_to_dicts(string):
     """
     def find_object(target, index):
         for o_count, other_obj in enumerate(objects[:-(index + 1)]):
-            if other_obj['name'] == target:
+            if other_obj['identifier'] == target:
                 return o_count, other_obj
 
     input_objects = parse_from_string(string)
@@ -97,7 +97,7 @@ def string_to_dicts(string):
                 # didn't find any
                 raise ValueError(
                     'Failed to find "{}" modifier for "{}" in input string'.format(
-                        obj['modifier'], obj['name']
+                        obj['modifier'], obj['identifier']
                     )
                 )
             else:
@@ -138,7 +138,7 @@ def string_to_dict(string):
         for d in re.split(split_pattern_one, str(dt))
     ]
 
-    modifier, primitive_type, name = data[:3]
+    modifier, primitive_type, identifier = data[:3]
     base_data = data[3:]
 
     count_1 = int(base_data[0])
@@ -154,7 +154,7 @@ def string_to_dict(string):
     return {
         'modifier': modifier,
         'type': primitive_type,
-        'name': name,
+        'identifier': identifier,
         'values': [l1, l2, l3],
         'dependencies': []
     }

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -19,7 +19,7 @@ def shade_to_rad(shade, blk=False, minimal=False):
     """
     rad_prop = shade.properties.radiance
     modifier = rad_prop.modifier_blk if blk else rad_prop.modifier
-    rad_poly = Polygon(shade.name, shade.vertices, modifier)
+    rad_poly = Polygon(shade.identifier, shade.vertices, modifier)
     return rad_poly.to_radiance(minimal, False, False)
 
 
@@ -40,7 +40,7 @@ def door_to_rad(door, blk=False, minimal=False):
     """
     rad_prop = door.properties.radiance
     modifier = rad_prop.modifier_blk if blk else rad_prop.modifier
-    rad_poly = Polygon(door.name, door.vertices, modifier)
+    rad_poly = Polygon(door.identifier, door.vertices, modifier)
     door_strs = [rad_poly.to_radiance(minimal, False, False)]
     for shd in door.shades:
         door_strs.append(shade_to_rad(shd, blk, minimal))
@@ -64,7 +64,7 @@ def aperture_to_rad(aperture, blk=False, minimal=False):
     """
     rad_prop = aperture.properties.radiance
     modifier = rad_prop.modifier_blk if blk else rad_prop.modifier
-    rad_poly = Polygon(aperture.name, aperture.vertices, modifier)
+    rad_poly = Polygon(aperture.identifier, aperture.vertices, modifier)
     ap_strs = [rad_poly.to_radiance(minimal, False, False)]
     for shd in aperture.shades:
         ap_strs.append(shade_to_rad(shd, blk, minimal))
@@ -89,7 +89,7 @@ def face_to_rad(face, blk=False, minimal=False):
     """
     rad_prop = face.properties.radiance
     modifier = rad_prop.modifier_blk if blk else rad_prop.modifier
-    rad_poly = Polygon(face.name, face.punched_vertices, modifier)
+    rad_poly = Polygon(face.identifier, face.punched_vertices, modifier)
     face_strs = [rad_poly.to_radiance(minimal, False, False)]
     for shd in face.shades:
         face_strs.append(shade_to_rad(shd, blk, minimal))

--- a/tests/aperture_extend_test.py
+++ b/tests/aperture_extend_test.py
@@ -38,22 +38,22 @@ def test_default_modifiers():
     vertices_floor = [[0, 0, 0], [0, 10, 0], [10, 10, 0], [10, 0, 0]]
     vertices_roof = [[10, 0, 3], [10, 10, 3], [0, 10, 3], [0, 0, 3]]
 
-    wf = Face.from_vertices('wall face', vertices_parent_wall)
-    wa = Aperture.from_vertices('wall window', vertices_wall)
+    wf = Face.from_vertices('wall_face', vertices_parent_wall)
+    wa = Aperture.from_vertices('wall_window', vertices_wall)
     wf.add_aperture(wa)
-    Room('Test Room 1', [wf])
+    Room('TestRoom1', [wf])
     assert wa.properties.radiance.modifier == generic_exterior_window
 
-    wf2 = Face.from_vertices('wall face2', vertices_parent_wall_2)
-    wa2 = Aperture.from_vertices('wall window2', vertices_wall_2)
+    wf2 = Face.from_vertices('wall_face2', vertices_parent_wall_2)
+    wa2 = Aperture.from_vertices('wall_window2', vertices_wall_2)
     wf2.add_aperture(wa2)
-    Room('Test Room 2', [wf2])
+    Room('TestRoom2', [wf2])
     wa.set_adjacency(wa2)
     assert wa.properties.radiance.modifier == generic_interior_window
 
-    ra = Aperture.from_vertices('roof window', vertices_roof)
+    ra = Aperture.from_vertices('roof_window', vertices_roof)
     assert ra.properties.radiance.modifier == generic_exterior_window
-    fa = Aperture.from_vertices('floor window', vertices_floor)
+    fa = Aperture.from_vertices('floor_window', vertices_floor)
     assert fa.properties.radiance.modifier == generic_exterior_window
 
 
@@ -113,7 +113,7 @@ def test_to_dict():
     ad = aperture.to_dict()
     assert 'modifier' in ad['properties']['radiance']
     assert ad['properties']['radiance']['modifier'] is not None
-    assert ad['properties']['radiance']['modifier']['name'] == 'TriplePane'
+    assert ad['properties']['radiance']['modifier']['identifier'] == 'TriplePane'
 
 
 def test_from_dict():

--- a/tests/door_extend_test.py
+++ b/tests/door_extend_test.py
@@ -36,22 +36,22 @@ def test_default_modifiers():
     vertices_wall = [[0, 1, 0], [0, 2, 0], [0, 2, 2], [0, 0, 2]]
     vertices_wall_2 = list(reversed(vertices_wall))
 
-    wf = Face.from_vertices('wall face', vertices_parent_wall)
-    wdr = Door.from_vertices('wall door', vertices_wall)
+    wf = Face.from_vertices('wall_face', vertices_parent_wall)
+    wdr = Door.from_vertices('wall_door', vertices_wall)
     wf.add_door(wdr)
-    Room('Test Room 1', [wf])
+    Room('TestRoom1', [wf])
     assert wdr.properties.radiance.modifier == generic_door
 
-    wf2 = Face.from_vertices('wall face2', vertices_parent_wall_2)
-    wdr2 = Door.from_vertices('wall door2', vertices_wall_2)
+    wf2 = Face.from_vertices('wall_face2', vertices_parent_wall_2)
+    wdr2 = Door.from_vertices('wall_door2', vertices_wall_2)
     wdr.is_glass = True
     wdr2.is_glass = True
     wf2.add_door(wdr2)
-    Room('Test Room 2', [wf2])
+    Room('TestRoom2', [wf2])
     wdr.set_adjacency(wdr2)
     assert wdr.properties.radiance.modifier == generic_interior_window
 
-    ra = Door.from_vertices('wall door', vertices_parent_wall)
+    ra = Door.from_vertices('wall_door', vertices_parent_wall)
     ra.is_glass = True
     assert ra.properties.radiance.modifier == generic_exterior_window
 
@@ -99,7 +99,7 @@ def test_duplicate():
 def test_to_dict():
     """Test the Door to_dict method with radiance properties."""
     door = Door.from_vertices(
-        'front door', [[0, 0, 0], [10, 0, 0], [10, 0, 10], [0, 0, 10]])
+        'front_door', [[0, 0, 0], [10, 0, 0], [10, 0, 10], [0, 0, 10]])
     painted_door = Plastic.from_single_reflectance('PaintedDoor', 0.75)
 
     drd = door.to_dict()
@@ -112,7 +112,7 @@ def test_to_dict():
     drd = door.to_dict()
     assert 'modifier' in drd['properties']['radiance']
     assert drd['properties']['radiance']['modifier'] is not None
-    assert drd['properties']['radiance']['modifier']['name'] == 'PaintedDoor'
+    assert drd['properties']['radiance']['modifier']['identifier'] == 'PaintedDoor'
 
 
 def test_from_dict():

--- a/tests/face_extend_test.py
+++ b/tests/face_extend_test.py
@@ -102,7 +102,7 @@ def test_to_dict():
     fd = face.to_dict()
     assert 'modifier' in fd['properties']['radiance']
     assert fd['properties']['radiance']['modifier'] is not None
-    assert fd['properties']['radiance']['modifier']['name'] == '035Concrete'
+    assert fd['properties']['radiance']['modifier']['identifier'] == '035Concrete'
 
 
 def test_from_dict():

--- a/tests/geometry_bubble_test.py
+++ b/tests/geometry_bubble_test.py
@@ -7,6 +7,6 @@ from honeybee_radiance.geometry import Bubble
 
 def test_cup():
     geo = Bubble('test_bubble')
-    assert geo.name == 'test_bubble'
+    assert geo.identifier == 'test_bubble'
     assert geo.to_radiance(
         minimal=True) == 'void bubble test_bubble 0 0 4 0.0 0.0 0.0 10.0'

--- a/tests/geometry_cone_test.py
+++ b/tests/geometry_cone_test.py
@@ -4,7 +4,7 @@ from .rad_string_collection import metal_cone
 
 def test_cone():
     geo = Cone('test_cone')
-    assert geo.name == 'test_cone'
+    assert geo.identifier == 'test_cone'
     assert geo.center_pt_start == (0, 0, 0)
     assert geo.center_pt_end == (0, 0, 10)
     assert geo.radius_start == 10
@@ -15,7 +15,7 @@ def test_cone():
 
 def test_assign_values():
     geo = Cone('test_cone', (0.6, 0.7, 0.8), 50, (0, 0, 0), 100)
-    assert geo.name == 'test_cone'
+    assert geo.identifier == 'test_cone'
     assert geo.center_pt_start == (0.6, 0.7, 0.8)
     assert geo.center_pt_end == (0, 0, 0)
     assert geo.radius_start == 50
@@ -26,12 +26,12 @@ def test_assign_values():
 
 def test_update_values():
     geo = Cone('test_cone', (0.6, 0.7, 0.8), 50, (0, 0, 0), 100)
-    geo.name = 'new_cone'
+    geo.identifier = 'new_cone'
     geo.center_pt_start = (10, 10, 10)
     geo.center_pt_end = (0, 0, 0)
     geo.radius_start = 0
     geo.radius_end = 20
-    assert geo.name == 'new_cone'
+    assert geo.identifier == 'new_cone'
     assert geo.center_pt_start == (10, 10, 10)
     assert geo.center_pt_end == (0, 0, 0)
     assert geo.radius_start == 0
@@ -43,7 +43,7 @@ def test_update_values():
 def test_from_string():
     geometry_str = metal_cone
     geo = Cone.from_string(geometry_str)
-    assert geo.name == 'cone_one'
+    assert geo.identifier == 'cone_one'
     assert geo.center_pt_start == (-77.3022, -78.4625, 415.900)
     assert geo.center_pt_end == (-81.9842, -78.9436, 420.900)
     assert geo.radius_start == 10
@@ -58,7 +58,7 @@ def test_from_and_to_dict():
     cone_dict = cone.to_dict()
 
     # check values in dictionary
-    assert cone_dict['name'] == 'default_cone'
+    assert cone_dict['identifier'] == 'default_cone'
     assert cone_dict['modifier'] == modifier.to_dict()
     assert cone_dict['center_pt_start'] == (0, 0, 0)
     assert cone_dict['center_pt_end'] == (0, 0, 10)

--- a/tests/geometry_cup_test.py
+++ b/tests/geometry_cup_test.py
@@ -7,6 +7,6 @@ from honeybee_radiance.geometry import Cup
 
 def test_cup():
     geo = Cup('test_cup')
-    assert geo.name == 'test_cup'
+    assert geo.identifier == 'test_cup'
     assert geo.to_radiance(
         minimal=True) == 'void cup test_cup 0 0 8 0.0 0.0 0.0 0.0 0.0 10.0 10.0 0.0'

--- a/tests/geometry_cylinder_test.py
+++ b/tests/geometry_cylinder_test.py
@@ -4,7 +4,7 @@ from .rad_string_collection import metal_cylinder
 
 def test_cylinder():
     geo = Cylinder('test_cylinder')
-    assert geo.name == 'test_cylinder'
+    assert geo.identifier == 'test_cylinder'
     assert geo.center_pt_start == (0, 0, 0)
     assert geo.center_pt_end == (0, 0, 10)
     assert geo.radius == 10
@@ -15,7 +15,7 @@ def test_cylinder():
 
 def test_assign_values():
     geo = Cylinder('test_cylinder', (0.6, 0.7, 0.8), (0, 0, 0), 100)
-    assert geo.name == 'test_cylinder'
+    assert geo.identifier == 'test_cylinder'
     assert geo.center_pt_start == (0.6, 0.7, 0.8)
     assert geo.center_pt_end == (0, 0, 0)
     assert geo.radius == 100
@@ -25,11 +25,11 @@ def test_assign_values():
 
 def test_update_values():
     geo = Cylinder('test_cylinder', (0.6, 0.7, 0.8), (0, 0, 0), 100)
-    geo.name = 'new_cylinder'
+    geo.identifier = 'new_cylinder'
     geo.center_pt_start = (10, 10, 10)
     geo.center_pt_end = (0, 0, 0)
     geo.radius = 0
-    assert geo.name == 'new_cylinder'
+    assert geo.identifier == 'new_cylinder'
     assert geo.center_pt_start == (10, 10, 10)
     assert geo.center_pt_end == (0, 0, 0)
     assert geo.radius == 0
@@ -40,7 +40,7 @@ def test_update_values():
 def test_from_string():
     geometry_str = metal_cylinder
     geo = Cylinder.from_string(geometry_str)
-    assert geo.name == 'cylinder_one'
+    assert geo.identifier == 'cylinder_one'
     assert geo.center_pt_start == (-77.3022, -78.4625, 415.900)
     assert geo.center_pt_end == (-81.9842, -78.9436, 420.900)
     assert geo.radius == 10
@@ -54,7 +54,7 @@ def test_from_and_to_dict():
     cylinder_dict = cylinder.to_dict()
 
     # check values in dictionary
-    assert cylinder_dict['name'] == 'default_cylinder'
+    assert cylinder_dict['identifier'] == 'default_cylinder'
     assert cylinder_dict['modifier'] == modifier.to_dict()
     assert cylinder_dict['center_pt_start'] == (0, 0, 0)
     assert cylinder_dict['center_pt_end'] == (0, 0, 10)

--- a/tests/geometry_polygon_test.py
+++ b/tests/geometry_polygon_test.py
@@ -9,7 +9,7 @@ alt_vertices = \
 
 def test_polygon():
     geo = Polygon('test_polygon', vertices)
-    assert geo.name == 'test_polygon'
+    assert geo.identifier == 'test_polygon'
     assert geo.vertices == tuple(tuple(pt) for pt in vertices)
     assert geo.to_radiance(
         minimal=True) == \
@@ -19,7 +19,7 @@ def test_polygon():
 
 def test_assign_values():
     geo = Polygon('test_polygon',vertices)
-    geo.name = 'new_polygon'
+    geo.identifier = 'new_polygon'
     geo.vertices = tuple(tuple(pt) for pt in alt_vertices)
     assert geo.to_radiance(minimal=True) == \
         'void polygon new_polygon 0 0 12 6.0 -10.0 20.0 6.0 -5.0 20.0 ' \
@@ -29,7 +29,7 @@ def test_assign_values():
 def test_from_string():
     geometry_str = metal_polygon
     geo = Polygon.from_string(geometry_str)
-    assert geo.name == 'polygon_one'
+    assert geo.identifier == 'polygon_one'
     assert geo.vertices == tuple(tuple(pt) for pt in vertices)
     assert ' '.join(geo.to_radiance(minimal=True).split()) == \
         ' '.join(geometry_str.split())
@@ -41,7 +41,7 @@ def test_from_and_to_dict():
     polygon_dict = polygon.to_dict()
 
     # check values in dictionary
-    assert polygon_dict['name'] == 'default_polygon'
+    assert polygon_dict['identifier'] == 'default_polygon'
     assert polygon_dict['modifier'] == modifier.to_dict()
     assert polygon_dict['vertices'] == tuple(tuple(pt) for pt in vertices)
 

--- a/tests/geometry_ring_test.py
+++ b/tests/geometry_ring_test.py
@@ -5,7 +5,7 @@ from .rad_string_collection import metal_ring
 
 def test_ring():
     geo = Ring('test_ring')
-    assert geo.name == 'test_ring'
+    assert geo.identifier == 'test_ring'
     assert geo.center_pt == (0, 0, 0)
     assert geo.normal_vector == (0, 0, 1)
     assert geo.radius_inner == 5
@@ -16,7 +16,7 @@ def test_ring():
 
 def test_assign_values():
     geo = Ring('test_ring', (0.6, 0.7, 0.8), (0, 0, 20), 50, 100)
-    assert geo.name == 'test_ring'
+    assert geo.identifier == 'test_ring'
     assert geo.center_pt == (0.6, 0.7, 0.8)
     assert geo.normal_vector == (0, 0, 20)
     assert geo.radius_inner == 50
@@ -27,12 +27,12 @@ def test_assign_values():
 
 def test_update_values():
     geo = Ring('test_ring', (0.6, 0.7, 0.8), (0, 0, 20), 50, 100)
-    geo.name = 'new_ring'
+    geo.identifier = 'new_ring'
     geo.center_pt = (10, 10, 10)
     geo.normal_vector = (0, 0, 10)
     geo.radius_inner = 0
     geo.radius_outer = 20
-    assert geo.name == 'new_ring'
+    assert geo.identifier == 'new_ring'
     assert geo.center_pt == (10, 10, 10)
     assert geo.normal_vector == (0, 0, 10)
     assert geo.radius_inner == 0
@@ -44,7 +44,7 @@ def test_update_values():
 def test_from_string():
     geometry_str = metal_ring
     geo = Ring.from_string(geometry_str)
-    assert geo.name == 'ring_one'
+    assert geo.identifier == 'ring_one'
     assert geo.center_pt == (0, 0, 0)
     assert geo.normal_vector == (0, 0, 1)
     assert geo.radius_inner == 10
@@ -59,7 +59,7 @@ def test_from_and_to_dict():
     ring_dict = ring.to_dict()
 
     # check values in dictionary
-    assert ring_dict['name'] == 'default_ring'
+    assert ring_dict['identifier'] == 'default_ring'
     assert ring_dict['modifier'] == modifier.to_dict()
     assert ring_dict['center_pt'] == (0, 0, 0)
     assert ring_dict['normal_vector'] == (0, 0, 1)

--- a/tests/geometry_source_test.py
+++ b/tests/geometry_source_test.py
@@ -5,7 +5,7 @@ from .rad_string_collection import metal_source
 
 def test_source():
     geo = Source('test_source')
-    assert geo.name == 'test_source'
+    assert geo.identifier == 'test_source'
     assert geo.direction == (0, 0, -1)
     assert geo.angle == 0.533
     assert geo.to_radiance(
@@ -15,7 +15,7 @@ def test_source():
 
 def test_assign_values():
     geo = Source('test_source', (0.6, 0.7, 0.8), 100)
-    assert geo.name == 'test_source'
+    assert geo.identifier == 'test_source'
     assert geo.direction == (0.6, 0.7, 0.8)
     assert geo.angle == 100
     assert geo.to_radiance(minimal=True) == \
@@ -24,10 +24,10 @@ def test_assign_values():
 
 def test_update_values():
     geo = Source('test_source', (0.6, 0.7, 0.8), 100)
-    geo.name = 'new_source'
+    geo.identifier = 'new_source'
     geo.direction = (10, 10, 10)
     geo.angle = 0
-    assert geo.name == 'new_source'
+    assert geo.identifier == 'new_source'
     assert geo.direction == (10, 10, 10)
     assert geo.angle == 0
     assert geo.to_radiance(minimal=True) == \
@@ -37,7 +37,7 @@ def test_update_values():
 def test_from_string():
     geometry_str = metal_source
     geo = Source.from_string(geometry_str)
-    assert geo.name == 'source_one'
+    assert geo.identifier == 'source_one'
     assert geo.direction == (0, 0, -1)
     assert geo.angle == 0.533
     assert ' '.join(geo.to_radiance(minimal=True).split()) == \
@@ -50,7 +50,7 @@ def test_from_and_to_dict():
     source_dict = source.to_dict()
 
     # check values in dictionary
-    assert source_dict['name'] == 'default_source'
+    assert source_dict['identifier'] == 'default_source'
     assert source_dict['modifier'] == modifier.to_dict()
     assert source_dict['direction'] == (0, 0, -1)
     assert source_dict['angle'] == 0.533

--- a/tests/geometry_sphere_test.py
+++ b/tests/geometry_sphere_test.py
@@ -5,7 +5,7 @@ from .rad_string_collection import metal_sphere
 
 def test_sphere():
     geo = Sphere('test_sphere')
-    assert geo.name == 'test_sphere'
+    assert geo.identifier == 'test_sphere'
     assert geo.center_pt == (0, 0, 0)
     assert geo.radius == 10
     assert geo.to_radiance(
@@ -15,7 +15,7 @@ def test_sphere():
 
 def test_assign_values():
     geo = Sphere('test_sphere', (0.6, 0.7, 0.8), 100)
-    assert geo.name == 'test_sphere'
+    assert geo.identifier == 'test_sphere'
     assert geo.center_pt == (0.6, 0.7, 0.8)
     assert geo.radius == 100
     assert geo.to_radiance(minimal=True) == \
@@ -24,10 +24,10 @@ def test_assign_values():
 
 def test_update_values():
     geo = Sphere('test_sphere', (0.6, 0.7, 0.8), 100)
-    geo.name = 'new_sphere'
+    geo.identifier = 'new_sphere'
     geo.center_pt = (10, 10, 10)
     geo.radius = 0
-    assert geo.name == 'new_sphere'
+    assert geo.identifier == 'new_sphere'
     assert geo.center_pt == (10, 10, 10)
     assert geo.radius == 0
     assert geo.to_radiance(minimal=True) == \
@@ -37,7 +37,7 @@ def test_update_values():
 def test_from_string():
     geometry_str = metal_sphere
     geo = Sphere.from_string(geometry_str)
-    assert geo.name == 'sphere_one'
+    assert geo.identifier == 'sphere_one'
     assert geo.center_pt == (-77.3022, -78.4625, 415.900)
     assert geo.radius == 10
     assert ' '.join(geo.to_radiance(minimal=True).split()) == \
@@ -50,7 +50,7 @@ def test_from_and_to_dict():
     sphere_dict = sphere.to_dict()
 
     # check values in dictionary
-    assert sphere_dict['name'] == 'default_sphere'
+    assert sphere_dict['identifier'] == 'default_sphere'
     assert sphere_dict['modifier'] == modifier.to_dict()
     assert sphere_dict['center_pt'] == (0, 0, 0)
     assert sphere_dict['radius'] == 10

--- a/tests/geometry_tube_test.py
+++ b/tests/geometry_tube_test.py
@@ -7,6 +7,6 @@ from honeybee_radiance.geometry import Tube
 
 def test_cup():
     geo = Tube('test_tube')
-    assert geo.name == 'test_tube'
+    assert geo.identifier == 'test_tube'
     assert geo.to_radiance(
         minimal=True) == 'void tube test_tube 0 0 7 0.0 0.0 0.0 0.0 0.0 10.0 10.0'

--- a/tests/material_bsdf_test.py
+++ b/tests/material_bsdf_test.py
@@ -9,7 +9,7 @@ def test_bsdf():
     mt = BSDF(klems_bsdf_file)
     assert mt.bsdf_file == os.path.normpath(klems_bsdf_file)
     assert list(mt.up_orientation) == [0.01, 0.01, 1.0]
-    assert mt.name == 'klemsfull'
+    assert mt.identifier == 'klemsfull'
     assert str(mt.modifier) == 'void'
     assert mt.function_file == '.'
     assert mt.angle_basis == 'Klems Full'
@@ -18,11 +18,11 @@ def test_bsdf():
 
 def test_assign_values():
     mt = BSDF(
-        klems_bsdf_file, name='klemsklems', up_orientation=(0, 0, 10),
+        klems_bsdf_file, identifier='klemsklems', up_orientation=(0, 0, 10),
         thickness=10)
     assert mt.bsdf_file == os.path.normpath(klems_bsdf_file)
     assert list(mt.up_orientation) == [0, 0, 10]
-    assert mt.name == 'klemsklems'
+    assert mt.identifier == 'klemsklems'
     assert mt.thickness == 10
 
 
@@ -43,7 +43,7 @@ def test_from_string():
     mt = BSDF.from_string(bsdf_str)
     assert mt.bsdf_file == os.path.normpath(klems_bsdf_file)
     assert list(mt.up_orientation) == [0.01, 0.01, 1.0]
-    assert mt.name == 'klemsfull'
+    assert mt.identifier == 'klemsfull'
     assert str(mt.modifier) == 'void'
     assert mt.function_file == '.'
     assert mt.angle_basis == 'Klems Full'

--- a/tests/material_glass_test.py
+++ b/tests/material_glass_test.py
@@ -72,7 +72,7 @@ def test_from_string():
             
     """
     gl = Glass.from_string(glass_str)
-    assert gl.name == 'glass_alt_mat'
+    assert gl.identifier == 'glass_alt_mat'
     assert gl.r_transmissivity == 0.91
     assert gl.g_transmissivity == 0.92
     assert gl.b_transmissivity == 0.93
@@ -81,7 +81,7 @@ def test_from_string():
 
 def test_from_dict_w_modifier():
     glass_mod = {
-        "name": "test_glass_mod",
+        "identifier": "test_glass_mod",
         "type": "glass",
         "r_transmissivity": 0.4,
         "g_transmissivity": 0.5,
@@ -92,7 +92,7 @@ def test_from_dict_w_modifier():
     }
 
     glass_dict = {
-        "name": "test_glass",
+        "identifier": "test_glass",
         "type": "glass",
         "r_transmissivity": 0.1,
         "g_transmissivity": 0.2,

--- a/tests/material_glow_test.py
+++ b/tests/material_glow_test.py
@@ -48,7 +48,7 @@ def test_from_string():
             
     """
     mt = Glow.from_string(glow_str)
-    assert mt.name == 'glow_alt_mat'
+    assert mt.identifier == 'glow_alt_mat'
     assert mt.r_emittance == 100
     assert mt.g_emittance == 200
     assert mt.b_emittance == 10000

--- a/tests/material_light_test.py
+++ b/tests/material_light_test.py
@@ -43,7 +43,7 @@ def test_from_string():
             
     """
     mt = Light.from_string(light_str)
-    assert mt.name == 'light_alt_mat'
+    assert mt.identifier == 'light_alt_mat'
     assert mt.r_emittance == 100
     assert mt.g_emittance == 200
     assert mt.b_emittance == 10000
@@ -52,7 +52,7 @@ def test_from_string():
 
 def test_from_dict_w_modifier():
     glass_mod = {
-        "name": "test_glass_mod",
+        "identifier": "test_glass_mod",
         "type": "glass",
         "r_transmissivity": 0.4,
         "g_transmissivity": 0.5,
@@ -63,7 +63,7 @@ def test_from_dict_w_modifier():
     }
 
     light_dict = {
-        "name": "test_light",
+        "identifier": "test_light",
         "type": "light",
         "r_emittance": 0.1,
         "g_emittance": 0.2,

--- a/tests/material_metal_test.py
+++ b/tests/material_metal_test.py
@@ -76,7 +76,7 @@ def test_from_string():
             
     """
     mt = Metal.from_string(plastic_str)
-    assert mt.name == 'plastic_alt_mat'
+    assert mt.identifier == 'plastic_alt_mat'
     assert mt.r_reflectance == 0.91
     assert mt.g_reflectance == 0.92
     assert mt.b_reflectance == 0.93
@@ -85,7 +85,7 @@ def test_from_string():
 
 def test_from_dict_w_modifier():
     glass_mod = {
-        "name": "test_glass_mod",
+        "identifier": "test_glass_mod",
         "type": "glass",
         "r_transmissivity": 0.4,
         "g_transmissivity": 0.5,
@@ -96,7 +96,7 @@ def test_from_dict_w_modifier():
     }
 
     plastic_dict = {
-        "name": "test_metal",
+        "identifier": "test_metal",
         "type": "metal",
         "r_reflectance": 0.1,
         "g_reflectance": 0.2,

--- a/tests/material_plastic_test.py
+++ b/tests/material_plastic_test.py
@@ -80,7 +80,7 @@ def test_from_string():
             
     """
     pl = Plastic.from_string(plastic_str)
-    assert pl.name == 'plastic_alt_mat'
+    assert pl.identifier == 'plastic_alt_mat'
     assert pl.r_reflectance == 0.91
     assert pl.g_reflectance == 0.92
     assert pl.b_reflectance == 0.93
@@ -89,7 +89,7 @@ def test_from_string():
 
 def test_from_dict_w_modifier():
     glass_mod = {
-        "name": "test_glass_mod",
+        "identifier": "test_glass_mod",
         "type": "glass",
         "r_transmissivity": 0.4,
         "g_transmissivity": 0.5,
@@ -100,7 +100,7 @@ def test_from_dict_w_modifier():
     }
 
     plastic_dict = {
-        "name": "test_plastic",
+        "identifier": "test_plastic",
         "type": "plastic",
         "r_reflectance": 0.1,
         "g_reflectance": 0.2,

--- a/tests/material_trans_test.py
+++ b/tests/material_trans_test.py
@@ -60,7 +60,7 @@ def test_from_string():
             
     """
     tr = Trans.from_string(trans_str)
-    assert tr.name == 'test'
+    assert tr.identifier == 'test'
     assert tr.r_reflectance == 0.7
     assert tr.g_reflectance == 0.7
     assert tr.b_reflectance == 0.7

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -26,7 +26,7 @@ import pytest
 
 def test_radiance_properties():
     """Test the existence of the Model radiance properties."""
-    room = Room.from_box('Tiny House Room', 5, 10, 3)
+    room = Room.from_box('TinyHouseRoom', 5, 10, 3)
     south_face = room[3]
     south_face.apertures_by_ratio(0.4, 0.01)
     south_face.apertures[0].overhang(0.5, indoor=False)
@@ -35,7 +35,7 @@ def test_radiance_properties():
     fritted_glass_trans = Glass.from_single_transmittance('FrittedGlass', 0.35)
     south_face.apertures[0].outdoor_shades[0].properties.radiance.modifier = \
         fritted_glass_trans
-    model = Model('Tiny House', [room])
+    model = Model('TinyHouse', [room])
 
     assert hasattr(model.properties, 'radiance')
     assert isinstance(model.properties.radiance, ModelRadianceProperties)
@@ -49,10 +49,10 @@ def test_radiance_properties():
     assert isinstance(model.properties.radiance.global_modifier_set, ModifierSet)
 
 
-def test_check_duplicate_modifier_set_names():
-    """Test the check_duplicate_modifier_set_names method."""
-    first_floor = Room.from_box('First Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
-    second_floor = Room.from_box('Second Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+def test_check_duplicate_modifier_set_identifiers():
+    """Test the check_duplicate_modifier_set_identifiers method."""
+    first_floor = Room.from_box('FirstFloor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('SecondFloor', 10, 10, 3, origin=Point3D(0, 0, 3))
     for face in first_floor[1:5]:
         face.apertures_by_ratio(0.2, 0.01)
     for face in second_floor[1:5]:
@@ -63,11 +63,11 @@ def test_check_duplicate_modifier_set_names():
     pts_3 = [Point3D(10, 0, 6), Point3D(10, 10, 6), Point3D(5, 10, 9), Point3D(5, 0, 9)]
     pts_4 = [Point3D(0, 0, 6), Point3D(10, 0, 6), Point3D(5, 0, 9)]
     pts_5 = [Point3D(10, 10, 6), Point3D(0, 10, 6), Point3D(5, 10, 9)]
-    face_1 = Face('Attic Face 1', Face3D(pts_1))
-    face_2 = Face('Attic Face 2', Face3D(pts_2))
-    face_3 = Face('Attic Face 3', Face3D(pts_3))
-    face_4 = Face('Attic Face 4', Face3D(pts_4))
-    face_5 = Face('Attic Face 5', Face3D(pts_5))
+    face_1 = Face('AtticFace1', Face3D(pts_1))
+    face_2 = Face('AtticFace2', Face3D(pts_2))
+    face_3 = Face('AtticFace3', Face3D(pts_3))
+    face_4 = Face('AtticFace4', Face3D(pts_4))
+    face_5 = Face('AtticFace5', Face3D(pts_5))
     attic = Room('Attic', [face_1, face_2, face_3, face_4, face_5], 0.01, 1)
 
     mod_set = ModifierSet('Attic_Construction_Set')
@@ -77,20 +77,20 @@ def test_check_duplicate_modifier_set_names():
 
     Room.solve_adjacency([first_floor, second_floor, attic], 0.01)
 
-    model = Model('Multi Zone Single Family House', [first_floor, second_floor, attic])
+    model = Model('Multi_Zone_Single_Family_House', [first_floor, second_floor, attic])
 
-    assert model.properties.radiance.check_duplicate_modifier_set_names(False)
+    assert model.properties.radiance.check_duplicate_modifier_set_identifiers(False)
     mod_set.unlock()
-    mod_set.name = 'Generic_Interior_Visible_Modifier_Set'
+    mod_set.identifier = 'Generic_Interior_Visible_Modifier_Set'
     mod_set.lock()
-    assert not model.properties.radiance.check_duplicate_modifier_set_names(False)
+    assert not model.properties.radiance.check_duplicate_modifier_set_identifiers(False)
     with pytest.raises(ValueError):
-        model.properties.radiance.check_duplicate_modifier_set_names(True)
+        model.properties.radiance.check_duplicate_modifier_set_identifiers(True)
 
 
-def test_check_duplicate_modifier_names():
-    """Test the check_duplicate_modifier_names method."""
-    room = Room.from_box('Tiny House Zone', 5, 10, 3)
+def test_check_duplicate_modifier_identifiers():
+    """Test the check_duplicate_modifier_identifiers method."""
+    room = Room.from_box('Tiny_House_Zone', 5, 10, 3)
 
     high_ref_ceil = Plastic.from_single_reflectance('CustomModifier', 0.9)
     room[-1].properties.radiance.modifier = high_ref_ceil
@@ -98,26 +98,26 @@ def test_check_duplicate_modifier_names():
     north_face = room[1]
     aperture_verts = [Point3D(4.5, 10, 1), Point3D(2.5, 10, 1),
                       Point3D(2.5, 10, 2.5), Point3D(4.5, 10, 2.5)]
-    aperture = Aperture('Front Aperture', Face3D(aperture_verts))
+    aperture = Aperture('Front_Aperture', Face3D(aperture_verts))
     aperture.is_operable = True
     triple_pane = Glass.from_single_transmittance('CustomTriplePane', 0.3)
     aperture.properties.radiance.modifier = triple_pane
     north_face.add_aperture(aperture)
 
-    model = Model('Tiny House', [room])
+    model = Model('Tiny_House', [room])
 
-    assert model.properties.radiance.check_duplicate_modifier_names(False)
+    assert model.properties.radiance.check_duplicate_modifier_identifiers(False)
     triple_pane.unlock()
-    triple_pane.name = 'CustomModifier'
+    triple_pane.identifier = 'CustomModifier'
     triple_pane.lock()
-    assert not model.properties.radiance.check_duplicate_modifier_names(False)
+    assert not model.properties.radiance.check_duplicate_modifier_identifiers(False)
     with pytest.raises(ValueError):
-        model.properties.radiance.check_duplicate_modifier_names(True)
+        model.properties.radiance.check_duplicate_modifier_identifiers(True)
 
 
 def test_to_from_dict():
     """Test the Model to_dict and from_dict method with a single zone model."""
-    room = Room.from_box('Tiny House Room', 5, 10, 3)
+    room = Room.from_box('Tiny_House_Room', 5, 10, 3)
 
     dark_floor = Plastic.from_single_reflectance('DarkFloor', 0.1)
     room[0].properties.radiance.modifier = dark_floor
@@ -135,12 +135,12 @@ def test_to_from_dict():
     north_face = room[1]
     door_verts = [Point3D(2, 10, 0.1), Point3D(1, 10, 0.1),
                   Point3D(1, 10, 2.5), Point3D(2, 10, 2.5)]
-    door = Door('Front Door', Face3D(door_verts))
+    door = Door('FrontDoor', Face3D(door_verts))
     north_face.add_door(door)
 
     aperture_verts = [Point3D(4.5, 10, 1), Point3D(2.5, 10, 1),
                       Point3D(2.5, 10, 2.5), Point3D(4.5, 10, 2.5)]
-    aperture = Aperture('Front Aperture', Face3D(aperture_verts))
+    aperture = Aperture('FrontAperture', Face3D(aperture_verts))
     aperture.is_operable = True
     triple_pane = Glass.from_single_transmittance('CustomTriplePane', 0.3)
     aperture.properties.radiance.modifier = triple_pane
@@ -148,11 +148,11 @@ def test_to_from_dict():
 
     tree_canopy_geo = Face3D.from_regular_polygon(
         6, 2, Plane(Vector3D(0, 0, 1), Point3D(5, -3, 4)))
-    tree_canopy = Shade('Tree Canopy', tree_canopy_geo)
+    tree_canopy = Shade('TreeCanopy', tree_canopy_geo)
     tree_trans = Glass.from_single_transmittance('TreeTransmittance', 0.75)
     tree_canopy.properties.radiance.modifier = tree_trans
 
-    model = Model('Tiny House', [room], orphaned_shades=[tree_canopy])
+    model = Model('TinyHouse', [room], orphaned_shades=[tree_canopy])
     model.north_angle = 15
     model_dict = model.to_dict(included_prop=['radiance'])
     new_model = Model.from_dict(model_dict)
@@ -177,7 +177,7 @@ def test_to_from_dict():
 
 def test_to_dict_single_zone():
     """Test the Model to_dict method with a single zone model."""
-    room = Room.from_box('Tiny House Zone', 5, 10, 3)
+    room = Room.from_box('Tiny_House_Zone', 5, 10, 3)
 
     dark_floor = Plastic.from_single_reflectance('DarkFloor', 0.1)
     room[0].properties.radiance.modifier = dark_floor
@@ -196,25 +196,25 @@ def test_to_dict_single_zone():
     north_face.overhang(0.25, indoor=False)
     door_verts = [Point3D(2, 10, 0.1), Point3D(1, 10, 0.1),
                   Point3D(1, 10, 2.5), Point3D(2, 10, 2.5)]
-    door = Door('Front Door', Face3D(door_verts))
+    door = Door('Front_Door', Face3D(door_verts))
     north_face.add_door(door)
 
     aperture_verts = [Point3D(4.5, 10, 1), Point3D(2.5, 10, 1),
                       Point3D(2.5, 10, 2.5), Point3D(4.5, 10, 2.5)]
-    aperture = Aperture('Front Aperture', Face3D(aperture_verts))
+    aperture = Aperture('Front_Aperture', Face3D(aperture_verts))
     triple_pane = Glass.from_single_transmittance('CustomTriplePane', 0.3)
     aperture.properties.radiance.modifier = triple_pane
     north_face.add_aperture(aperture)
 
     tree_canopy_geo = Face3D.from_regular_polygon(
         6, 2, Plane(Vector3D(0, 0, 1), Point3D(5, -3, 4)))
-    tree_canopy = Shade('Tree Canopy', tree_canopy_geo)
+    tree_canopy = Shade('Tree_Canopy', tree_canopy_geo)
 
     table_geo = Face3D.from_rectangle(2, 2, Plane(o=Point3D(1.5, 4, 1)))
     table = Shade('Table', table_geo)
     room.add_indoor_shade(table)
 
-    model = Model('Tiny House', [room], orphaned_shades=[tree_canopy])
+    model = Model('Tiny_House', [room], orphaned_shades=[tree_canopy])
     model.north_angle = 15
 
     model_dict = model.to_dict()
@@ -228,20 +228,20 @@ def test_to_dict_single_zone():
     assert len(model_dict['properties']['radiance']['modifier_sets']) == 1
 
     assert model_dict['rooms'][0]['faces'][0]['properties']['radiance']['modifier'] == \
-        dark_floor.name
+        dark_floor.identifier
     south_ap_dict = model_dict['rooms'][0]['faces'][3]['apertures'][0]
     assert south_ap_dict['outdoor_shades'][0]['properties']['radiance']['modifier'] == \
-        light_shelf_out.name
+        light_shelf_out.identifier
     assert south_ap_dict['indoor_shades'][0]['properties']['radiance']['modifier'] == \
-        light_shelf_in.name
+        light_shelf_in.identifier
     assert model_dict['rooms'][0]['faces'][1]['apertures'][0]['properties']['radiance']['modifier'] == \
-        triple_pane.name
+        triple_pane.identifier
 
 
 def test_to_dict_multizone_house():
     """Test the Model to_dict method with a multi-zone house."""
-    first_floor = Room.from_box('First Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
-    second_floor = Room.from_box('Second Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
     for face in first_floor[1:5]:
         face.apertures_by_ratio(0.2, 0.01)
     for face in second_floor[1:5]:
@@ -252,11 +252,11 @@ def test_to_dict_multizone_house():
     pts_3 = [Point3D(10, 0, 6), Point3D(10, 10, 6), Point3D(5, 10, 9), Point3D(5, 0, 9)]
     pts_4 = [Point3D(0, 0, 6), Point3D(10, 0, 6), Point3D(5, 0, 9)]
     pts_5 = [Point3D(10, 10, 6), Point3D(0, 10, 6), Point3D(5, 10, 9)]
-    face_1 = Face('Attic Face 1', Face3D(pts_1))
-    face_2 = Face('Attic Face 2', Face3D(pts_2))
-    face_3 = Face('Attic Face 3', Face3D(pts_3))
-    face_4 = Face('Attic Face 4', Face3D(pts_4))
-    face_5 = Face('Attic Face 5', Face3D(pts_5))
+    face_1 = Face('AtticFace1', Face3D(pts_1))
+    face_2 = Face('AtticFace2', Face3D(pts_2))
+    face_3 = Face('AtticFace3', Face3D(pts_3))
+    face_4 = Face('AtticFace4', Face3D(pts_4))
+    face_5 = Face('AtticFace5', Face3D(pts_5))
     attic = Room('Attic', [face_1, face_2, face_3, face_4, face_5], 0.01, 1)
 
     mod_set = ModifierSet('Attic_Construction_Set')
@@ -266,7 +266,7 @@ def test_to_dict_multizone_house():
 
     Room.solve_adjacency([first_floor, second_floor, attic], 0.01)
 
-    model = Model('Multi Zone Single Family House', [first_floor, second_floor, attic])
+    model = Model('Multi_Zone_Single_Family_House', [first_floor, second_floor, attic])
     model_dict = model.to_dict()
 
     assert 'radiance' in model_dict['properties']
@@ -283,12 +283,12 @@ def test_to_dict_multizone_house():
     assert model_dict['rooms'][2]['faces'][0]['boundary_condition']['type'] == 'Surface'
 
     assert model_dict['rooms'][2]['properties']['radiance']['modifier_set'] == \
-        mod_set.name
+        mod_set.identifier
 
 
 def test_writer_to_rad():
     """Test the Model to.rad method."""
-    room = Room.from_box('Tiny House Zone', 5, 10, 3)
+    room = Room.from_box('Tiny_House_Zone', 5, 10, 3)
 
     dark_floor = Plastic.from_single_reflectance('DarkFloor', 0.1)
     room[0].properties.radiance.modifier = dark_floor
@@ -307,25 +307,25 @@ def test_writer_to_rad():
     north_face.overhang(0.25, indoor=False)
     door_verts = [Point3D(2, 10, 0.1), Point3D(1, 10, 0.1),
                   Point3D(1, 10, 2.5), Point3D(2, 10, 2.5)]
-    door = Door('Front Door', Face3D(door_verts))
+    door = Door('Front_Door', Face3D(door_verts))
     north_face.add_door(door)
 
     aperture_verts = [Point3D(4.5, 10, 1), Point3D(2.5, 10, 1),
                       Point3D(2.5, 10, 2.5), Point3D(4.5, 10, 2.5)]
-    aperture = Aperture('Front Aperture', Face3D(aperture_verts))
+    aperture = Aperture('Front_Aperture', Face3D(aperture_verts))
     triple_pane = Glass.from_single_transmittance('custom_triple_pane_0.3', 0.3)
     aperture.properties.radiance.modifier = triple_pane
     north_face.add_aperture(aperture)
 
     tree_canopy_geo = Face3D.from_regular_polygon(
         6, 2, Plane(Vector3D(0, 0, 1), Point3D(5, -3, 4)))
-    tree_canopy = Shade('Tree Canopy', tree_canopy_geo)
+    tree_canopy = Shade('Tree_Canopy', tree_canopy_geo)
 
     table_geo = Face3D.from_rectangle(2, 2, Plane(o=Point3D(1.5, 4, 1)))
     table = Shade('Table', table_geo)
     room.add_indoor_shade(table)
 
-    model = Model('Tiny House', [room], orphaned_shades=[tree_canopy])
+    model = Model('Tiny_House', [room], orphaned_shades=[tree_canopy])
     model.north_angle = 15
 
     assert hasattr(model.to, 'rad')

--- a/tests/modifier_set_test.py
+++ b/tests/modifier_set_test.py
@@ -8,11 +8,11 @@ import pytest
 
 def test_modifierset_init():
     """Test the initialization of ModifierSet and basic properties."""
-    default_set = ModifierSet('Default Set')
+    default_set = ModifierSet('Default_Set')
 
     str(default_set)  # test the string representation of the modifier
 
-    assert default_set.name == 'DefaultSet'
+    assert default_set.identifier == 'Default_Set'
     assert len(default_set.modifiers) == 18
     assert len(default_set.modifiers_unique) == 9
     assert len(default_set.modified_modifiers_unique) == 0
@@ -27,7 +27,7 @@ def test_modifierset_init():
 
 def test_modifierset_defaults():
     """Test the ModifierSet defaults."""
-    default_set = ModifierSet('Default Set')
+    default_set = ModifierSet('Default_Set')
 
     assert len(default_set.wall_set) == 2
     assert len(default_set.floor_set) == 2
@@ -64,7 +64,7 @@ def test_modifierset_defaults():
 
 def test_setting_modifier():
     """Test the setting of modifiers on the ModifierSet."""
-    default_set = ModifierSet('Thermal Mass Construction Set')
+    default_set = ModifierSet('Thermal_Mass_Construction_Set')
     opaque_material_1 = Plastic.from_single_reflectance('test_opaque', 0.5)
     opaque_material_2 = Plastic.from_single_reflectance('test_opaque', 0.45)
     opaque_material_3 = Plastic.from_single_reflectance('test_opaque', 0.55)
@@ -95,7 +95,7 @@ def test_setting_modifier():
 
 def test_setting_aperture_modifier():
     """Test the setting of aperture modifiers on the ModifierSet."""
-    default_set = ModifierSet('Tinted Window Set')
+    default_set = ModifierSet('Tinted_Window_Set')
     glass_material = Glass.from_single_transmittance('test_glass', 0.6)
     glass_material_dark = Glass.from_single_transmittance('test_glass_dark', 0.3)
 
@@ -117,14 +117,14 @@ def test_setting_aperture_modifier():
 
 def test_modifierset_equality():
     """Test the equality of ModifierSets to one another."""
-    default_set = ModifierSet('Default Set')
+    default_set = ModifierSet('Default_Set')
     new_default_set = default_set.duplicate()
 
     assert default_set is default_set
     assert new_default_set is not default_set
     assert new_default_set == default_set
 
-    new_default_set.name = 'New Construction Set'
+    new_default_set.identifier = 'New_Construction_Set'
     assert new_default_set != default_set
 
     new_default_set = default_set.duplicate()
@@ -135,7 +135,7 @@ def test_modifierset_equality():
 
 def test_modifierset_to_dict_full():
     """Test the to_dict method writing out all modifiers."""
-    default_set = ModifierSet('Default Set')
+    default_set = ModifierSet('Default_Set')
 
     modifier_dict = default_set.to_dict(none_for_defaults=False)
 
@@ -160,8 +160,8 @@ def test_modifierset_to_dict_full():
 
 def test_modifierset_dict_methods():
     """Test the to/from dict methods."""
-    insulated_set = ModifierSet('Insulated Set')
-    triple_clear = Glass.from_single_transmittance('Triple Clear Window', 0.4)
+    insulated_set = ModifierSet('Insulated_Set')
+    triple_clear = Glass.from_single_transmittance('Triple_Clear_Window', 0.4)
 
     insulated_set.aperture_set.window_modifier = triple_clear
     mod_dict = insulated_set.to_dict()

--- a/tests/primitive_test.py
+++ b/tests/primitive_test.py
@@ -6,23 +6,25 @@ from honeybee_radiance.geometry import Polygon, Sphere
 from honeybee_radiance.modifier.material import Plastic, Glass
 from .rad_string_collection import frit
 
+import pytest
 
-def test_illegal_name():
-    p = Primitive('$$%name  of material')
-    assert p.name == 'nameofmaterial'
+
+def test_illegal_identifier():
+    with pytest.raises(Exception):
+        p = Primitive('$$%name  of material')
 
 
 def test_from_string():
     """from_string uses from_dict under the hood."""
     p = Primitive.from_string(frit)
-    assert p.name == 'glass_mat'
+    assert p.identifier == 'glass_mat'
     assert len(p.values[0]) == 1
     assert p.values[0][0] == 'glass_alt_mat'
     assert p.values[1] == []
     assert p.values[2] == ['1', '1', '1']
     assert len(p.dependencies) == 1
     # check modifier
-    assert p.modifier.name == 'glass_angular_effect'
+    assert p.modifier.identifier == 'glass_angular_effect'
     assert p.modifier.type == 'brightfunc'
 
 

--- a/tests/room_extend_test.py
+++ b/tests/room_extend_test.py
@@ -20,7 +20,7 @@ import pytest
 
 def test_radiance_properties():
     """Test the existence of the Room radiance properties."""
-    room = Room.from_box('Shoe Box', 5, 10, 3, 90, Point3D(0, 0, 3))
+    room = Room.from_box('Shoe_Box', 5, 10, 3, 90, Point3D(0, 0, 3))
 
     assert hasattr(room.properties, 'radiance')
     assert isinstance(room.properties.radiance, RoomRadianceProperties)
@@ -30,7 +30,7 @@ def test_radiance_properties():
 
 def test_set_modifier_set():
     """Test the auto-assigning of Room properties."""
-    room = Room.from_box('Shoe Box', 5, 10, 3, 90, Point3D(0, 0, 3))
+    room = Room.from_box('Shoe_Box', 5, 10, 3, 90, Point3D(0, 0, 3))
     door_verts = [[1, 0, 0.1], [2, 0, 0.1], [2, 0, 3], [1, 0, 3]]
     room[3].add_door(Door.from_vertices('test_door', door_verts))
     room[1].apertures_by_ratio(0.4, 0.01)
@@ -44,7 +44,7 @@ def test_set_modifier_set():
     assert room[1].apertures[0].properties.radiance.modifier == \
         generic_modifier_set_visible_exterior.aperture_set.window_modifier
 
-    insect_screen_set = ModifierSet('Insect Screen Set')
+    insect_screen_set = ModifierSet('Insect_Screen_Set')
     insect_screen_set.aperture_set.window_modifier = \
         generic_exterior_window_insect_screen_solar
     room.properties.radiance.modifier_set = insect_screen_set
@@ -61,8 +61,8 @@ def test_set_modifier_set():
 
 def test_duplicate():
     """Test what happens to radiance properties when duplicating a Room."""
-    custom_set = ModifierSet('Custom Modifier Set')
-    room_original = Room.from_box('Shoe Box', 5, 10, 3)
+    custom_set = ModifierSet('Custom_Modifier_Set')
+    room_original = Room.from_box('Shoe_Box', 5, 10, 3)
     room_original.properties.radiance.modifier_set = generic_modifier_set_visible_exterior
 
     room_dup_1 = room_original.duplicate()
@@ -83,7 +83,7 @@ def test_duplicate():
 
     prefix ='Opt1'
     room_dup_1.add_prefix('Opt1')
-    assert room_dup_1.name.startswith('Opt1')
+    assert room_dup_1.identifier.startswith('Opt1')
 
     room_dup_2 = room_dup_1.duplicate()
 
@@ -96,8 +96,8 @@ def test_duplicate():
 
 def test_to_dict():
     """Test the Room to_dict method with radiance properties."""
-    custom_set = ModifierSet('Custom Modifier Set')
-    room = Room.from_box('Shoe Box', 5, 10, 3)
+    custom_set = ModifierSet('Custom_Modifier_Set')
+    room = Room.from_box('Shoe_Box', 5, 10, 3)
 
     rd = room.to_dict()
     assert 'properties' in rd
@@ -115,19 +115,19 @@ def test_to_dict():
 def test_from_dict():
     """Test the Room from_dict method with radiance properties."""
     custom_set = ModifierSet('CustomModifierSet')
-    room = Room.from_box('Shoe Box', 5, 10, 3)
+    room = Room.from_box('Shoe_Box', 5, 10, 3)
     room.properties.radiance.modifier_set = custom_set
 
     rd = room.to_dict()
     new_room = Room.from_dict(rd)
-    assert new_room.properties.radiance.modifier_set.name == 'CustomModifierSet'
+    assert new_room.properties.radiance.modifier_set.identifier == 'CustomModifierSet'
     assert new_room.to_dict() == rd
 
 
 def test_writer_to_rad():
     """Test the Room to_rad method."""
     room = Room.from_box('ClosedOffice', 5, 10, 3)
-    custom_set = ModifierSet('Custom Modifier Set')
+    custom_set = ModifierSet('Custom_Modifier_Set')
     concrete = Plastic.from_single_reflectance('035Concrete', 0.35)
     custom_set.wall_set.exterior_modifier = concrete
     room.properties.radiance.modifier_set = custom_set

--- a/tests/sensorgrid_test.py
+++ b/tests/sensorgrid_test.py
@@ -9,7 +9,7 @@ sensors = [Sensor((0, 0, 0), (0, 0, 1)), Sensor((0, 0, 10), (0, 0, 1))]
 
 def test_creation():
     sg = SensorGrid('sg_1', sensors)
-    assert sg.name == 'sg_1'
+    assert sg.identifier == 'sg_1'
     assert len(sg) == 2
     assert sg[0] == sensors[0]
     assert sg[1] == sensors[1]
@@ -47,7 +47,7 @@ def test_from_loc_dir():
 
 def test_from_file():
     sensor_grid = SensorGrid.from_file('./tests/assets/test_points.pts')
-    assert sensor_grid.name == 'test_points'
+    assert sensor_grid.identifier == 'test_points'
     assert sensor_grid[0].position == (0, 0, 0)
     assert sensor_grid[0].direction == (0, 0, 1)
     assert len(sensor_grid) == 3
@@ -65,7 +65,7 @@ def test_to_and_from_dict():
     sg = SensorGrid('sg', sensors)
     sg_dict = sg.to_dict()
     assert sg_dict == {
-        'name': 'sg',
+        'identifier': 'sg',
         'sensors': [
             {'x': 0, 'y': 0, 'z': 0, 'dx': 0, 'dy': 0, 'dz': 1},
             {'x': 0, 'y': 0, 'z': 10, 'dx': 0, 'dy': 0, 'dz': 1}

--- a/tests/shade_extend_test.py
+++ b/tests/shade_extend_test.py
@@ -39,9 +39,9 @@ def test_default_properties():
     out_shade = Shade.from_vertices(
         'overhang', [[0, 0, 3], [1, 0, 3], [1, 1, 3], [0, 1, 3]])
     in_shade = Shade.from_vertices(
-        'light shelf', [[0, 0, 3], [-1, 0, 3], [-1, -1, 3], [0, -1, 3]])
+        'light_shelf', [[0, 0, 3], [-1, 0, 3], [-1, -1, 3], [0, -1, 3]])
     aperture = Aperture.from_vertices(
-        'parent aperture', [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]])
+        'parent_aperture', [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]])
 
     assert out_shade.properties.radiance.modifier == generic_context
     assert in_shade.properties.radiance.modifier == generic_context
@@ -109,7 +109,7 @@ def test_to_dict():
     shdd = shade.to_dict()
     assert 'modifier' in shdd['properties']['radiance']
     assert shdd['properties']['radiance']['modifier'] is not None
-    assert shdd['properties']['radiance']['modifier']['name'] == 'Foliage'
+    assert shdd['properties']['radiance']['modifier']['identifier'] == 'Foliage'
 
 
 def test_from_dict():

--- a/tests/view_test.py
+++ b/tests/view_test.py
@@ -113,7 +113,7 @@ def test_from_string():
 
 def test_from_file():
     vw = View.from_file('./tests/assets/view.vf')
-    assert vw.name == 'view'
+    assert vw.identifier == 'view'
     assert list(vw.position) == [0, 0, 0]
     assert list(vw.direction) == [0, 0, 1]
     assert list(vw.up_vector) == [0, 1, 0]


### PR DESCRIPTION
This commit replaces the use of "name" with "identifier" to make it clear to users that this property is used to identify the object and should be unique.

Note that the tests won't pass here until we merge in [this PR in honeybee-core](https://github.com/ladybug-tools/honeybee-core/pull/67).

This PR should NOT be merged in until comparable PRs can be put together for the other 12 repos that are broken by this change.