### PR TITLE
fix(modifierset): Refactor non-abridged ModifierSet

### DIFF
--- a/honeybee_radiance/lib/data/modifiersets/default.json
+++ b/honeybee_radiance/lib/data/modifiersets/default.json
@@ -5,23 +5,23 @@
         "wall_set": {
             "interior_modifier": "generic_wall_0.50",
             "exterior_modifier": "generic_wall_0.50",
-            "type": "WallSetAbridged"
+            "type": "WallModifierSetAbridged"
         },
         "floor_set": {
             "interior_modifier": "generic_floor_0.20",
             "exterior_modifier": "generic_floor_0.20",
-            "type": "FloorSetAbridged"
+            "type": "FloorModifierSetAbridged"
         },
         "roof_ceiling_set": {
             "interior_modifier": "generic_ceiling_0.80",
             "exterior_modifier": "generic_ceiling_0.80",
-            "type": "RoofCeilingSetAbridged"
+            "type": "RoofCeilingModifierSetAbridged"
         },
         "aperture_set": {
             "interior_modifier": "generic_interior_window_vis_0.88",
             "skylight_modifier": "generic_exterior_window_vis_0.64",
             "operable_modifier": "generic_exterior_window_vis_0.64",
-            "type": "ApertureSetAbridged",
+            "type": "ApertureModifierSetAbridged",
             "window_modifier": "generic_exterior_window_vis_0.64"
         },
         "door_set": {
@@ -30,12 +30,12 @@
             "overhead_modifier": "generic_opaque_door_0.50",
             "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
             "interior_glass_modifier": "generic_interior_window_vis_0.88",
-            "type": "DoorSetAbridged"
+            "type": "DoorModifierSetAbridged"
         },
         "shade_set": {
             "interior_modifier": "generic_interior_shade_0.50",
             "exterior_modifier": "generic_exterior_shade_0.35",
-            "type": "ShadeSetAbridged"
+            "type": "ShadeModifierSetAbridged"
         },
         "air_boundary_modifier": "air_boundary"
     },
@@ -45,23 +45,23 @@
         "wall_set": {
             "interior_modifier": "generic_wall_0.50",
             "exterior_modifier": "generic_wall_0.50",
-            "type": "WallSetAbridged"
+            "type": "WallModifierSetAbridged"
         },
         "floor_set": {
             "interior_modifier": "generic_floor_0.20",
             "exterior_modifier": "generic_floor_0.20",
-            "type": "FloorSetAbridged"
+            "type": "FloorModifierSetAbridged"
         },
         "roof_ceiling_set": {
             "interior_modifier": "generic_ceiling_0.80",
             "exterior_modifier": "generic_ceiling_0.80",
-            "type": "RoofCeilingSetAbridged"
+            "type": "RoofCeilingModifierSetAbridged"
         },
         "aperture_set": {
             "interior_modifier": "generic_interior_window_sol_0.77",
             "skylight_modifier": "generic_exterior_window_sol_0.37",
             "operable_modifier": "generic_exterior_window_sol_0.37",
-            "type": "ApertureSetAbridged",
+            "type": "ApertureModifierSetAbridged",
             "window_modifier": "generic_exterior_window_sol_0.37"
         },
         "door_set": {
@@ -70,12 +70,12 @@
             "overhead_modifier": "generic_opaque_door_0.50",
             "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
             "interior_glass_modifier": "generic_interior_window_vis_0.88",
-            "type": "DoorSetAbridged"
+            "type": "DoorModifierSetAbridged"
         },
         "shade_set": {
             "interior_modifier": "generic_interior_shade_0.50",
             "exterior_modifier": "generic_exterior_shade_0.35",
-            "type": "ShadeSetAbridged"
+            "type": "ShadeModifierSetAbridged"
         },
         "air_boundary_modifier": "air_boundary"
     },
@@ -85,23 +85,23 @@
         "wall_set": {
             "interior_modifier": "generic_wall_0.50",
             "exterior_modifier": "generic_wall_exterior_side_0.35",
-            "type": "WallSetAbridged"
+            "type": "WallModifierSetAbridged"
         },
         "floor_set": {
             "interior_modifier": "generic_floor_0.20",
             "exterior_modifier": "generic_floor_exterior_side_0.50",
-            "type": "FloorSetAbridged"
+            "type": "FloorModifierSetAbridged"
         },
         "roof_ceiling_set": {
             "interior_modifier": "generic_ceiling_0.80",
             "exterior_modifier": "generic_ceiling_exterior_side_0.35",
-            "type": "RoofCeilingSetAbridged"
+            "type": "RoofCeilingModifierSetAbridged"
         },
         "aperture_set": {
             "interior_modifier": "generic_interior_window_vis_0.88",
             "skylight_modifier": "generic_exterior_window_vis_0.64",
             "operable_modifier": "generic_exterior_window_vis_0.64",
-            "type": "ApertureSetAbridged",
+            "type": "ApertureModifierSetAbridged",
             "window_modifier": "generic_exterior_window_vis_0.64"
         },
         "door_set": {
@@ -110,12 +110,12 @@
             "overhead_modifier": "generic_opaque_door_0.50",
             "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
             "interior_glass_modifier": "generic_interior_window_vis_0.88",
-            "type": "DoorSetAbridged"
+            "type": "DoorModifierSetAbridged"
         },
         "shade_set": {
             "interior_modifier": "generic_interior_shade_0.50",
             "exterior_modifier": "generic_exterior_shade_0.35",
-            "type": "ShadeSetAbridged"
+            "type": "ShadeModifierSetAbridged"
         },
         "air_boundary_modifier": "air_boundary"
     },
@@ -125,23 +125,23 @@
         "wall_set": {
             "interior_modifier": "generic_wall_0.50",
             "exterior_modifier": "generic_wall_exterior_side_0.35",
-            "type": "WallSetAbridged"
+            "type": "WallModifierSetAbridged"
         },
         "floor_set": {
             "interior_modifier": "generic_floor_0.20",
             "exterior_modifier": "generic_floor_exterior_side_0.50",
-            "type": "FloorSetAbridged"
+            "type": "FloorModifierSetAbridged"
         },
         "roof_ceiling_set": {
             "interior_modifier": "generic_ceiling_0.80",
             "exterior_modifier": "generic_ceiling_exterior_side_0.35",
-            "type": "RoofCeilingSetAbridged"
+            "type": "RoofCeilingModifierSetAbridged"
         },
         "aperture_set": {
             "interior_modifier": "generic_interior_window_sol_0.77",
             "skylight_modifier": "generic_exterior_window_sol_0.37",
             "operable_modifier": "generic_exterior_window_sol_0.37",
-            "type": "ApertureSetAbridged",
+            "type": "ApertureModifierSetAbridged",
             "window_modifier": "generic_exterior_window_sol_0.37"
         },
         "door_set": {
@@ -150,12 +150,12 @@
             "overhead_modifier": "generic_opaque_door_0.50",
             "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
             "interior_glass_modifier": "generic_interior_window_vis_0.88",
-            "type": "DoorSetAbridged"
+            "type": "DoorModifierSetAbridged"
         },
         "shade_set": {
             "interior_modifier": "generic_interior_shade_0.50",
             "exterior_modifier": "generic_exterior_shade_0.35",
-            "type": "ShadeSetAbridged"
+            "type": "ShadeModifierSetAbridged"
         },
         "air_boundary_modifier": "air_boundary"
     }

--- a/honeybee_radiance/modifierset.py
+++ b/honeybee_radiance/modifierset.py
@@ -13,32 +13,32 @@ from honeybee.typing import valid_rad_string
 
 _default_modifiers = {
     '_BaseSet': {'exterior': None, 'interior': None},
-    'WallSet': {
+    'WallModifierSet': {
         'exterior': generic_wall,
         'interior': generic_wall
     },
-    'FloorSet': {
+    'FloorModifierSet': {
         'exterior': generic_floor,
         'interior': generic_floor
     },
-    'RoofCeilingSet': {
+    'RoofCeilingModifierSet': {
         'exterior': generic_ceiling,
         'interior': generic_ceiling
     },
-    'ApertureSet': {
+    'ApertureModifierSet': {
         'exterior': generic_exterior_window,
         'interior': generic_interior_window,
         'operable': generic_exterior_window,
         'skylight': generic_exterior_window
     },
-    'DoorSet': {
+    'DoorModifierSet': {
         'exterior': generic_door,
         'interior': generic_door,
         'exterior_glass': generic_exterior_window,
         'interior_glass': generic_interior_window,
         'overhead': generic_door
     },
-    'ShadeSet': {
+    'ShadeModifierSet': {
         'exterior': generic_exterior_shade,
         'interior': generic_interior_shade
     }
@@ -56,18 +56,18 @@ class ModifierSet(object):
         identifier: Text string for a unique ModifierSet ID. Must not contain
             spaces or special characters. This will be used to identify the
             object across a model and in the exported Radiance files.
-        wall_set: An optional WallSet object for this ModifierSet.
-            If None, it will be the honeybee generic default WallSet.
-        floor_set: An optional FloorSet object for this ModifierSet.
-            If None, it will be the honeybee generic default FloorSet.
-        roof_ceiling_set: An optional RoofCeilingSet object for this ModifierSet.
-            If None, it will be the honeybee generic default RoofCeilingSet.
-        aperture_set: An optional ApertureSet object for this ModifierSet.
-            If None, it will be the honeybee generic default ApertureSet.
-        door_set: An optional DoorSet object for this ModifierSet.
-            If None, it will be the honeybee generic default DoorSet.
-        shade_set: An optional ShadeSet object for this ModifierSet.
-            If None, it will be the honeybee generic default ShadeSet.
+        wall_set: An optional WallModifierSet object for this ModifierSet.
+            If None, it will be the honeybee generic default WallModifierSet.
+        floor_set: An optional FloorModifierSet object for this ModifierSet.
+            If None, it will be the honeybee generic default FloorModifierSet.
+        roof_ceiling_set: An optional RoofCeilingModifierSet object for this ModifierSet.
+            If None, it will be the honeybee generic default RoofCeilingModifierSet.
+        aperture_set: An optional ApertureModifierSet object for this ModifierSet.
+            If None, it will be the honeybee generic default ApertureModifierSet.
+        door_set: An optional DoorModifierSet object for this ModifierSet.
+            If None, it will be the honeybee generic default DoorModifierSet.
+        shade_set: An optional ShadeModifierSet object for this ModifierSet.
+            If None, it will be the honeybee generic default ShadeModifierSet.
         air_boundary_modifier: An optional Modifier to be used for all Faces with
             an AirBoundary face type. If None, it will be the honyebee generic
             air wall modifier.
@@ -135,91 +135,92 @@ class ModifierSet(object):
 
     @property
     def wall_set(self):
-        """Get or set the WallSet assigned to this ModifierSet."""
+        """Get or set the WallModifierSet assigned to this ModifierSet."""
         return self._wall_set
 
     @wall_set.setter
     def wall_set(self, value):
         if value is not None:
-            assert isinstance(value, WallSet), \
-                'Expected WallSet. Got {}'.format(type(value))
+            assert isinstance(value, WallModifierSet), \
+                'Expected WallModifierSet. Got {}'.format(type(value))
             self._wall_set = value
         else:
-            self._wall_set = WallSet()
+            self._wall_set = WallModifierSet()
 
     @property
     def floor_set(self):
-        """Get or set the FloorSet assigned to this ModifierSet."""
+        """Get or set the FloorModifierSet assigned to this ModifierSet."""
         return self._floor_set
 
     @floor_set.setter
     def floor_set(self, value):
         if value is not None:
-            assert isinstance(value, FloorSet), \
-                'Expected FloorSet. Got {}'.format(type(value))
+            assert isinstance(value, FloorModifierSet), \
+                'Expected FloorModifierSet. Got {}'.format(type(value))
             self._floor_set = value
         else:
-            self._floor_set = FloorSet()
+            self._floor_set = FloorModifierSet()
 
     @property
     def roof_ceiling_set(self):
-        """Get or set the RoofCeilingSet assigned to this ModifierSet."""
+        """Get or set the RoofCeilingModifierSet assigned to this ModifierSet."""
         return self._roof_ceiling_set
 
     @roof_ceiling_set.setter
     def roof_ceiling_set(self, value):
         if value is not None:
-            assert isinstance(value, RoofCeilingSet), \
-                'Expected RoofCeilingSet. Got {}'.format(type(value))
+            assert isinstance(value, RoofCeilingModifierSet), \
+                'Expected RoofCeilingModifierSet. Got {}'.format(type(value))
             self._roof_ceiling_set = value
         else:
-            self._roof_ceiling_set = RoofCeilingSet()
+            self._roof_ceiling_set = RoofCeilingModifierSet()
 
     @property
     def aperture_set(self):
-        """Get or set the ApertureSet assigned to this ModifierSet."""
+        """Get or set the ApertureModifierSet assigned to this ModifierSet."""
         return self._aperture_set
 
     @aperture_set.setter
     def aperture_set(self, value):
         if value is not None:
-            assert isinstance(value, ApertureSet), \
-                'Expected ApertureSet. Got {}'.format(type(value))
+            assert isinstance(value, ApertureModifierSet), \
+                'Expected ApertureModifierSet. Got {}'.format(type(value))
             self._aperture_set = value
         else:
-            self._aperture_set = ApertureSet()
+            self._aperture_set = ApertureModifierSet()
 
     @property
     def door_set(self):
-        """Get or set the DoorSet assigned to this ModifierSet."""
+        """Get or set the DoorModifierSet assigned to this ModifierSet."""
         return self._door_set
 
     @door_set.setter
     def door_set(self, value):
         if value is not None:
-            assert isinstance(value, DoorSet), \
-                'Expected DoorSet. Got {}'.format(type(value))
+            assert isinstance(value, DoorModifierSet), \
+                'Expected DoorModifierSet. Got {}'.format(type(value))
             self._door_set = value
         else:
-            self._door_set = DoorSet()
+            self._door_set = DoorModifierSet()
 
     @property
     def shade_set(self):
-        """Get or set the ShadeSet assigned to this ModifierSet."""
+        """Get or set the ShadeModifierSet assigned to this ModifierSet."""
         return self._shade_set
 
     @shade_set.setter
     def shade_set(self, value):
         if value is not None:
-            assert isinstance(value, ShadeSet), \
-                'Expected ShadeSet. Got {}'.format(type(value))
+            assert isinstance(value, ShadeModifierSet), \
+                'Expected ShadeModifierSet. Got {}'.format(type(value))
             self._shade_set = value
         else:
-            self._shade_set = ShadeSet()
+            self._shade_set = ShadeModifierSet()
 
     @property
     def air_boundary_modifier(self):
-        """Get or set a Modifier to be used for all Faces with an AirBoundary face type."""
+        """Get or set a Modifier to be used for all Faces with an AirBoundary face type.
+        """
         if self._air_boundary_modifier is None:
             return air_boundary
         return self._air_boundary_modifier
@@ -369,30 +370,38 @@ class ModifierSet(object):
             'type': 'ModifierSet',
             'identifier': str,  # ModifierSet identifier
             "display_name": str,  # ModifierSet display name
-            'wall_set': {},  # WallSet dictionary
+            'wall_set': {},  # WallModifierSet dictionary
             'floor_set': {},  # FloorlSet dictionary
-            'roof_ceiling_set': {},  # RoofCeilingSet dictionary
-            'aperture_set': {},  # ApertureSet dictionary
-            'door_set': {},  # DoorSet dictionary
-            'shade_set': {},  # ShadeSet dictionary
-            'air_boundary_modifier': {},  # AirBoundarySet dictionary
-            'modifiers': []  # A list of Honeybee Radiance Modifier dictionaries
+            'roof_ceiling_set': {},  # RoofCeilingModifierSet dictionary
+            'aperture_set': {},  # ApertureModifierSet dictionary
+            'door_set': {},  # DoorModifierSet dictionary
+            'shade_set': {},  # ShadeModifierSet dictionary
+            'air_boundary_modifier': {},  # AirBoundary dictionary
             }
         """
         assert data['type'] == 'ModifierSet', \
             'Expected ModifierSet. Got {}.'.format(data['type'])
 
-        # gather all modifier objects
-        modifiers = {}
-        for mod in data['modifiers']:
-            modifiers[mod['identifier']] = dict_to_modifier(mod)
-
-        # build each of the sub-sets
-        wall_set, floor_set, roof_ceiling_set, aperture_set, door_set, shade_set, \
-            air_boundary_mod = cls._get_subsets_from_abridged(data, modifiers)
+        # build each of the sub-construction sets
+        wall_set = WallModifierSet.from_dict(data['wall_set']) if 'wall_set' \
+            in data and data['wall_set'] is not None else None
+        floor_set = FloorModifierSet.from_dict(data['floor_set']) if 'floor_set' \
+            in data and data['floor_set'] is not None else None
+        roof_ceiling_set = RoofCeilingModifierSet.from_dict(data['roof_ceiling_set']) \
+            if 'roof_ceiling_set' in data and \
+            data['roof_ceiling_set'] is not None else None
+        aperture_set = ApertureModifierSet.from_dict(data['aperture_set']) if \
+            'aperture_set' in data and data['aperture_set'] is not None else None
+        door_set = DoorModifierSet.from_dict(data['door_set']) if \
+            'door_set' in data and data['door_set'] is not None else None
+        shade_set = ShadeModifierSet.from_dict(data['shade_set']) if \
+            'shade_set' in data and data['shade_set'] is not None else None
+        air_mod = dict_to_modifier(data['air_boundary_modifier']) \
+            if 'air_boundary_modifier' in data and \
+            data['air_boundary_modifier'] is not None else None
 
         new_obj = cls(data['identifier'], wall_set, floor_set, roof_ceiling_set,
-                      aperture_set, door_set, shade_set, air_boundary_mod)
+                      aperture_set, door_set, shade_set, air_mod)
         if 'display_name' in data and data['display_name'] is not None:
             new_obj.display_name = data['display_name']
         return new_obj
@@ -413,13 +422,13 @@ class ModifierSet(object):
             'type': 'ModifierSetAbridged',
             'identifier': str,  # ModifierSet identifier
             "display_name": str,  # ModifierSet display name
-            'wall_set': {},  # WallSet dictionary
-            'floor_set': {},  # FloorlSet dictionary
-            'roof_ceiling_set': {},  # RoofCeilingSet dictionary
-            'aperture_set': {},  # ApertureSet dictionary
-            'door_set': {},  # DoorSet dictionary
-            'shade_set': {},  # ShadeSet dictionary
-            'air_boundary_modifier': {},  # AirBoundarySet dictionary
+            'wall_set': {},  # WallModifierSetAbridged dictionary
+            'floor_set': {},  # FloorlSetAbridged dictionary
+            'roof_ceiling_set': {},  # RoofCeilingModifierSetAbridged dictionary
+            'aperture_set': {},  # ApertureModifierSetAbridged dictionary
+            'door_set': {},  # DoorModifierSetAbridged dictionary
+            'shade_set': {},  # ShadeModifierSetAbridged dictionary
+            'air_boundary_modifier': {},  # AirBoundary dictionary
             }
         """
         assert data['type'] == 'ModifierSetAbridged', \
@@ -436,9 +445,9 @@ class ModifierSet(object):
         """Get ModifierSet as a dictionary.
 
         Args:
-            abridged: Boolean noting whether detailed materials and modifier
-                objects should be written into the ModifierSet (False) or just
-                an abridged version (True). Default: False.
+            abridged: Boolean noting whether detailed modifier objects should be
+                written into the ModifierSet (False) or just an abridged
+                version (True). Default: False.
             none_for_defaults: Boolean to note whether default modifiers in the
                 set should be included in detail (False) or should be None (True).
                 Default: True.
@@ -447,22 +456,23 @@ class ModifierSet(object):
             else {'type': 'ModifierSetAbridged'}
 
         base['identifier'] = self.identifier
-        base['wall_set'] = self.wall_set._to_dict(none_for_defaults)
-        base['floor_set'] = self.floor_set._to_dict(none_for_defaults)
-        base['roof_ceiling_set'] = self.roof_ceiling_set._to_dict(none_for_defaults)
-        base['aperture_set'] = self.aperture_set._to_dict(none_for_defaults)
-        base['door_set'] = self.door_set._to_dict(none_for_defaults)
-        base['shade_set'] = self.shade_set._to_dict(none_for_defaults)
+        base['wall_set'] = self.wall_set.to_dict(abridged, none_for_defaults)
+        base['floor_set'] = self.floor_set.to_dict(abridged, none_for_defaults)
+        base['roof_ceiling_set'] = \
+            self.roof_ceiling_set.to_dict(abridged, none_for_defaults)
+        base['aperture_set'] = self.aperture_set.to_dict(abridged, none_for_defaults)
+        base['door_set'] = self.door_set.to_dict(abridged, none_for_defaults)
+        base['shade_set'] = self.shade_set.to_dict(abridged, none_for_defaults)
         if none_for_defaults:
-            base['air_boundary_modifier'] = self._air_boundary_modifier.identifier if \
-                self._air_boundary_modifier is not None else None
+            if abridged:
+                base['air_boundary_modifier'] = self._air_boundary_modifier.identifier \
+                    if self._air_boundary_modifier is not None else None
+            else:
+                base['air_boundary_modifier'] = self._air_boundary_modifier.to_dict() \
+                    if self._air_boundary_modifier is not None else None
         else:
-            base['air_boundary_modifier'] = self.air_boundary_modifier.identifier
-
-        if not abridged:
-            modifiers = self.modified_modifiers_unique if none_for_defaults \
-                else self.modifiers_unique
-            base['modifiers'] = [modifier.to_dict() for modifier in modifiers]
+            base['air_boundary_modifier'] = self.air_boundary_modifier.identifier \
+                if abridged else self.air_boundary_modifier.to_dict()
 
         if self._display_name is not None:
             base['display_name'] = self.display_name
@@ -473,7 +483,7 @@ class ModifierSet(object):
         return self.__copy__()
 
     def lock(self):
-        """The lock() method to will also lock the WallSet, FloorSet, etc."""
+        """The lock() method to will also lock the WallModifierSet, etc."""
         self._locked = True
         self._wall_set.lock()
         self._floor_set.lock()
@@ -483,7 +493,7 @@ class ModifierSet(object):
         self._shade_set.lock()
 
     def unlock(self):
-        """The unlock() method will also unlock the WallSet, FloorSet, etc."""
+        """The unlock() method will also unlock the WallModifierSet, etc."""
         self._locked = False
         self._wall_set.unlock()
         self._floor_set.unlock()
@@ -503,16 +513,16 @@ class ModifierSet(object):
     def _get_subsets_from_abridged(data, modifiers):
         """Get subset objects from and abirdged dictionary."""
         wall_set = ModifierSet._make_modifier_subset(
-            data, WallSet(), 'wall_set', modifiers)
+            data, WallModifierSet(), 'wall_set', modifiers)
         floor_set = ModifierSet._make_modifier_subset(
-            data, FloorSet(), 'floor_set', modifiers)
+            data, FloorModifierSet(), 'floor_set', modifiers)
         roof_ceiling_set = ModifierSet._make_modifier_subset(
-            data, RoofCeilingSet(), 'roof_ceiling_set', modifiers)
+            data, RoofCeilingModifierSet(), 'roof_ceiling_set', modifiers)
         shade_set = ModifierSet._make_modifier_subset(
-            data, ShadeSet(), 'shade_set', modifiers)
+            data, ShadeModifierSet(), 'shade_set', modifiers)
         aperture_set = ModifierSet._make_aperture_subset(
-            data, ApertureSet(), modifiers)
-        door_set = ModifierSet._make_door_subset(data, DoorSet(), modifiers)
+            data, ApertureModifierSet(), modifiers)
+        door_set = ModifierSet._make_door_subset(data, DoorModifierSet(), modifiers)
         if 'air_boundary_modifier' in data and data['air_boundary_modifier'] is not None:
             air_boundary_mod = modifiers[data['air_boundary_modifier']]
         else:
@@ -523,7 +533,7 @@ class ModifierSet(object):
 
     @staticmethod
     def _make_modifier_subset(data, sub_set, sub_set_name, modifiers):
-        """Make a WallSet, FloorSet, RoofCeilingSet, or ShadeSet from dictionary."""
+        """Make a wall set, floor set, roof ceiling set, or shade set from dictionary."""
         if sub_set_name in data:
             if 'exterior_modifier' in data[sub_set_name] and \
                     data[sub_set_name]['exterior_modifier'] is not None:
@@ -537,7 +547,7 @@ class ModifierSet(object):
 
     @staticmethod
     def _make_aperture_subset(data, sub_set, modifiers):
-        """Make an ApertureSet from a dictionary."""
+        """Make an ApertureModifierSet from a dictionary."""
         if 'aperture_set' in data:
             if 'window_modifier' in data['aperture_set'] and \
                     data['aperture_set']['window_modifier'] is not None:
@@ -559,7 +569,7 @@ class ModifierSet(object):
 
     @staticmethod
     def _make_door_subset(data, sub_set, modifiers):
-        """Make a DoorSet from dictionary."""
+        """Make a DoorModifierSet from dictionary."""
         if 'door_set' in data:
             if 'exterior_modifier' in data['door_set'] and \
                     data['door_set']['exterior_modifier'] is not None:
@@ -620,7 +630,10 @@ class ModifierSet(object):
 
 @lockable
 class _BaseSet(object):
-    """Base class for the sets assigned to Faces (WallSet, FloorSet, RoofCeilingSet).
+    """Base class for the sets assigned to Faces.
+    
+    This includes WallModifierSet, FloorModifierSet, RoofCeilingModifierSet and
+    ShadeModifierSet.
 
     Args:
         exterior_modifier: A radiance modifier object for faces with an
@@ -679,28 +692,57 @@ class _BaseSet(object):
         """Boolean noting whether any modifiers are modified from the default."""
         return len(self.modified_modifiers) != 0
 
-    def _to_dict(self, none_for_defaults=True):
+    @classmethod
+    def from_dict(cls, data):
+        """Create a SubSet from a dictionary.
+
+        Note that the dictionary must be a non-abridged version for this
+        classmethod to work.
+
+        Args:
+            data: Dictionary describing the Set of the object.
+        """
+        assert data['type'] == cls.__name__, \
+            'Expected {}. Got {}.'.format(cls.__name__, data['type'])
+        extc = dict_to_modifier(data['exterior_modifier']) \
+            if 'exterior_modifier' in data and data['exterior_modifier'] \
+            is not None else None
+        intc = dict_to_modifier(data['interior_modifier']) \
+            if 'interior_modifier' in data and data['interior_modifier'] \
+            is not None else None
+        return cls(extc, intc)
+
+    def to_dict(self, abridged=False, none_for_defaults=True):
         """Get the ModifierSet as a dictionary.
 
         Args:
+            abridged: Boolean noting whether detailed modifiers objects should
+                be written into the ModifierSet (False) or just an abridged
+                version (True). Default: False.
             none_for_defaults: Boolean to note whether default modifiers in the
                 set should be included in detail (False) or should be None (True).
                 Default: True.
         """
         attributes = self._slots
         if none_for_defaults:
-            base = {
-                attr[1:]:getattr(self, attr[1:]).identifier
-                if getattr(self, attr) is not None else None
-                for attr in attributes
-                }
+            if abridged:
+                base = {attr[1:]:getattr(self, attr[1:]).identifier
+                        if getattr(self, attr) is not None else None
+                        for attr in attributes}
+            else:
+                base = {attr[1:]:getattr(self, attr[1:]).to_dict()
+                        if getattr(self, attr) is not None else None
+                        for attr in attributes}
         else:
-            base = {
-                attr[1:]:getattr(self, attr[1:]).identifier
-                for attr in attributes
-            }
+            if abridged:
+                base = {attr[1:]:getattr(self, attr[1:]).identifier
+                        for attr in attributes}
+            else:
+                base = {attr[1:]:getattr(self, attr[1:]).to_dict()
+                        for attr in attributes}
 
-        base['type'] = self.__class__.__name__ + 'Abridged'
+        base['type'] = self.__class__.__name__ + 'Abridged' if abridged else \
+            self.__class__.__name__
         return base
 
     def duplicate(self):
@@ -748,7 +790,7 @@ class _BaseSet(object):
 
 
 @lockable
-class WallSet(_BaseSet):
+class WallModifierSet(_BaseSet):
     """Set containing all radiance modifiers needed to for an radiance model's Walls.
 
     Properties:
@@ -762,7 +804,7 @@ class WallSet(_BaseSet):
 
 
 @lockable
-class FloorSet(_BaseSet):
+class FloorModifierSet(_BaseSet):
     """Set containing all radiance modifiers needed to for an radiance model's floors.
 
     Properties:
@@ -776,7 +818,7 @@ class FloorSet(_BaseSet):
 
 
 @lockable
-class RoofCeilingSet(_BaseSet):
+class RoofCeilingModifierSet(_BaseSet):
     """Set containing all radiance modifiers needed to for an radiance model's roofs.
 
     Properties:
@@ -790,7 +832,7 @@ class RoofCeilingSet(_BaseSet):
 
 
 @lockable
-class ShadeSet(_BaseSet):
+class ShadeModifierSet(_BaseSet):
     """Set containing all radiance modifiers needed to for an radiance model's Shade.
 
     Properties:
@@ -804,7 +846,7 @@ class ShadeSet(_BaseSet):
 
 
 @lockable
-class ApertureSet(_BaseSet):
+class ApertureModifierSet(_BaseSet):
     """Set containing all radiance modifiers needed to for a radiance model's Apertures.
 
     Args:
@@ -848,17 +890,6 @@ class ApertureSet(_BaseSet):
         self._exterior_modifier = self._validate_modifier(value)
 
     @property
-    def operable_modifier(self):
-        """Get or set the modifier for operable apertures."""
-        if self._operable_modifier is None:
-            return _default_modifiers[self.__class__.__name__]['operable']
-        return self._operable_modifier
-
-    @operable_modifier.setter
-    def operable_modifier(self, value):
-        self._operable_modifier = self._validate_modifier(value)
-
-    @property
     def skylight_modifier(self):
         """Get or set the modifier for apertures in roofs."""
         if self._skylight_modifier is None:
@@ -869,15 +900,55 @@ class ApertureSet(_BaseSet):
     def skylight_modifier(self, value):
         self._skylight_modifier = self._validate_modifier(value)
 
-    def _to_dict(self, none_for_defaults=True):
+    @property
+    def operable_modifier(self):
+        """Get or set the modifier for operable apertures."""
+        if self._operable_modifier is None:
+            return _default_modifiers[self.__class__.__name__]['operable']
+        return self._operable_modifier
+
+    @operable_modifier.setter
+    def operable_modifier(self, value):
+        self._operable_modifier = self._validate_modifier(value)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a ApertureModifierSet from a dictionary.
+
+        Note that the dictionary must be a non-abridged version for this
+        classmethod to work.
+
+        Args:
+            data: Dictionary describing the ApertureModifierSet.
+        """
+        assert data['type'] == cls.__name__, \
+            'Expected {}. Got {}.'.format(cls.__name__, data['type'])
+        extc = dict_to_modifier(data['window_modifier']) \
+            if 'window_modifier' in data and data['window_modifier'] \
+            is not None else None
+        intc = dict_to_modifier(data['interior_modifier']) \
+            if 'interior_modifier' in data and data['interior_modifier'] \
+            is not None else None
+        skyc = dict_to_modifier(data['skylight_modifier']) \
+            if 'skylight_modifier' in data and data['skylight_modifier'] \
+            is not None else None
+        opc = dict_to_modifier(data['operable_modifier']) \
+            if 'operable_modifier' in data and data['operable_modifier'] \
+            is not None else None
+        return cls(extc, intc, skyc, opc)
+
+    def to_dict(self, abridged=False, none_for_defaults=True):
         """Get the ModifierSet as a dictionary.
 
         Args:
+            abridged: Boolean noting whether detailed modifier objects should
+                be written into the ModifierSet (False) or just an abridged
+                version (True). Default: False.
             none_for_defaults: Boolean to note whether default modifiers in the
                 set should be included in detail (False) or should be None (True).
                 Default: True.
         """
-        base = _BaseSet._to_dict(self, none_for_defaults)
+        base = _BaseSet.to_dict(self, abridged, none_for_defaults)
         if 'exterior_modifier' in base:
             base['window_modifier'] = base['exterior_modifier']
             del base['exterior_modifier']
@@ -905,7 +976,7 @@ class ApertureSet(_BaseSet):
 
 
 @lockable
-class DoorSet(_BaseSet):
+class DoorModifierSet(_BaseSet):
     """Set containing all radiance modifiers needed to for an radiance model's Doors.
 
     Args:
@@ -973,6 +1044,35 @@ class DoorSet(_BaseSet):
     @overhead_modifier.setter
     def overhead_modifier(self, value):
         self._overhead_modifier = self._validate_modifier(value)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a ApertureModifierSet from a dictionary.
+
+        Note that the dictionary must be a non-abridged version for this
+        classmethod to work.
+
+        Args:
+            data: Dictionary describing the ApertureModifierSet.
+        """
+        assert data['type'] == cls.__name__, \
+            'Expected {}. Got {}.'.format(cls.__name__, data['type'])
+        extc = dict_to_modifier(data['exterior_modifier']) \
+            if 'exterior_modifier' in data and data['exterior_modifier'] \
+            is not None else None
+        intc = dict_to_modifier(data['interior_modifier']) \
+            if 'interior_modifier' in data and data['interior_modifier'] \
+            is not None else None
+        egc = dict_to_modifier(data['exterior_glass_modifier']) \
+            if 'exterior_glass_modifier' in data and data['exterior_glass_modifier'] \
+            is not None else None
+        igc = dict_to_modifier(data['interior_glass_modifier']) \
+            if 'interior_glass_modifier' in data and data['interior_glass_modifier'] \
+            is not None else None
+        ohc = dict_to_modifier(data['overhead_modifier']) \
+            if 'overhead_modifier' in data and data['overhead_modifier'] \
+            is not None else None
+        return cls(extc, intc, egc, igc, ohc)
 
     def __len__(self):
         return 3

--- a/tests/modifier_set_test.py
+++ b/tests/modifier_set_test.py
@@ -1,5 +1,5 @@
-from honeybee_radiance.modifierset import ModifierSet, WallSet, FloorSet, \
-    RoofCeilingSet, ApertureSet, DoorSet, ShadeSet
+from honeybee_radiance.modifierset import ModifierSet, WallModifierSet, FloorModifierSet, \
+    RoofCeilingModifierSet, ApertureModifierSet, DoorModifierSet, ShadeModifierSet
 from honeybee_radiance.modifier import Modifier
 from honeybee_radiance.modifier.material import Plastic, Glass
 
@@ -17,12 +17,12 @@ def test_modifierset_init():
     assert len(default_set.modifiers_unique) == 9
     assert len(default_set.modified_modifiers_unique) == 0
 
-    assert isinstance(default_set.wall_set, WallSet)
-    assert isinstance(default_set.floor_set, FloorSet)
-    assert isinstance(default_set.roof_ceiling_set, RoofCeilingSet)
-    assert isinstance(default_set.aperture_set, ApertureSet)
-    assert isinstance(default_set.door_set, DoorSet)
-    assert isinstance(default_set.shade_set, ShadeSet)
+    assert isinstance(default_set.wall_set, WallModifierSet)
+    assert isinstance(default_set.floor_set, FloorModifierSet)
+    assert isinstance(default_set.roof_ceiling_set, RoofCeilingModifierSet)
+    assert isinstance(default_set.aperture_set, ApertureModifierSet)
+    assert isinstance(default_set.door_set, DoorModifierSet)
+    assert isinstance(default_set.shade_set, ShadeModifierSet)
 
 
 def test_modifierset_defaults():


### PR DESCRIPTION
This commit refactors the non-abridged ModifierSet so that it is easier to deconstruct and edit.

It also changes the class names of the subset objects (eg. WallSet) to be specific for radiance (eg. WallModifierSet) so that there is no collision with the schemas of honeybee-energy.