### PR TITLE
feat(model): Add method for Model.to.rad_folder

### DIFF
--- a/honeybee_radiance/_extend_honeybee.py
+++ b/honeybee_radiance/_extend_honeybee.py
@@ -14,8 +14,8 @@ from .properties.face import FaceRadianceProperties
 from .properties.shade import ShadeRadianceProperties
 from .properties.aperture import ApertureRadianceProperties
 from .properties.door import DoorRadianceProperties
-from .writer import model_to_rad, room_to_rad, face_to_rad, shade_to_rad, \
-    aperture_to_rad, door_to_rad
+from .writer import model_to_rad_folder, model_to_rad, room_to_rad, face_to_rad, \
+    shade_to_rad, aperture_to_rad, door_to_rad
 
 
 # set a hidden radiance attribute on each core geometry Property class to None
@@ -73,6 +73,7 @@ ApertureProperties.radiance = property(aperture_radiance_properties)
 DoorProperties.radiance = property(door_radiance_properties)
 
 # add energy writer to rad
+model_writer.rad_folder = model_to_rad_folder
 model_writer.rad = model_to_rad
 room_writer.rad = room_to_rad
 face_writer.rad = face_to_rad

--- a/honeybee_radiance/geometry/bubble.py
+++ b/honeybee_radiance/geometry/bubble.py
@@ -23,7 +23,7 @@ class Bubble(Sphere):
             a model and in the exported Radiance files.
         center_pt: Sphere center point as (x, y, z) (Default: (0, 0 ,0)).
         radius: Bubble radius as a number (Default: 10).
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])

--- a/honeybee_radiance/geometry/cone.py
+++ b/honeybee_radiance/geometry/cone.py
@@ -31,7 +31,7 @@ class Cone(Geometry):
         radius_start: Cone start radius as a number (Default: 10).
         center_pt_end: Cone end center point as (x, y, z) (Default: (0, 0 ,10)).
         radius_end: Cone end radius as a number (Default: 0).
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -117,7 +117,7 @@ class Cone(Geometry):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "cone",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -161,7 +161,7 @@ class Cone(Geometry):
 
             {
             "type": "cone",  # Geometry type
-            "modifier": {} or "void",
+            "modifier": {} ,
             "identifier": "",  # Geometry identifer
             "display_name": "",  # Geometry display name
             "center_pt_start": (0, 0, 0),

--- a/honeybee_radiance/geometry/cup.py
+++ b/honeybee_radiance/geometry/cup.py
@@ -32,7 +32,7 @@ class Cup(Cone):
         radius_start: Cup start radius as a number (Default: 10).
         center_pt_end: Cup end center point as (x, y, z) (Default: (0, 0 ,10)).
         radius_end: Cup end radius as a number (Default: 0).
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])

--- a/honeybee_radiance/geometry/cylinder.py
+++ b/honeybee_radiance/geometry/cylinder.py
@@ -29,7 +29,7 @@ class Cylinder(Geometry):
             (Default: (0, 0 ,0)).
         center_pt_end: Cylinder end center point as (x, y, z) (Default: (0, 0 ,10)).
         radius: Cylinder start radius as a number (Default: 10).
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -103,7 +103,7 @@ class Cylinder(Geometry):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "cylinder",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -146,7 +146,7 @@ class Cylinder(Geometry):
 
             {
             "type": "cylinder",  # Geometry type
-            "modifier": {} or "void",
+            "modifier": {} ,
             "identifier": "",  # Geometry identifer
             "display_name": "",  # Geometry display name
             "center_pt_start": (0, 0, 0),

--- a/honeybee_radiance/geometry/polygon.py
+++ b/honeybee_radiance/geometry/polygon.py
@@ -32,7 +32,7 @@ class Polygon(Geometry):
             vertices that make up the polygon. Vertices musct be ordered
             counter-clockwise as viewed from the front side. The last vertex is
             assumed to be connected to the first.
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -86,7 +86,7 @@ class Polygon(Geometry):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "polygon",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -130,7 +130,7 @@ class Polygon(Geometry):
 
             {
             "type": "polygon",  # Geometry type
-            "modifier": {} or "void",
+            "modifier": {} ,
             "identifier": "",  # Geometry identifer
             "display_name": "",  # Geometry display name
             "vertices": [(0, 0, 10), (10, 0, 10), (10, 0, 0)],

--- a/honeybee_radiance/geometry/ring.py
+++ b/honeybee_radiance/geometry/ring.py
@@ -30,7 +30,7 @@ class Ring(Geometry):
         normal_vector: Surface normal as (x, y, z) (Default: (0, 0 ,1)).
         radius_inner: Ring inner radius as a number (Default: 5).
         radius_outer: Ring outer radius as a number (Default: 10).
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -116,7 +116,7 @@ class Ring(Geometry):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default is "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "ring",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -160,7 +160,7 @@ class Ring(Geometry):
 
             {
             "type": "ring",  # Geometry type
-            "modifier": {} or "void",
+            "modifier": {} ,
             "identifier": "",  # Geometry identifier
             "display_name": "",  # Geometry display name
             "center_pt": (0, 0, 0),

--- a/honeybee_radiance/geometry/source.py
+++ b/honeybee_radiance/geometry/source.py
@@ -26,7 +26,7 @@ class Source(Geometry):
             a model and in the exported Radiance files.
         direction: A vector to set source direction (x, y, z) (Default: (0, 0 ,-1)).
         angle: Source solid angle (Default: 0.533).
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -93,7 +93,7 @@ class Source(Geometry):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default is "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "source",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -135,7 +135,7 @@ class Source(Geometry):
 
             {
             "type": "source",  # Geometry type
-            "modifier": {} or "void",
+            "modifier": {} ,
             "identifier": "",  # Geometry identifier
             "display_name": "",  # Geometry display name
             "direction": {"x": float, "y": float, "z": float},

--- a/honeybee_radiance/geometry/sphere.py
+++ b/honeybee_radiance/geometry/sphere.py
@@ -22,7 +22,7 @@ class Sphere(Geometry):
             a model and in the exported Radiance files.
         center_pt: Sphere center point as (x, y, z) (Default: (0, 0 ,0)).
         radius: Sphere radius as a number (Default: 10).
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -89,7 +89,7 @@ class Sphere(Geometry):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "sphere",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -131,7 +131,7 @@ class Sphere(Geometry):
 
             {
             "type": "sphere",  # Geometry type
-            "modifier": {} or "void",
+            "modifier": {} ,
             "identifier": "",  # Geometry identifier
             "display_name": "",  # Geometry display name
             "center_pt": {"x": float, "y": float, "z": float},

--- a/honeybee_radiance/geometry/tube.py
+++ b/honeybee_radiance/geometry/tube.py
@@ -28,7 +28,7 @@ class Tube(Cylinder):
             (Default: (0, 0 ,0)).
         center_pt_end: Tube end center point as (x, y, z) (Default: (0, 0 ,10)).
         radius: Tube start radius as a number (Default: 10).
-        modifier: Geometry modifier (Default: "void").
+        modifier: Geometry modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])

--- a/honeybee_radiance/modifier/material/antimatter.py
+++ b/honeybee_radiance/modifier/material/antimatter.py
@@ -30,7 +30,7 @@ class Antimatter(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/ashik2.py
+++ b/honeybee_radiance/modifier/material/ashik2.py
@@ -27,7 +27,7 @@ class Ashik2(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/brtdfunc.py
+++ b/honeybee_radiance/modifier/material/brtdfunc.py
@@ -57,7 +57,7 @@ class BRTDfunc(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/bsdf.py
+++ b/honeybee_radiance/modifier/material/bsdf.py
@@ -52,7 +52,7 @@ class BSDF(Material):
             not be perpendicular to any typical face.
         thickness: Optional number to set the thickness of the BSDF material.
             (default: 0).
-        modifier: Material modifier (Default: 'void').
+        modifier: Material modifier (Default: None).
         function_file: Optional input for function file (Default: .).
         transform: Optional transform input to to scale the thickness and reorient
             the up vector (default: None).
@@ -88,7 +88,7 @@ class BSDF(Material):
 
     # TODO(): compress file content: https://stackoverflow.com/a/15529390/4394669
     def __init__(self, bsdf_file, identifier=None, up_orientation=None, thickness=0,
-                 modifier='void', function_file='.', transform=None, angle_basis=None,
+                 modifier=None, function_file='.', transform=None, angle_basis=None,
                  dependencies=None):
         """Create BSDF material."""
         identifier = identifier or '.'.join(os.path.split(bsdf_file)[-1].split('.')[:-1])
@@ -285,7 +285,7 @@ class BSDF(Material):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "BSDF",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -350,7 +350,7 @@ class BSDF(Material):
         .. code-block:: python
 
             {
-            "modifier": "",  # material modifier (Default: "void")
+            "modifier": {},  # material modifier (Default: None)
             "type": "BSDF",  # Material type
             "identifier": string,  # Material identifer
             "display_name": string  # Material display name

--- a/honeybee_radiance/modifier/material/dielectric.py
+++ b/honeybee_radiance/modifier/material/dielectric.py
@@ -29,7 +29,7 @@ class Dielectric(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/glass.py
+++ b/honeybee_radiance/modifier/material/glass.py
@@ -24,7 +24,7 @@ class Glass(Material):
             1 (Default: 0).
         refraction: Index of refraction. 1.52 for glass and 1.4 for ETFE
             (Default: 1.52).
-        modifier: Material modifier (Default: "void").
+        modifier: Material modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -54,7 +54,7 @@ class Glass(Material):
                  '_refraction_index')
 
     def __init__(self, identifier, r_transmissivity=0.0, g_transmissivity=0.0,
-                 b_transmissivity=0.0, refraction_index=None, modifier="void",
+                 b_transmissivity=0.0, refraction_index=None, modifier=None,
                  dependencies=None):
         """Create glass material."""
         Material.__init__(self, identifier, modifier=modifier,
@@ -137,7 +137,7 @@ class Glass(Material):
 
     @classmethod
     def from_transmittance(cls, identifier, r_transmittance=0.0, g_transmittance=0.0,
-                           b_transmittance=0.0, refraction_index=None, modifier="void",
+                           b_transmittance=0.0, refraction_index=None, modifier=None,
                            dependencies=None):
         """Create glass material from transmittance values.
 
@@ -157,7 +157,7 @@ class Glass(Material):
                 (Default: 0).
             refraction: Index of refraction. 1.52 for glass and 1.4 for ETFE
                 (Default: 1.52).
-            modifier: Material modifier (Default: "void").
+            modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
                 primitive is defined based on other primitives. (Default: [])
@@ -177,7 +177,7 @@ class Glass(Material):
 
     @classmethod
     def from_single_transmissivity(cls, identifier, rgb_transmissivity=0,
-                                   refraction_index=None, modifier="void",
+                                   refraction_index=None, modifier=None,
                                    dependencies=None):
         """Create glass material with single transmissivity value.
 
@@ -189,7 +189,7 @@ class Glass(Material):
                 be between 0 and 1 (Default: 0).
             refraction: Index of refraction. 1.52 for glass and 1.4 for ETFE
                 (Default: 1.52).
-            modifier: Material modifier (Default: "void").
+            modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
                 primitive is defined based on other primitives. (Default: [])
@@ -209,7 +209,8 @@ class Glass(Material):
 
     @classmethod
     def from_single_transmittance(cls, identifier, rgb_transmittance=0,
-                                  refraction_index=None, modifier="void", dependencies=None):
+                                  refraction_index=None, modifier=None,
+                                  dependencies=None):
         """Create glass material with single transmittance value.
 
         Args:
@@ -220,7 +221,7 @@ class Glass(Material):
                 be between 0 and 1 (Default: 0).
             refraction: Index of refraction. 1.52 for glass and 1.4 for ETFE
                 (Default: 1.52).
-            modifier: Material modifier (Default: "void").
+            modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
                 primitive is defined based on other primitives. (Default: [])
@@ -249,7 +250,7 @@ class Glass(Material):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "glass",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -299,7 +300,7 @@ class Glass(Material):
             "g_transmissivity": float,  # Transmissivity for green
             "b_transmissivity": float,  # Transmissivity for blue
             "refraction_index": float,  # Index of refraction
-            "modifier": "",  # material modifier (Default: "void")
+            "modifier": {},  # material modifier (Default: None)
             "dependencies": []
             }
         """

--- a/honeybee_radiance/modifier/material/glow.py
+++ b/honeybee_radiance/modifier/material/glow.py
@@ -25,6 +25,7 @@ class Glow(Material):
             sources will never illuminate objects on the other side of an illum
             surface. This provides a convenient way to illuminate local light fixture
             geometry without overlighting nearby objects.
+        modifier: Material modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -46,7 +47,7 @@ class Glow(Material):
     __slots__ = ('_r_emittance', '_g_emittance', '_b_emittance', '_max_radius')
 
     def __init__(self, identifier, r_emittance=0.0, g_emittance=0.0, b_emittance=0.0,
-                 max_radius=0.0, modifier='void', dependencies=None):
+                 max_radius=0.0, modifier=None, dependencies=None):
         """Init Glow material."""
         Material.__init__(self, identifier, modifier=modifier,
                           dependencies=dependencies)
@@ -116,7 +117,7 @@ class Glow(Material):
         self._max_radius = float(value)
 
     @classmethod
-    def from_single_value(cls, identifier, rgb=0, max_radius=0, modifier='void',
+    def from_single_value(cls, identifier, rgb=0, max_radius=0, modifier=None,
                           dependencies=None):
         """Create glow material with single value.
 
@@ -126,7 +127,7 @@ class Glow(Material):
             a model and in the exported Radiance files.
             rgb: Input for r_emittance, g_emittance and b_emittance. The value should be
                 between 0 and 1 (Default: 0).
-            modifier: Material modifier (Default: "void").
+            modifier: Material modifier (Default: None).
             max_radius: Maximum radius for shadow testing (default: 0). If maxrad is zero,
                 then the surface will never be tested for shadow, although it may
                 participate in an interreflection calculation. If maxrad is negative, then
@@ -158,7 +159,7 @@ class Glow(Material):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {}  # primitive modifier (Default: None)
             "type": "glow",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -209,6 +210,7 @@ class Glow(Material):
             "g_emittance": float,  # A positive value for the Green channel of the glow
             "b_emittance": float,  # A positive value for the Blue channel of the glow
             "max_radius": float,  # Maximum radius for shadow testing
+            "modifier": {}  # primitive modifier (Default: None)
             "dependencies: []
             }
         """

--- a/honeybee_radiance/modifier/material/illum.py
+++ b/honeybee_radiance/modifier/material/illum.py
@@ -27,7 +27,7 @@ class Illum(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/interface.py
+++ b/honeybee_radiance/modifier/material/interface.py
@@ -25,7 +25,7 @@ class Interface(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/light.py
+++ b/honeybee_radiance/modifier/material/light.py
@@ -14,10 +14,10 @@ class Light(Material):
         identifier: Text string for a unique Material ID. Must not contain spaces
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
-        r_emittance: A positive value for the Red channel of the light (default: 0).
-        g_emittance: A positive value for the Green channel of the light (default: 0).
-        b_emittance: A positive value for the Blue channel of the light (default: 0).
-        modifier: Material modifier. The default value is void.
+        r_emittance: A positive value for the Red channel of the light (Default: 0).
+        g_emittance: A positive value for the Green channel of the light (Default: 0).
+        b_emittance: A positive value for the Blue channel of the light (Default: 0).
+        modifier: Material modifier. (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])
@@ -38,7 +38,7 @@ class Light(Material):
     __slots__ = ('_r_emittance', '_g_emittance', '_b_emittance')
 
     def __init__(self, identifier, r_emittance=0, g_emittance=0, b_emittance=0,
-                 modifier='void', dependencies=None):
+                 modifier=None, dependencies=None):
         """Radiance Light material."""
         Material.__init__(self, identifier, modifier=modifier,
                           dependencies=dependencies)
@@ -88,7 +88,7 @@ class Light(Material):
         self._b_emittance = typing.float_positive(value)
 
     @classmethod
-    def from_single_value(cls, identifier, rgb=0, modifier="void", dependencies=None):
+    def from_single_value(cls, identifier, rgb=0, modifier=None, dependencies=None):
         """Create light material with single value.
 
         Args:
@@ -97,7 +97,7 @@ class Light(Material):
                 a model and in the exported Radiance files.
             rgb: Input for r_emittance, g_emittance and b_emittance. The value should be
                 between 0 and 1 (Default: 0).
-            modifier: Material modifier (Default: "void").
+            modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
                 primitive is defined based on other primitives. (Default: [])
@@ -122,7 +122,7 @@ class Light(Material):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {}  # primitive modifier (Default: None)
             "type": "light",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name

--- a/honeybee_radiance/modifier/material/metal.py
+++ b/honeybee_radiance/modifier/material/metal.py
@@ -26,7 +26,7 @@ class Metal(Plastic):
             value of 0 corresponds to a perfectly smooth surface, and a value of 1
             would be a very rough surface. Roughness values greater than 0.2 are not
             very realistic. (Default: 0).
-        modifier: Material modifier (Default: "void").
+        modifier: Material modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
             primitive is defined based on other primitives. (Default: [])

--- a/honeybee_radiance/modifier/material/metal2.py
+++ b/honeybee_radiance/modifier/material/metal2.py
@@ -17,7 +17,7 @@ class Metal2(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/metdata.py
+++ b/honeybee_radiance/modifier/material/metdata.py
@@ -17,7 +17,7 @@ class Metdata(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/metfunc.py
+++ b/honeybee_radiance/modifier/material/metfunc.py
@@ -17,7 +17,7 @@ class Metfunc(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/mist.py
+++ b/honeybee_radiance/modifier/material/mist.py
@@ -62,7 +62,7 @@ class Mist(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/plasdata.py
+++ b/honeybee_radiance/modifier/material/plasdata.py
@@ -34,7 +34,7 @@ class Plasdata(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/plasfunc.py
+++ b/honeybee_radiance/modifier/material/plasfunc.py
@@ -35,7 +35,7 @@ class Plasfunc(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/plastic.py
+++ b/honeybee_radiance/modifier/material/plastic.py
@@ -27,10 +27,10 @@ class Plastic(Material):
             value of 0 corresponds to a perfectly smooth surface, and a value of 1
             would be a very rough surface. Roughness values greater than 0.2 are not
             very realistic. (Default: 0).
-        modifier: Material modifier (Default: "void").
+        modifier: Material modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
-            primitive is defined based on other primitives. (Default: [])
+            primitive is defined based on other primitives. (Default: None).
 
     Properties:
         * identifier
@@ -59,7 +59,7 @@ class Plastic(Material):
                  '_specularity', '_roughness')
 
     def __init__(self, identifier, r_reflectance=0.0, g_reflectance=0.0, b_reflectance=0.0,
-                 specularity=0.0, roughness=0.0, modifier="void", dependencies=None):
+                 specularity=0.0, roughness=0.0, modifier=None, dependencies=None):
         """Create plastic material."""
         Material.__init__(self, identifier, modifier=modifier, dependencies=dependencies)
         self.r_reflectance = r_reflectance
@@ -157,7 +157,7 @@ class Plastic(Material):
     @classmethod
     def from_single_reflectance(
         cls, identifier, rgb_reflectance=0.0, specularity=0.0, roughness=0.0,
-        modifier="void", dependencies=None):
+        modifier=None, dependencies=None):
         """Create plastic material with single reflectance value.
 
         Args:
@@ -172,10 +172,10 @@ class Plastic(Material):
                 of 0 corresponds to a perfectly smooth surface, and a value of 1 would be
                 a very rough surface. Roughness values greater than 0.2 are not very
                 realistic. (Default: 0).
-            modifier: Material modifier (Default: "void").
+            modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
-                primitive is defined based on other primitives. (Default: [])
+                primitive is defined based on other primitives. (Default: None).
 
         Usage:
 
@@ -199,7 +199,7 @@ class Plastic(Material):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "plastic",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -250,7 +250,7 @@ class Plastic(Material):
             "b_reflectance": float,  # Reflectance for blue
             "specularity": float,  # Material specularity
             "roughness": float,  # Material roughness
-            "modifier": {} or void,  # Material modifier
+            "modifier": {},  # Material modifier (Default: None)
             "dependencies": []
             }
         """

--- a/honeybee_radiance/modifier/material/plastic2.py
+++ b/honeybee_radiance/modifier/material/plastic2.py
@@ -34,7 +34,7 @@ class Plastic2(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/prism1.py
+++ b/honeybee_radiance/modifier/material/prism1.py
@@ -33,7 +33,7 @@ class Prism1(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/prism2.py
+++ b/honeybee_radiance/modifier/material/prism2.py
@@ -24,7 +24,7 @@ class Prism2(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/spotlight.py
+++ b/honeybee_radiance/modifier/material/spotlight.py
@@ -26,7 +26,7 @@ class Spotlight(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/trans.py
+++ b/honeybee_radiance/modifier/material/trans.py
@@ -32,10 +32,10 @@ class Trans(Material):
             transmitted light that is transmitted diffusely in as scattering fashion.
         transmitted_spec: The transmitted specular component is the fraction of
             transmitted light that is not diffusely scattered.
-        modifier: Material modifier (Default: "void").
+        modifier: Material modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
-            primitive is defined based on other primitives. (Default: [])
+            primitive is defined based on other primitives. (Default: None)
 
     Properties:
         * identifier
@@ -58,7 +58,7 @@ class Trans(Material):
 
     def __init__(self, identifier, r_reflectance=0.0, g_reflectance=0.0, b_reflectance=0.0,
                  specularity=0.0, roughness=0.0, transmitted_diff=0.0,
-                 transmitted_spec=0.0, modifier="void", dependencies=None):
+                 transmitted_spec=0.0, modifier=None, dependencies=None):
         """Create trans material."""
         Material.__init__(self, identifier, modifier=modifier,
                           dependencies=dependencies)
@@ -190,7 +190,7 @@ class Trans(Material):
     def from_reflected_specularity(
             cls, identifier, r_reflectance=0.0, g_reflectance=0.0, b_reflectance=0.0,
             reflected_specularity=0.0, roughness=0.0, transmitted_diff=0.0,
-            transmitted_spec=0.0, modifier="void", dependencies=None):
+            transmitted_spec=0.0, modifier=None, dependencies=None):
         """Create trans material from reflected specularity.
 
         Note:
@@ -217,7 +217,7 @@ class Trans(Material):
                 transmitted light that is transmitted diffusely in as scattering fashion.
             transmitted_spec: The transmitted specular component is the fraction of
                 transmitted light that is not diffusely scattered.
-            modifier: Material modifier (Default: "void").
+            modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
                 primitive is defined based on other primitives. (Default: [])
@@ -263,7 +263,7 @@ class Trans(Material):
     @classmethod
     def from_single_reflectance(
         cls, identifier, rgb_reflectance=0.0, specularity=0.0, roughness=0.0,
-        transmitted_diff=0.0, transmitted_spec=0.0, modifier="void",
+        transmitted_diff=0.0, transmitted_spec=0.0, modifier=None,
             dependencies=None):
         """Create trans material with single reflectance value.
 
@@ -283,7 +283,7 @@ class Trans(Material):
                 transmitted light that is transmitted diffusely in as scattering fashion.
             transmitted_spec: The transmitted specular component is the fraction of
                 transmitted light that is not diffusely scattered.
-            modifier: Material modifier (Default: "void").
+            modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
                 primitive is defined based on other primitives. (Default: [])
@@ -304,7 +304,7 @@ class Trans(Material):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "trans",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -362,7 +362,7 @@ class Trans(Material):
             "transmitted_diff": float,
             "transmitted_spec": float,
             "dependencies": []
-            "modifier": {} or void,  # Material modifier
+            "modifier": {},  # Material modifier (Default: None)
             }
         """
         assert 'type' in data, 'Input dictionary is missing "type".'

--- a/honeybee_radiance/modifier/material/trans2.py
+++ b/honeybee_radiance/modifier/material/trans2.py
@@ -25,7 +25,7 @@ class Trans2(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/transdata.py
+++ b/honeybee_radiance/modifier/material/transdata.py
@@ -26,7 +26,7 @@ class Transdata(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/material/transfunc.py
+++ b/honeybee_radiance/modifier/material/transfunc.py
@@ -29,7 +29,7 @@ class Transfunc(Material):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/mixture/mixdata.py
+++ b/honeybee_radiance/modifier/mixture/mixdata.py
@@ -25,7 +25,7 @@ class Mixdata(Mixture):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/mixture/mixfunc.py
+++ b/honeybee_radiance/modifier/mixture/mixfunc.py
@@ -30,7 +30,7 @@ class Mixfunc(Mixture):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/mixture/mixpict.py
+++ b/honeybee_radiance/modifier/mixture/mixpict.py
@@ -28,7 +28,7 @@ class Mixpict(Mixture):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/mixture/mixtext.py
+++ b/honeybee_radiance/modifier/mixture/mixtext.py
@@ -42,7 +42,7 @@ class Mixtext(Mixture):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/pattern/brightdata.py
+++ b/honeybee_radiance/modifier/pattern/brightdata.py
@@ -25,7 +25,7 @@ class Brightdata(Pattern):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/pattern/brightfunc.py
+++ b/honeybee_radiance/modifier/pattern/brightfunc.py
@@ -23,7 +23,7 @@ class Brightfunc(Pattern):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/pattern/brighttext.py
+++ b/honeybee_radiance/modifier/pattern/brighttext.py
@@ -57,7 +57,7 @@ class Brighttext(Pattern):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/pattern/colordata.py
+++ b/honeybee_radiance/modifier/pattern/colordata.py
@@ -32,7 +32,7 @@ class Colordata(Pattern):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/pattern/colorfunc.py
+++ b/honeybee_radiance/modifier/pattern/colorfunc.py
@@ -23,7 +23,7 @@ class Colorfunc(Pattern):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/pattern/colorpict.py
+++ b/honeybee_radiance/modifier/pattern/colorpict.py
@@ -29,7 +29,7 @@ class Colorpict(Pattern):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/modifier/pattern/colortext.py
+++ b/honeybee_radiance/modifier/pattern/colortext.py
@@ -49,7 +49,7 @@ class Colortext(Pattern):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitve definitions and the
             values in each array correspond to values occurring within each line.

--- a/honeybee_radiance/mutil.py
+++ b/honeybee_radiance/mutil.py
@@ -21,8 +21,6 @@ def modifier_class_from_type_string(type_string):
             in the dictionary representation of the modifier.
     """
     _mapper = {'bsdf': 'BSDF', 'brtdfunc': 'BRTDfunc'}
-    if type_string == 'void':
-        return Void
     if type_string in Primitive.MATERIALTYPES:
         target_module = material
     elif type_string in Primitive.MIXTURETYPES:

--- a/honeybee_radiance/primitive.py
+++ b/honeybee_radiance/primitive.py
@@ -61,7 +61,7 @@ class Void(object):
 
     def to_dict(self):
         """Return void."""
-        return {'type': 'void'}
+        return None
 
     @classmethod
     def from_dict(cls, value):
@@ -101,7 +101,7 @@ class Primitive(object):
             or special characters. This will be used to identify the object across
             a model and in the exported Radiance files.
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
-            (Default: "void").
+            (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
             refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
@@ -205,7 +205,7 @@ class Primitive(object):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "custom",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -240,7 +240,7 @@ class Primitive(object):
         .. code-block:: python
 
             {
-            "modifier": "",  # primitive modifier (Default: "void")
+            "modifier": {},  # primitive modifier (Default: None)
             "type": "custom",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
@@ -462,7 +462,7 @@ class Primitive(object):
             for dep in self.dependencies:
                 output.append(self._to_radiance(dep, minimal))
 
-        if include_modifier and self.modifier.identifier != 'void':
+        if include_modifier and not self.modifier.is_void:
             output.append(self._to_radiance(self.modifier, minimal))
         output.append(self._to_radiance(self, minimal))
 
@@ -495,7 +495,8 @@ class Primitive(object):
             import honeybee_radiance.mutil as mutil  # imports all modifiers classes
 
         # try to get modifier
-        if input_dict['modifier'] == 'void':
+        if 'modifier' not in input_dict or input_dict['modifier'] is None or \
+                input_dict['modifier'] == 'void':
             modifier = VOID
         else:
             modifier = mutil.dict_to_modifier(input_dict['modifier'])

--- a/honeybee_radiance/properties/_base.py
+++ b/honeybee_radiance/properties/_base.py
@@ -64,9 +64,7 @@ class _GeometryRadianceProperties(object):
         if self._modifier_blk:  # set by user
             return self._modifier_blk
         mod = self.modifier  # assign a default based on whether the modifier is opaque
-        if mod.is_void:
-            return black
-        elif mod.is_opaque:
+        if mod.is_void or mod.is_opaque:
             return black
         else:
             return mod

--- a/honeybee_radiance/properties/aperture.py
+++ b/honeybee_radiance/properties/aperture.py
@@ -71,9 +71,7 @@ class ApertureRadianceProperties(_GeometryRadianceProperties):
     def modifier_blk(self):
         """Get or set a modifier to be used in direct solar and in isolation studies.
 
-        If None, this will be a completely black material if the Aperture's modifier
-        is opaque and will be equal to the modifier if the Aperture's modifier is
-        non-opaque.
+        If None, this will be a completely black material.
         """
         if self._modifier_blk:  # set by user
             return self._modifier_blk

--- a/honeybee_radiance/properties/door.py
+++ b/honeybee_radiance/properties/door.py
@@ -72,8 +72,7 @@ class DoorRadianceProperties(_GeometryRadianceProperties):
     def modifier_blk(self):
         """Get or set a modifier to be used in direct solar and in isolation studies.
 
-        If None, this will be a completely black material if the Door's modifier
-        is opaque and will be equal to the modifier if the Door's modifier is non-opaque.
+        If None, this will be a completely black material.
         """
         if self._modifier_blk:  # set by user
             return self._modifier_blk

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -1,6 +1,16 @@
 # coding=utf-8
 """Methods to write to rad."""
+from ladybug.futil import write_to_file_by_name, preparedir, nukedir
+from honeybee.config import folders
+from honeybee.boundarycondition import Surface
+from honeybee_radiance_folder.folder import ModelFolder
+
 from .geometry import Polygon
+from .modifier.material import BSDF
+from .lib.modifiers import black
+
+import os
+import shutil
 
 
 def shade_to_rad(shade, blk=False, minimal=False):
@@ -10,7 +20,7 @@ def shade_to_rad(shade, blk=False, minimal=False):
     does it include any states for dynamic geometry.
 
     Args:
-        shade: A honeybee Shade for which an RAD representation will be returned.
+        shade: A honeybee Shade for which a RAD representation will be returned.
         blk: Boolean to note whether the "blacked out" version of the Shade should
             be output, which is useful for direct studies and isolation studies
             to understand the contribution of individual apertures.
@@ -31,7 +41,7 @@ def door_to_rad(door, blk=False, minimal=False):
     any of the shades assigned to the Door.
 
     Args:
-        door: A honeybee Door for which an RAD representation will be returned.
+        door: A honeybee Door for which a RAD representation will be returned.
         blk: Boolean to note whether the "blacked out" version of the Door should
             be output, which is useful for direct studies and isolation studies
             to understand the contribution of individual apertures.
@@ -55,7 +65,7 @@ def aperture_to_rad(aperture, blk=False, minimal=False):
     the shade geometry assigned to the Aperture.
 
     Args:
-        aperture: A honeybee Aperture for which an RAD representation will be returned.
+        aperture: A honeybee Aperture for which a RAD representation will be returned.
         blk: Boolean to note whether the "blacked out" version of the Aperture should
             be output, which is useful for direct studies and isolation studies
             to understand the contribution of individual apertures.
@@ -109,7 +119,7 @@ def room_to_rad(room, blk=False, minimal=False):
     will only write the default state for each dynamic object.
 
     Args:
-        room: A honeybee Room for which an RAD representation will be returned.
+        room: A honeybee Room for which a RAD representation will be returned.
         blk: Boolean to note whether the "blacked out" version of the geometry
             should be output, which is useful for direct studies and isolation
             studies to understand the contribution of individual apertures.
@@ -127,61 +137,356 @@ def room_to_rad(room, blk=False, minimal=False):
 def model_to_rad(model, blk=False, minimal=False):
     r"""Generate an RAD string representation of a Model.
 
-    The resulting string will include all geometry (Rooms, Faces, Shades, Apertures,
+    The resulting strings will include all geometry (Rooms, Faces, Shades, Apertures,
     Doors) and all modifiers. However, it does not include any states for dynamic
     geometry and will only write the default state for each dynamic object. To
     correctly account for dynamic objects, the model_to_rad_folder should be used.
 
+    Note that this method will also ensure that any Faces, Apertures, or Doors
+    with Surface boundary condition only have one of such objects in the output
+    string.
+
     Args:
-        model: A honeybee Model for which an RAD representation will be returned.
+        model: A honeybee Model for which a RAD representation will be returned.
         blk: Boolean to note whether the "blacked out" version of the geometry
             should be output, which is useful for direct studies and isolation
             studies to understand the contribution of individual apertures.
         minimal: Boolean to note whether the radiance string should be written
             in a minimal format (with spaces instead of line breaks). Default: False.
-    """
-    model_str = ['#   ================ MODEL ================\n']
-    rad_prop = model.properties.radiance
+    
+    Returns:
+        A tuple of two strings.
 
+        -   model_str: A radiance string that contains all geometry of the Model.
+
+        -   modifier_str: A radiance string that contains all of the modifiers
+            in the model. These will be modifier_blk if blk is True.
+    """
     # write all modifiers into the file
-    model_str.append('#   ============== MODIFIERS ==============\n')
+    modifier_str = ['#   ============== MODIFIERS ==============\n']
+    rad_prop = model.properties.radiance
     modifiers = rad_prop.blk_modifiers if blk else rad_prop.modifiers
     for mod in modifiers:
-        model_str.append(mod.to_radiance(minimal, False, False))
+        modifier_str.append(mod.to_radiance(minimal))
 
-    # write all Rooms into the file
-    rooms = model.rooms
-    if len(rooms) != 0:
-        model_str.append('#   ================ ROOMS ================\n')
-        for room in rooms:
-            model_str.append(room_to_rad(room, blk, minimal))
-
-    # write all orphaned Faces into the file
-    faces = model.orphaned_faces
+    # write all Faces into the file
+    model_str = ['#   ================ MODEL ================\n']
+    faces = model.faces
+    interior_faces = set()
     if len(faces) != 0:
         model_str.append('#   ================ FACES ================\n')
         for face in faces:
+            if isinstance(face.boundary_condition, Surface):
+                if face.identifier in interior_faces:
+                    continue
+                interior_faces.add(face.boundary_condition.boundary_condition_object)
             model_str.append(face_to_rad(face, blk, minimal))
 
     # write all orphaned Apertures into the file
     apertures = model.orphaned_apertures
+    interior_aps = set()
     if len(apertures) != 0:
         model_str.append('#   ============== APERTURES ==============\n')
         for ap in apertures:
+            if isinstance(ap.boundary_condition, Surface):
+                if ap.identifier in interior_aps:
+                    continue
+                interior_aps.add(ap.boundary_condition.boundary_condition_object)
             model_str.append(aperture_to_rad(ap, blk, minimal))
 
     # write all orphaned Doors into the file
     doors = model.orphaned_doors
+    interior_drs = set()
     if len(doors) != 0:
         model_str.append('#   ================ DOORS ================\n')
         for dr in doors:
+            if isinstance(dr.boundary_condition, Surface):
+                if dr.identifier in interior_drs:
+                    continue
+                interior_drs.add(dr.boundary_condition.boundary_condition_object)
             model_str.append(door_to_rad(dr, blk, minimal))
+
+    # write all Room shades into the file
+    rooms = model.rooms
+    if len(rooms) != 0:
+        model_str.append('#   ============== ROOM SHADES ==============\n')
+        for room in rooms:
+            for shd in room.shades:
+                model_str.append(shade_to_rad(shd, blk, minimal))
 
     # write all orphaned Shades into the file
     shades = model.orphaned_shades
     if len(shades) != 0:
-        model_str.append('#   ================ SHADES ================\n')
+        model_str.append('#   ============= CONTEXT SHADES =============\n')
         for shd in shades:
             model_str.append(shade_to_rad(shd, blk, minimal))
 
-    return '\n\n'.join(model_str)
+    return '\n\n'.join(model_str), '\n\n'.join(modifier_str)
+
+
+def model_to_rad_folder(model, folder=None, minimal=False):
+    r"""Write a honeybee model to a rad folder.
+
+    The rad files in the resulting folders will include all geometry
+    (Rooms, Faces, Shades, Apertures, Doors), all modifiers, and all states
+    of dynamic objects.
+
+    Args:
+        model: A honeybee Model for which radiance folder will be written.
+        folder: An optional folder to be used as the root of the model's
+            Radiance folder. If None, the files will be written into a sub-directory
+            of the honeybee-core default_simulation_folder. This sub-directory
+            is specifically: default_simulation_folder/[MODEL IDENTIFIER]/Radiance
+        minimal: Boolean to note whether the radiance strings should be written
+            in a minimal format (with spaces instead of line breaks). Default: False.
+    """
+    # prepare the folder for simulation
+    model_id = model.identifier
+    if folder is None:
+        folder = os.path.join(folders.default_simulation_folder, model_id, 'Radiance')
+    if os.path.isdir(folder):
+        nukedir(folder, rmdir=True)  # delete the folder if it already exists
+    else:
+        preparedir(folder)  # create the directory if it's not there
+    model_folder = ModelFolder(folder)
+    model_folder.write()
+
+    # gather static apertures
+    exterior_aps, exterior_aps_blk, interior_aps, interior_aps_blk = \
+        model.properties.radiance.subfaces_by_interior_exterior()
+
+    # write exterior static apertures
+    ext_mods, ext_mods_blk, mod_combs, mod_names = \
+        _collect_modifiers(exterior_aps, exterior_aps_blk, True)
+    _write_static_files(folder, model_folder.STATIC_APERTURE_EXTERIOR, model_id,
+                        exterior_aps, exterior_aps_blk, ext_mods, ext_mods_blk,
+                        mod_combs, mod_names, False, minimal)
+
+    # write interior static apertures
+    int_mods, int_mods_blk, mod_combs, mod_names = \
+        _collect_modifiers(interior_aps, interior_aps_blk, True)
+    _write_static_files(folder, model_folder.STATIC_APERTURE_INTERIOR, model_id,
+                        interior_aps, interior_aps_blk, int_mods, int_mods_blk,
+                        mod_combs, mod_names, False, minimal)
+
+    # gather static faces
+    opaque_faces, opaque_faces_blk, nonopaque_faces, nonopaque_faces_blk = \
+        model.properties.radiance.faces_by_opaque()
+
+    # write opaque static faces
+    of_mods, of_mods_blk, mod_combs, mod_names = \
+        _collect_modifiers(opaque_faces, opaque_faces_blk, True)
+    _write_static_files(folder, model_folder.STATIC_OPAQUE_ROOT, model_id,
+                        opaque_faces, opaque_faces_blk, of_mods, of_mods_blk,
+                        mod_combs, mod_names, True, minimal)
+    
+    # write nonopaque static faces
+    nof_mods, nof_mods_blk, mod_combs, mod_names = \
+        _collect_modifiers(nonopaque_faces, nonopaque_faces_blk, False)
+    _write_static_files(folder, model_folder.STATIC_NONOPAQUE_ROOT, model_id,
+                        nonopaque_faces, nonopaque_faces_blk, nof_mods, nof_mods_blk,
+                        mod_combs, mod_names, True, minimal)
+
+    # gather static indoor shades
+    opaque_shades, opaque_shades_blk, nonopaque_shades, nonopaque_shades_blk = \
+        model.properties.radiance.indoor_shades_by_opaque()
+
+    # write opaque static indoor shades
+    os_mods, os_mods_blk, mod_combs, mod_names = \
+        _collect_modifiers(opaque_shades, opaque_shades_blk, True)
+    _write_static_files(folder, model_folder.STATIC_OPAQUE_INDOOR, model_id,
+                        opaque_shades, opaque_shades_blk, os_mods, os_mods_blk,
+                        mod_combs, mod_names, False, minimal)
+    
+    # write nonopaque static indoor shades
+    nos_mods, nos_mods_blk, mod_combs, mod_names = \
+        _collect_modifiers(nonopaque_shades, nonopaque_shades_blk, False)
+    _write_static_files(folder, model_folder.STATIC_NONOPAQUE_INDOOR, model_id,
+                        nonopaque_shades, nonopaque_shades_blk, nos_mods, nos_mods_blk,
+                        mod_combs, mod_names, False, minimal)
+
+    # gather static outdoor shades
+    opaque_shades, opaque_shades_blk, nonopaque_shades, nonopaque_shades_blk = \
+        model.properties.radiance.outdoor_shades_by_opaque()
+
+    # write opaque static outdoor shades
+    os_mods, os_mods_blk, mod_combs, mod_names = \
+        _collect_modifiers(opaque_shades, opaque_shades_blk, True)
+    _write_static_files(folder, model_folder.STATIC_OPAQUE_OUTDOOR, model_id,
+                        opaque_shades, opaque_shades_blk, os_mods, os_mods_blk,
+                        mod_combs, mod_names, False, minimal)
+
+    # write nonopaque static outdoor shades
+    nos_mods, nos_mods_blk, mod_combs, mod_names = \
+        _collect_modifiers(nonopaque_shades, nonopaque_shades_blk, False)
+    _write_static_files(folder, model_folder.STATIC_NONOPAQUE_OUTDOOR, model_id,
+                        nonopaque_shades, nonopaque_shades_blk, nos_mods, nos_mods_blk,
+                        mod_combs, mod_names, False, minimal)
+
+
+def _write_static_files(
+        folder, sub_folder, model_id, geometry, geometry_blk, modifiers, modifiers_blk,
+        mod_combs, mod_names, punched_verts=False, minimal=False):
+    """Write out the three files that need to go into any static radiance model folder.
+
+    This includes a .rad, .mat, and .blk file for the folder.
+    This method will also catch any cases of BSDF modifiers and copy the XML files
+    to the bsdf folder of the model folder.
+
+    Args:
+        folder: The model folder location on this machine.
+        sub_folder: The sub-folder for the three files (relative to the model folder).
+        model_id: A Model identifier to be used for the names of each of the files.
+        geometry: A list of geometry objects all with default blk modifiers.
+        geometry_blk: A list of geometry objects with overridden blk modifiers.
+        modifiers: A list of modifiers to write.
+        modifiers_blk: A list of modifier_blk to write.
+        mod_combs: Dictionary of modifiers from _unique_modifier_blk_combinations method.
+        mod_names: Modifier names from the _unique_modifier_blk_combinations method.
+        punched_verts: Boolean noting whether punched geometry should be written
+        minimal: Boolean noting whether radiance strings should be written minimally.
+    """
+    if len(geometry) != 0 or len(geometry_blk) != 0:
+        # write the strings for the geometry
+        face_strs = []
+        if punched_verts:
+            for face in geometry:
+                modifier = face.properties.radiance.modifier
+                rad_poly = Polygon(face.identifier, face.punched_vertices, modifier)
+                face_strs.append(rad_poly.to_radiance(minimal, False, False))
+            for face, mod_name in zip(geometry_blk, mod_names):
+                modifier = mod_combs[mod_name][0]
+                rad_poly = Polygon(face.identifier, face.punched_vertices, modifier)
+                face_strs.append(rad_poly.to_radiance(minimal, False, False))
+        else:
+            for face in geometry:
+                modifier = face.properties.radiance.modifier
+                rad_poly = Polygon(face.identifier, face.vertices, modifier)
+                face_strs.append(rad_poly.to_radiance(minimal, False, False))
+            for face, mod_name in zip(geometry_blk, mod_names):
+                modifier = mod_combs[mod_name][0]
+                rad_poly = Polygon(face.identifier, face.vertices, modifier)
+                face_strs.append(rad_poly.to_radiance(minimal, False, False))
+
+        # write the strings for the modifiers
+        mod_strs = []
+        mod_blk_strs = []
+        for mod in modifiers:
+            if isinstance(mod, BSDF):
+                _process_bsdf_modifier(folder, mod, mod_strs, minimal)
+            else:
+                mod_strs.append(mod.to_radiance(minimal))
+        for mod in modifiers_blk:
+            if isinstance(mod, BSDF):
+                _process_bsdf_modifier(folder, mod, mod_strs, minimal)
+            else:
+                mod_blk_strs.append(mod.to_radiance(minimal))
+
+        # write the three files for the model sub-folder
+        dest = os.path.join(folder, sub_folder)
+        write_to_file_by_name(dest, '{}.rad'.format(model_id), '\n\n'.join(face_strs))
+        write_to_file_by_name(dest, '{}.mat'.format(model_id), '\n\n'.join(mod_strs))
+        write_to_file_by_name(dest, '{}.blk'.format(model_id), '\n\n'.join(mod_blk_strs))
+
+
+def _unique_modifiers(geometry_objects):
+    """Get a list of unique modifiers across an array of geometry objects.
+    
+    Args:
+        geometry_objects: An array of geometry objects (Faces, Apertures,
+            Doors, Shades) for which unique modifiers will be determined.
+
+    Returns:
+        A list of all unique modifiers across the input geometry_objects
+    """
+    modifiers = []
+    for obj in geometry_objects:
+        mod = obj.properties.radiance.modifier
+        if not _instance_in_array(mod, modifiers):
+            modifiers.append(mod)
+    return list(set(modifiers))
+
+
+def _unique_modifier_blk_combinations(geometry_objects):
+    """Get lists of unique modifier/mofidier_blk combinations across geometry objects.
+
+    Args:
+        geometry_objects: An array of geometry objects (Faces, Apertures,
+            Doors, Shades) for which unique combinations of modifier and
+            modifier_blk will be determined.
+    
+    Returns:
+        A tuple with two objects.
+
+        -   modifier_combs: A dictionary of modifiers with identifiers of
+            modifiers as keys and tuples with two modifiers as values. Each
+            item in the dictionary represents a unique combination of modifier
+            and modifer_blk found in the objects. Both modifiers in the pair
+            have the same identifier (making them write-able into a radiance
+            folder). The first item in the tuple is the true modifier while
+            the second one is the modifier_blk.
+
+        -   modifier_names: A list of modifier names with one name for each of
+            the input geometry_objects. These names can be looked up in the
+            modifier_combs dictionary to get the modifier combination for a
+            given geometry object
+    """
+    modifier_combs = {}
+    modifier_names = []
+    for obj in geometry_objects:
+        mod = obj.properties.radiance.modifier
+        mod_blk = obj.properties.radiance.modifier_blk
+        comb_name = '{}_{}'.format(mod.identifier, mod_blk.identifier)
+        modifier_names.append(comb_name)
+        try:  # test to see if the combination already exists
+            modifier_combs[comb_name]
+        except KeyError:  # new combination of modifier and modifier_blk
+            new_mod = mod.duplicate()
+            new_mod.identifier = comb_name
+            new_mod_blk = mod_blk.duplicate()
+            new_mod_blk.identifier = comb_name
+            modifier_combs[comb_name] = (new_mod, new_mod_blk)
+    return modifier_combs, modifier_names
+
+
+def _collect_modifiers(geo, geo_blk, opaque_or_aperture):
+    """Collect all modifier and modifier_blk across geometry."""
+    mods = _unique_modifiers(geo)
+    if opaque_or_aperture:
+        mods_blk = [black.duplicate() for mod in mods]
+        for i, mod in enumerate(mods):
+            mods_blk[i].identifier = mod.identifier
+    else:
+        mods_blk = mods[:]  # copy the list
+    mod_combs, mod_names = _unique_modifier_blk_combinations(geo_blk)
+    mods.extend([mod_comb[0] for mod_comb in mod_combs.values()])
+    mods_blk.extend([mod_comb[1] for mod_comb in mod_combs.values()])
+    return mods, mods_blk, mod_combs, mod_names
+
+
+def _process_bsdf_modifier(folder, modifier, mod_strs, minimal):
+    """Process a BSDF modifier for a radiance model folder."""
+    # copy the BSDF to the model radiance folder
+    model_bsdf_folder = os.path.join(folder, 'model', 'bsdf')
+    bsdf_name = os.path.split(modifier.bsdf_file)[-1]
+    new_bsdf_path = os.path.join(model_bsdf_folder, bsdf_name)
+    shutil.copy(modifier.bsdf_file, new_bsdf_path)
+
+    # write a radiance string using the correct path to the BSDF
+    mod_dup = modifier.duplicate()  # duplicate to avoid editing the original
+    mod_dup.bsdf_file = new_bsdf_path
+    mod_strs.append(mod_dup.to_radiance(minimal))
+
+
+def _instance_in_array(object_instance, object_array):
+    """Check if a specific object instance is already in an array.
+
+    This can be much faster than  `if object_instance in object_arrary`
+    when you expect to be testing a lot of the same instance of an object for
+    inclusion in an array since the builtin method uses an == operator to
+    test inclusion.
+    """
+    for val in object_array:
+        if val is object_instance:
+            return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 honeybee-core==1.26.1
+honeybee-radiance-folder==1.0.1
 honeybee-radiance-command==1.0.0

--- a/tests/material_glass_test.py
+++ b/tests/material_glass_test.py
@@ -87,7 +87,7 @@ def test_from_dict_w_modifier():
         "g_transmissivity": 0.5,
         "b_transmissivity": 0.6,
         "refraction_index": None,
-        "modifier": "void",
+        "modifier": None,
         "dependencies": []
     }
 

--- a/tests/material_glow_test.py
+++ b/tests/material_glow_test.py
@@ -72,7 +72,7 @@ def test_to_dict():
     assert mdict['g_emittance'] == 100000
     assert mdict['max_radius'] == 0
     assert mdict['type'] == 'glow'
-    assert mdict['modifier'] == {'type': 'void'}
+    assert 'modifier' not in mdict or mdict['modifier'] is None
 
 
 def test_to_from_dict():

--- a/tests/material_light_test.py
+++ b/tests/material_light_test.py
@@ -58,7 +58,7 @@ def test_from_dict_w_modifier():
         "g_transmissivity": 0.5,
         "b_transmissivity": 0.6,
         "refraction_index": None,
-        "modifier": "void",
+        "modifier": None,
         "dependencies": []
     }
 
@@ -93,5 +93,5 @@ def test_to_dict():
     assert mdict['b_emittance'] == 100000
     assert mdict['g_emittance'] == 100000
     assert mdict['type'] == 'light'
-    assert mdict['modifier'] == {'type': 'void'}
+    assert 'modifier' not in mdict or mdict['modifier'] is None
 

--- a/tests/material_metal_test.py
+++ b/tests/material_metal_test.py
@@ -91,7 +91,7 @@ def test_from_dict_w_modifier():
         "g_transmissivity": 0.5,
         "b_transmissivity": 0.6,
         "refraction_index": None,
-        "modifier": "void",
+        "modifier": None,
         "dependencies": []
     }
 

--- a/tests/material_plastic_test.py
+++ b/tests/material_plastic_test.py
@@ -95,7 +95,7 @@ def test_from_dict_w_modifier():
         "g_transmissivity": 0.5,
         "b_transmissivity": 0.6,
         "refraction_index": None,
-        "modifier": "void",
+        "modifier": None,
         "dependencies": []
     }
 


### PR DESCRIPTION
This commit adds a method to the radiance writer to serialize a honeybee model into a radiance folder structure. At the moment, there are no states in honeybee-radiance and so this method only serializes objects into the static and bsdf folders.

There are a number of things to note about this implementation:
* All aperture-assigned static shades are written into either the opaque or nonopaque folder (not the aperture folder) since these are the only folders that allow us to distinguish between indoor and outdoor shades (the static aperture folder does not support this distinction).
* We currently do not enforce that apertures need to have a nonopaque modifier. So opaque apertures and doors are still written into the aperture folder.
* For every object where there is an overridden modifier_blk, two completely new modifiers are generated for every unique combination of modifer and modifier_blk. This greatly increases the complexity of the code since this type of check has to be run for every single sub-directory in the radiance folder structure.  But it's the only way to support the flexibility pf overriding the modifier_blk while also getting the matching names between modifer and modifer_blk that the radiance folder structure expects.
* In the event that no objects of a certain type are in the model (like no nonopaque building faces), I currently don't write any files at all rather than writing empty files. This is likely to be a very common occurrence since the folder structure has many directories that will rarely get use.
* I have included checks to be sure that, for every Face, Aperture, and Door with a Surface boundary condition, only one of the pair of the matching objects is written. There's no logic to which of the two objects is picked beyond whichever shows up first in the list (so the direction that this interior object should be considered random ).

I still have to add some tests for the new method but the code here should be good enough to review, @mostapharoudsari.