### PR TITLE
fix(mirror): Making Void an acceptable alternate material

### DIFF
--- a/honeybee_radiance/mutil.py
+++ b/honeybee_radiance/mutil.py
@@ -21,6 +21,8 @@ def modifier_class_from_type_string(type_string):
             in the dictionary representation of the modifier.
     """
     _mapper = {'bsdf': 'BSDF', 'brtdfunc': 'BRTDfunc'}
+    if type_string == 'void':
+        return Void
     if type_string in Primitive.MATERIALTYPES:
         target_module = material
     elif type_string in Primitive.MIXTURETYPES:

--- a/tests/material_mirror_test.py
+++ b/tests/material_mirror_test.py
@@ -160,6 +160,18 @@ def test_from_to_dict_with_alternate_material():
     assert mm == mmc
 
 
+def test_from_to_dict_with_void_alternate_material():
+    material_string = """
+    void mirror glass_mat
+    1 void
+    0
+    3 1 1 1
+    """
+    mm = Mirror.from_string(material_string)
+    mmc = Mirror.from_dict(mm.to_dict())
+    assert mm == mmc
+
+
 def test_from_primitive_dict_with_alt_material():
     alt_mat = {
         'modifier': 'void',


### PR DESCRIPTION
I ran a test and found that the Mirror alaternate_material didn't properly allow Void to be assigned as an input to turn the material invisible. This commit fixes this issue.