### PR TITLE
feat(material): add mirror material to modifiers

### DIFF
--- a/honeybee_radiance/modifier/material/__init__.py
+++ b/honeybee_radiance/modifier/material/__init__.py
@@ -14,6 +14,7 @@ from .metal import Metal
 from .metal2 import Metal2
 from .metdata import Metdata
 from .metfunc import Metfunc
+from .mirror import Mirror
 from .mist import Mist
 from .plasdata import Plasdata
 from .plasfunc import Plasfunc
@@ -26,4 +27,3 @@ from .trans import Trans
 from .trans2 import Trans2
 from .transdata import Transdata
 from .transfunc import Transfunc
-

--- a/honeybee_radiance/modifier/material/light.py
+++ b/honeybee_radiance/modifier/material/light.py
@@ -151,7 +151,7 @@ class Light(Material):
         if 'display_name' in primitive_dict and primitive_dict['display_name'] is not None:
             cls_.display_name = primitive_dict['display_name']
 
-        # this might look r_emittanceundant but it is NOT. see glass for explanation.
+        # this might look redundant but it is NOT. see glass for explanation.
         cls_.values = primitive_dict['values']
         return cls_
 

--- a/honeybee_radiance/modifier/material/mirror.py
+++ b/honeybee_radiance/modifier/material/mirror.py
@@ -1,0 +1,345 @@
+"""Radiance Mirror Material.
+
+http://radsite.lbl.gov/radiance/refer/ray.html#Mirror
+"""
+from __future__ import division
+from .materialbase import Material
+import honeybee.typing as typing
+from ...primitive import Void, VOID
+
+
+class Mirror(Material):
+    """Radiance mirror material.
+
+    Mirror is used for planar surfaces that produce virtual source reflections. This
+    material should be used sparingly, as it may cause the light source calculation to
+    blow up if it is applied to many small surfaces. This material is only supported for
+    flat surfaces such as polygons and rings. The arguments are simply the
+    RGB reflectance values, which should be between 0 and 1.
+
+    An optional string argument may be used like the illum type to specify a different
+    material to be used for shading non-source rays. If this alternate material is given
+    as 'void', then the mirror surface will be invisible. This is only appropriate if
+    the surface hides other (more detailed) geometry with the same overall reflectance. 
+
+    Args:
+        identifier: Text string for a unique Material ID. Must not contain spaces
+            or special characters. This will be used to identify the object across
+            a model and in the exported Radiance files.
+        r_reflectance: Reflectance for red. The value should be between 0 and 1
+            (Default: 1).
+        g_reflectance: Reflectance for green. The value should be between 0 and 1
+            (Default: 1).
+        b_reflectance: Reflectance for blue. The value should be between 0 and 1
+            (Default: 1).
+        modifier: Material modifier (Default: None).
+        alternate_material: An optional material may be used like the illum type to
+            specify a different material to be used for shading non-source rays. If this
+            alternate material is given as "void", then the mirror surface will be
+            invisible. This is only appropriate if the surface hides other (more
+            detailed) geometry with the same overall reflectance (Default: None).
+        dependencies: A list of primitives that this primitive depends on. This
+            argument is only useful for defining advanced primitives where the
+            primitive is defined based on other primitives (Default: []).
+
+    Properties:
+        * identifier
+        * display_name
+        * r_reflectance
+        * g_reflectance
+        * b_reflectance
+        * average_reflectance
+        * values
+        * modifier
+        * alternate_material
+        * dependencies
+        * is_modifier
+        * is_material
+
+    Usage:
+
+    .. code-block:: python
+
+        mirror_material = Mirror("mirror_material", 0.95, .95, .95)
+        print(mirror_material)
+    """
+
+    __slots__ = ('_r_reflectance', '_g_reflectance', '_b_reflectance',
+                 '_alternate_material',)
+
+    def __init__(
+        self, identifier, r_reflectance=1.0, g_reflectance=1.0, b_reflectance=1.0,
+            modifier=None, alternate_material=None, dependencies=None):
+        """Create mirror material."""
+        # add alternate material as a dependency if provided
+        self._alternate_material = None  # placeholder for alternate material
+        Material.__init__(self, identifier, modifier=modifier, dependencies=dependencies)
+        self.r_reflectance = r_reflectance
+        self.g_reflectance = g_reflectance
+        self.b_reflectance = b_reflectance
+        self.alternate_material = alternate_material
+        self._update_values()
+
+    def _update_values(self):
+        "update value dictionaries."
+        if self.alternate_material is not None:
+            self._values[0] = [self.alternate_material.identifier]
+        self._values[2] = [
+            self.r_reflectance, self.g_reflectance, self.b_reflectance,
+        ]
+
+    @property
+    def r_reflectance(self):
+        """Get or set reflectance for red channel.
+
+        The value should be between 0 and 1 (Default: 0).
+        """
+        return self._r_reflectance
+
+    @r_reflectance.setter
+    def r_reflectance(self, reflectance):
+        self._r_reflectance = \
+            typing.float_in_range(reflectance, 0, 1, 'red reflectance')
+
+    @property
+    def g_reflectance(self):
+        """Get or set reflectance for green channel.
+
+        The value should be between 0 and 1 (Default: 0).
+        """
+        return self._g_reflectance
+
+    @g_reflectance.setter
+    def g_reflectance(self, reflectance):
+        self._g_reflectance = \
+            typing.float_in_range(reflectance, 0, 1, 'green reflectance')
+
+    @property
+    def b_reflectance(self):
+        """Get or set reflectance for blue channel.
+
+        The value should be between 0 and 1 (Default: 0).
+        """
+        return self._b_reflectance
+
+    @b_reflectance.setter
+    def b_reflectance(self, reflectance):
+        self._b_reflectance = \
+            typing.float_in_range(reflectance, 0, 1, 'blue reflectance')
+
+    @property
+    def alternate_material(self):
+        """Alternate material.
+
+        An optional material may be used like the illum type to specify a different
+        material to be used for shading non-source rays. If this alternate material is
+        given as "void", then the mirror surface will be invisible. This is only
+        appropriate if the surface hides other (more detailed) geometry with the same
+        overall reflectance (Default: None).
+        """
+        return self._alternate_material
+
+    @alternate_material.setter
+    def alternate_material(self, material):
+        if material is not None:
+            assert isinstance(material, (Material, Void)), \
+                'alternate material must be from type Material not {}'.format(
+                type(material))
+
+        self._alternate_material = material
+
+    @property
+    def dependencies(self):
+        """Get list of dependencies for this primitive.
+
+        Additional dependencies can be added with the add_dependent method.
+        """
+        return self._dependencies if not self.alternate_material \
+            else self._dependencies + [self.alternate_material]
+
+    @classmethod
+    def from_single_reflectance(
+        cls, identifier, rgb_reflectance=0.0, modifier=None, alternate_material=None,
+            dependencies=None):
+        """Create mirror material with single reflectance value.
+
+        Args:
+            identifier: Text string for a unique Material ID. Must not contain spaces
+                or special characters. This will be used to identify the object across
+                a model and in the exported Radiance files.
+            rgb_reflectance: Reflectance for red, green and blue. The value should be
+                between 0 and 1 (Default: 0).
+            modifier: Material modifier (Default: None).
+            alternate_material: An optional material may be used like the illum type to
+                specify a different material to be used for shading non-source rays. If
+                this alternate material is given as "void", then the mirror surface will
+                be invisible. This is only appropriate if the surface hides other (more
+                detailed) geometry with the same overall reflectance (Default: None).
+            dependencies: A list of primitives that this primitive depends on. This
+                argument is only useful for defining advanced primitives where the
+                primitive is defined based on other primitives. (Default: [])
+
+        Usage:
+
+        .. code-block:: python
+
+            wall_material = Mirror.by_single_reflect_value("mirror", 1.0)
+        """
+        return cls(
+            identifier, rgb_reflectance, rgb_reflectance, rgb_reflectance,
+            modifier, alternate_material, dependencies
+        )
+
+    @classmethod
+    def from_primitive_dict(cls, primitive_dict):
+        """Initialize mirror from a primitive dict.
+
+        Args:
+            data: A dictionary in the format below.
+
+        .. code-block:: python
+
+            {
+            "modifier": {},  # primitive modifier (Default: None)
+            "type": "mirror",  # primitive type
+            "identifier": "",  # primitive identifier
+            "display_name": "",  # primitive display name
+            "values": [],  # values
+            "dependencies": []
+            }
+        """
+        assert 'type' in primitive_dict, 'Input dictionary is missing "type".'
+        if primitive_dict['type'] != cls.__name__.lower():
+            raise ValueError('Type must be %s not %s.' % (
+                    cls.__name__.lower(), primitive_dict['type']
+                )
+            )
+
+        modifier, dependencies = cls.filter_dict_input(primitive_dict)
+        if len(primitive_dict['values'][0]) == 1:
+            # find name
+            alt_id = primitive_dict['values'][0][0]
+            if alt_id == 'void':
+                alternate_material = VOID
+            elif isinstance(alt_id, dict):
+                try:  # see if the mutil module has already been imported
+                    mutil
+                except NameError:
+                    # import the module here to avoid a circular import
+                    import honeybee_radiance.mutil as mutil
+                alternate_material = mutil.dict_to_modifier(alt_id)
+            else:
+                alt_mats = [d for d in dependencies if d.identifier == alt_id]
+
+                assert len(alt_mats) == 1, \
+                    'Failed to find alternate material for mirror: "{}" in ' \
+                    'dependencies.'.format(alt_id)
+
+                # remove it from dependencies
+                alternate_material = alt_mats[0]
+                dependencies.remove(alternate_material)
+        else:
+            alternate_material = None
+
+        values = primitive_dict['values'][2]
+        cls_ = cls(
+            identifier=primitive_dict["identifier"],
+            r_reflectance=values[0],
+            g_reflectance=values[1],
+            b_reflectance=values[2],
+            modifier=modifier,
+            alternate_material=alternate_material,
+            dependencies=dependencies
+        )
+        if 'display_name' in primitive_dict \
+                and primitive_dict['display_name'] is not None:
+            cls_.display_name = primitive_dict['display_name']
+
+        # this might look redundant but it is NOT. see glass for explanation.
+        cls_.values = primitive_dict['values']
+        return cls_
+
+    @classmethod
+    def from_dict(cls, data):
+        """Initialize Mirror from a dictionary.
+
+        Args:
+            data: A dictionary in the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "mirror",  # Material type
+            "identifier": "",  # Material identifier
+            "display_name": string  # Material display name
+            "r_reflectance": float,  # Reflectance for red
+            "g_reflectance": float,  # Reflectance for green
+            "b_reflectance": float,  # Reflectance for blue
+            "modifier": {} or void,  # Material modifier
+            "alternate_material": {},  # optional alternate material
+            "dependencies": []
+            }
+        """
+        assert 'type' in data, 'Input dictionary is missing "type".'
+        if data['type'] != cls.__name__.lower():
+            raise ValueError(
+                'Type must be %s not %s.' % (cls.__name__.lower(), data['type'])
+            )
+        modifier, dependencies = Material.filter_dict_input(data)
+        if 'alternate_material' in data and data['alternate_material']:
+            # alternate material
+            if data['alternate_material'] == 'void':
+                alternate_material = VOID
+            else:
+                try:  # see if the mutil module has already been imported
+                    mutil
+                except NameError:
+                    # import the module here to avoid a circular import
+                    import honeybee_radiance.mutil as mutil
+                alternate_material = mutil.dict_to_modifier(data['alternate_material'])
+        else:
+            alternate_material = None
+
+        new_obj = cls(identifier=data["identifier"],
+                      r_reflectance=data["r_reflectance"],
+                      g_reflectance=data["g_reflectance"],
+                      b_reflectance=data["b_reflectance"],
+                      modifier=modifier,
+                      alternate_material=alternate_material,
+                      dependencies=dependencies)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
+
+    def to_dict(self):
+        """Translate this object to a dictionary."""
+        base = {
+            'modifier': self.modifier.to_dict(),
+            'type': self.__class__.__name__.lower(),
+            'identifier': self.identifier,
+            'r_reflectance': self.r_reflectance,
+            'g_reflectance': self.g_reflectance,
+            'b_reflectance': self.b_reflectance,
+            # dependencies without alternate material
+            'dependencies': [dp.to_dict() for dp in self._dependencies]
+        }
+        if self.alternate_material:
+            if isinstance(self.alternate_material, Void):
+                base['alternate_material'] = {'type': 'void'}
+            else:
+                base['alternate_material'] = self.alternate_material.to_dict()
+        else:
+            base['alternate_material'] = None
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        return base
+
+    def __copy__(self):
+        mod, depend = self._dup_mod_and_depend()
+        alt_mat = None if not self.alternate_material \
+            else self.alternate_material.duplicate()
+        new_obj = self.__class__(
+            self.identifier, self.r_reflectance, self.g_reflectance, self.b_reflectance,
+            mod, alt_mat, depend)
+        new_obj._display_name = self._display_name
+        return new_obj

--- a/honeybee_radiance/modifier/material/plastic.py
+++ b/honeybee_radiance/modifier/material/plastic.py
@@ -225,7 +225,8 @@ class Plastic(Material):
             modifier=modifier,
             dependencies=dependencies
         )
-        if 'display_name' in primitive_dict and primitive_dict['display_name'] is not None:
+        if 'display_name' in primitive_dict \
+                and primitive_dict['display_name'] is not None:
             cls_.display_name = primitive_dict['display_name']
 
         # this might look redundant but it is NOT. see glass for explanation.
@@ -257,8 +258,7 @@ class Plastic(Material):
         assert 'type' in data, 'Input dictionary is missing "type".'
         if data['type'] != cls.__name__.lower():
             raise ValueError(
-                'Type must be %s not %s.' % (cls.__name__.lower(),
-                    data['type'])
+                'Type must be %s not %s.' % (cls.__name__.lower(), data['type'])
             )
         modifier, dependencies = Material.filter_dict_input(data)
 

--- a/honeybee_radiance/mutil.py
+++ b/honeybee_radiance/mutil.py
@@ -21,7 +21,9 @@ def modifier_class_from_type_string(type_string):
             in the dictionary representation of the modifier.
     """
     _mapper = {'bsdf': 'BSDF', 'brtdfunc': 'BRTDfunc'}
-    if type_string in Primitive.MATERIALTYPES:
+    if type_string == 'void':
+        return Void
+    elif type_string in Primitive.MATERIALTYPES:
         target_module = material
     elif type_string in Primitive.MIXTURETYPES:
         target_module = mixture

--- a/honeybee_radiance/primitive.py
+++ b/honeybee_radiance/primitive.py
@@ -157,7 +157,7 @@ class Primitive(object):
     # All Radiance primitive types
     TYPES = set().union(GEOMETRYTYPES, MODIFIERTYPES)
 
-    # Modifierts that are not usually opaque. This will be used to set is_opaque property
+    # Modifiers that are not usually opaque. This will be used to set is_opaque property
     # if it is not overridded by the user by setting the is_opaque property
     NONEOPAQUETYPES = set(('glass', 'trans', 'trans2', 'transdata', 'transfunc',
                            'dielectric', 'BSDF', 'mixfunc', 'BRTDfunc', 'mist',
@@ -460,6 +460,8 @@ class Primitive(object):
 
         if include_dependencies:
             for dep in self.dependencies:
+                if isinstance(dep, Void):
+                    continue
                 output.append(self._to_radiance(dep, minimal))
 
         if include_modifier and not self.modifier.is_void:
@@ -475,7 +477,7 @@ class Primitive(object):
             "type": self.type,
             "identifier": self.identifier,
             "values": self.values,
-            "dependencies": [dep.to_dict() for dep in self._dependencies]
+            "dependencies": [dep.to_dict() for dep in self.dependencies]
         }
         if self._display_name is not None:
             base['display_name'] = self.display_name

--- a/tests/material_mirror_test.py
+++ b/tests/material_mirror_test.py
@@ -1,0 +1,199 @@
+from honeybee_radiance.modifier.material import Mirror
+from honeybee_radiance.primitive import VOID
+
+import pytest
+
+
+def test_mirror():
+    mir = Mirror('test_mirror')
+    assert mir.r_reflectance == 1
+    assert mir.g_reflectance == 1
+    assert mir.b_reflectance == 1
+    assert mir.to_radiance(minimal=True) == \
+        'void mirror test_mirror 0 0 3 1.0 1.0 1.0'
+
+
+def test_assign_values():
+    mir = Mirror('test_mirror', 0.6, 0.7, 0.8)
+    assert mir.r_reflectance == 0.6
+    assert mir.g_reflectance == 0.7
+    assert mir.b_reflectance == 0.8
+    assert mir.to_radiance(minimal=True) == \
+        'void mirror test_mirror 0 0 3 0.6 0.7 0.8'
+
+
+def test_material_lockability():
+    """Test the lockability of Mirror."""
+    mir = Mirror('test_mirror', 0.6, 0.7, 0.8)
+    mir.r_reflectance = 0.5
+    mir.lock()
+    with pytest.raises(AttributeError):
+        mir.r_reflectance = 0.7
+    mir.unlock()
+    mir.r_reflectance = 0.7
+
+
+def test_material_equivalency():
+    """Test the equality of a material to another."""
+    mir_1 = Mirror('test_mirror', 0.6, 0.7, 0.8)
+    mir_2 = mir_1.duplicate()
+    mir_3 = Mirror('test_mirror2', 0.8, 0.7, 0.8)
+
+    assert mir_1 is mir_1
+    assert mir_1 is not mir_2
+    assert mir_1 == mir_2
+    assert isinstance(mir_2, Mirror)
+    assert mir_1 != mir_3
+    collection = [mir_1, mir_2, mir_3]
+    assert len(set(collection)) == 2
+
+    mir_2.r_reflectance = 0.7
+    assert mir_1 != mir_2
+
+
+def test_update_values():
+    mir = Mirror('test_mirror', 0.6, 0.7, 0.8)
+    mir.r_reflectance = 0.5
+    mir.g_reflectance = 0.4
+    mir.b_reflectance = 0.3
+    assert mir.r_reflectance == 0.5
+    assert mir.g_reflectance == 0.4
+    assert mir.b_reflectance == 0.3
+    assert mir.to_radiance(minimal=True) == \
+        'void mirror test_mirror 0 0 3 0.5 0.4 0.3'
+
+
+def test_from_string():
+    mirror_str = """void mirror mirror_alt_mat
+        0
+        0
+        3
+            0.91 0.92 0.93
+    """
+    mir = Mirror.from_string(mirror_str)
+    assert mir.identifier == 'mirror_alt_mat'
+    assert mir.r_reflectance == 0.91
+    assert mir.g_reflectance == 0.92
+    assert mir.b_reflectance == 0.93
+    assert mir.to_radiance(minimal=True) == ' '.join(mirror_str.split())
+
+
+def test_from_string_w_modifier():
+
+    material_string = """
+    void brightfunc glass_angular_effect
+    3 A1+(1-A1) (exp(-5.85 Rdot)-0.00287989916) .
+    0
+    1 0.08
+
+    glass_angular_effect mirror glass_mat
+    0
+    0
+    3 1 1 1
+    """
+    gg = Mirror.from_string(material_string)
+    assert gg.to_radiance(minimal=True, include_modifier=False) == \
+        'glass_angular_effect mirror glass_mat 0 0 3 1.0 1.0 1.0'
+    assert gg.modifier.to_radiance(minimal=True) == \
+        'void brightfunc glass_angular_effect 3 A1+(1-A1)' \
+        ' (exp(-5.85 Rdot)-0.00287989916) . 0 1 0.08'
+
+
+def test_from_single_value():
+    mir = Mirror.from_single_reflectance('mirror_test', 0.95)
+    assert mir.r_reflectance == 0.95
+    assert mir.g_reflectance == 0.95
+    assert mir.b_reflectance == 0.95
+
+
+def test_with_alternate_material():
+    material_string = """
+    void glass glass_alt_mat
+    0
+    0
+    3 0.96 0.96 0.96
+
+    void brightfunc glass_angular_effect
+    3 A1+(1-A1) (exp(-5.85 Rdot)-0.00287989916) .
+    0
+    1 0.08
+
+    glass_angular_effect mirror glass_mat
+    1 glass_alt_mat
+    0
+    3 1 1 1
+    """
+    mm = Mirror.from_string(material_string)
+    assert mm.to_radiance(
+        minimal=True, include_modifier=False, include_dependencies=False) == \
+        'glass_angular_effect mirror glass_mat 1 glass_alt_mat 0 3 1.0 1.0 1.0'
+    assert mm.modifier.to_radiance(minimal=True) == \
+        'void brightfunc glass_angular_effect 3 A1+(1-A1)' \
+        ' (exp(-5.85 Rdot)-0.00287989916) . 0 1 0.08'
+    assert mm.alternate_material.to_radiance(minimal=True) == \
+        'void glass glass_alt_mat 0 0 3 0.96 0.96 0.96'
+
+    # alternate material should show up in dependencies for to_radiance to work correctly
+    assert mm.dependencies[0] == mm.alternate_material
+    # but it should not be part of the private dependencies
+    assert mm._dependencies == []
+
+
+def test_from_to_dict_with_alternate_material():
+    material_string = """
+    void glass glass_alt_mat
+    0
+    0
+    3 0.96 0.96 0.96
+
+    void brightfunc glass_angular_effect
+    3 A1+(1-A1) (exp(-5.85 Rdot)-0.00287989916) .
+    0
+    1 0.08
+
+    glass_angular_effect mirror glass_mat
+    1 glass_alt_mat
+    0
+    3 1 1 1
+    """
+    mm = Mirror.from_string(material_string)
+    mmc = Mirror.from_dict(mm.to_dict())
+    assert mm == mmc
+
+
+def test_from_primitive_dict_with_alt_material():
+    alt_mat = {
+        'modifier': 'void',
+        'type': 'glass',
+        'identifier': 'glass_alt_mat',
+        'values': [[], [], [0.96, 0.96, 0.96]]
+    }
+
+    input_dict = {
+        'modifier': 'void',
+        'type': 'mirror',
+        'identifier': 'mirror_mat',
+        'values': [[alt_mat], [], [1, 1, 1]]
+    }
+
+    mm = Mirror.from_primitive_dict(input_dict)
+    assert mm.alternate_material.modifier == VOID
+    assert mm.alternate_material.type == 'glass'
+
+
+def test_from_to_dict_with_void_alternate_material():
+    material_string = """
+    void mirror mirror_mat
+    1 void
+    0
+    3 1 1 1
+    """
+    mm = Mirror.from_string(material_string)
+    mmc = Mirror.from_dict(mm.to_dict())
+    assert mm == mmc
+
+
+def test_material_with_void_alternate():
+    mm = Mirror('mirror_mat', alternate_material=VOID)
+    assert mm.to_radiance(minimal=True) == \
+        'void mirror mirror_mat 1 void 0 3 1.0 1.0 1.0'


### PR DESCRIPTION
resolves #46

Also addressed all the comments from @chriswmackey in #65 and addressed the limitation that was pointed out in #69 but this iteration differs `void` from `None` for alternate material. 
