### PR TITLE
docs(glass): Elaborate docstrings to explain implicit code

### DIFF
--- a/honeybee_radiance/modifier/material/glass.py
+++ b/honeybee_radiance/modifier/material/glass.py
@@ -22,8 +22,9 @@ class Glass(Material):
             and 1 (Default: 0).
         b_transmissivity: Transmissivity for blue. The value should be between 0 and
             1 (Default: 0).
-        refraction: Index of refraction. 1.52 for glass and 1.4 for ETFE
-            (Default: 1.52).
+        refraction_index: Index of refraction. Typical values are 1.52 for float
+            glass and 1.4 for ETFE. If None, Radiance will default to using 1.52
+            for glass (Default: None).
         modifier: Material modifier (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
@@ -79,7 +80,7 @@ class Glass(Material):
 
     @property
     def r_transmissivity(self):
-        """Transmissivity for red channel.
+        """Get or set the transmissivity for red channel.
 
         The value should be between 0 and 1 (Default: 0).
         """
@@ -92,7 +93,7 @@ class Glass(Material):
 
     @property
     def g_transmissivity(self):
-        """Transmissivity for green channel.
+        """Get or set the transmissivity for green channel.
 
         The value should be between 0 and 1 (Default: 0).
         """
@@ -105,7 +106,7 @@ class Glass(Material):
 
     @property
     def b_transmissivity(self):
-        """Transmissivity for blue channel.
+        """get or set the transmissivity for blue channel.
 
         The value should be between 0 and 1 (Default: 0).
         """
@@ -118,17 +119,21 @@ class Glass(Material):
 
     @property
     def refraction_index(self):
-        """Index of refraction. 1.52 for glass and 1.4 for ETFE (Default: 1.52)."""
+        """Get or set the index of refraction.
+        
+        Typical values are 1.52 for float glass and 1.4 for ETFE. If None, Radiance
+        will default to using 1.52 for glass.
+        """
         return self._refraction_index
 
     @refraction_index.setter
     def refraction_index(self, value):
         self._refraction_index = typing.float_positive(value) if value is not None \
-             else None
+            else None
 
     @property
     def average_transmissivity(self):
-        """Calculate average transmittance.
+        """Get the average transmissivity.
 
         The value is calculated by multiplying the r, g, b values by v-lambda.
         """
@@ -155,8 +160,9 @@ class Glass(Material):
                 (Default: 0).
             b_transmittance: Transmittance for blue. The value should be between 0 and 1
                 (Default: 0).
-            refraction: Index of refraction. 1.52 for glass and 1.4 for ETFE
-                (Default: 1.52).
+            refraction_index: Index of refraction. Typical values are 1.52 for float
+                glass and 1.4 for ETFE. If None, Radiance will default to using 1.52
+                for glass (Default: None).
             modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
@@ -187,8 +193,9 @@ class Glass(Material):
                 a model and in the exported Radiance files.
             rgb_transmissivity: Transmissivity for red, green and blue. The value should
                 be between 0 and 1 (Default: 0).
-            refraction: Index of refraction. 1.52 for glass and 1.4 for ETFE
-                (Default: 1.52).
+            refraction_index: Index of refraction. Typical values are 1.52 for float
+                glass and 1.4 for ETFE. If None, Radiance will default to using 1.52
+                for glass (Default: None).
             modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
@@ -217,10 +224,11 @@ class Glass(Material):
             identifier: Text string for a unique Material ID. Must not contain spaces
                 or special characters. This will be used to identify the object across
                 a model and in the exported Radiance files.
-            rgb_transmissivity: Transmissivity for red, green and blue. The value should
+            rgb_transmittance: Transmittance for red, green and blue. The value should
                 be between 0 and 1 (Default: 0).
-            refraction: Index of refraction. 1.52 for glass and 1.4 for ETFE
-                (Default: 1.52).
+            refraction_index: Index of refraction. Typical values are 1.52 for float
+                glass and 1.4 for ETFE. If None, Radiance will default to using 1.52
+                for glass (Default: None).
             modifier: Material modifier (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the

--- a/honeybee_radiance/modifier/material/mirror.py
+++ b/honeybee_radiance/modifier/material/mirror.py
@@ -19,8 +19,9 @@ class Mirror(Material):
 
     An optional string argument may be used like the illum type to specify a different
     material to be used for shading non-source rays. If this alternate material is given
-    as 'void', then the mirror surface will be invisible. This is only appropriate if
-    the surface hides other (more detailed) geometry with the same overall reflectance. 
+    as "void", then the mirror surface will be invisible. Using "void" is only
+    appropriate if the surface hides other (more detailed) geometry with the same
+    overall reflectance. 
 
     Args:
         identifier: Text string for a unique Material ID. Must not contain spaces
@@ -34,9 +35,10 @@ class Mirror(Material):
             (Default: 1).
         modifier: Material modifier (Default: None).
         alternate_material: An optional material may be used like the illum type to
-            specify a different material to be used for shading non-source rays. If this
-            alternate material is given as "void", then the mirror surface will be
-            invisible. This is only appropriate if the surface hides other (more
+            specify a different material to be used for shading non-source rays.
+            If None, this will keep the alternat_material as mirror. If this alternate
+            material is given as "void", then the mirror surface will be invisible.
+            Using "void" is only appropriate if the surface hides other (more
             detailed) geometry with the same overall reflectance (Default: None).
         dependencies: A list of primitives that this primitive depends on. This
             argument is only useful for defining advanced primitives where the
@@ -129,13 +131,12 @@ class Mirror(Material):
 
     @property
     def alternate_material(self):
-        """Alternate material.
+        """Get or set an optional material for shading non-source rays.
 
-        An optional material may be used like the illum type to specify a different
-        material to be used for shading non-source rays. If this alternate material is
-        given as "void", then the mirror surface will be invisible. This is only
-        appropriate if the surface hides other (more detailed) geometry with the same
-        overall reflectance (Default: None).
+        If None, this will keep the alternat_material as mirror. If this alternate
+        material is given as "void", then the mirror surface will be invisible.
+        Using "void" is only appropriate if the surface hides other (more
+        detailed) geometry with the same overall reflectance.
         """
         return self._alternate_material
 
@@ -171,9 +172,10 @@ class Mirror(Material):
                 between 0 and 1 (Default: 0).
             modifier: Material modifier (Default: None).
             alternate_material: An optional material may be used like the illum type to
-                specify a different material to be used for shading non-source rays. If
-                this alternate material is given as "void", then the mirror surface will
-                be invisible. This is only appropriate if the surface hides other (more
+                specify a different material to be used for shading non-source rays.
+                If None, this will keep the alternat_material as mirror. If this alternate
+                material is given as "void", then the mirror surface will be invisible.
+                Using "void" is only appropriate if the surface hides other (more
                 detailed) geometry with the same overall reflectance (Default: None).
             dependencies: A list of primitives that this primitive depends on. This
                 argument is only useful for defining advanced primitives where the
@@ -275,7 +277,7 @@ class Mirror(Material):
             "r_reflectance": float,  # Reflectance for red
             "g_reflectance": float,  # Reflectance for green
             "b_reflectance": float,  # Reflectance for blue
-            "modifier": {} or void,  # Material modifier
+            "modifier": {},  # Material modifier (Default: None)
             "alternate_material": {},  # optional alternate material
             "dependencies": []
             }


### PR DESCRIPTION
Accepting `None` for these cases is a bit implicit and it creates issues when parsing honeybee-schema since `None` indicates to a property that doesn't need to exist at all (rather than a number that needs to be there but just has a default value).

This commit also makes the docstrings of the Mirror alternate_material clearer. 