### PR TITLE
fix(bsdf): Ensure BSDF is serialize-able to JSON

### DIFF
--- a/tests/material_bsdf_test.py
+++ b/tests/material_bsdf_test.py
@@ -1,5 +1,6 @@
 from honeybee_radiance.modifier.material import BSDF
 import os
+import json
 
 klems_bsdf_file = './tests/assets/klemsfull.xml'
 tt_bsdf_file = './tests/assets/tensortree.xml'
@@ -61,3 +62,13 @@ def test_to_and_from_dict():
     with open(bsdf_in.bsdf_file, 'r') as f1, \
             open(bsdf_from_dict.bsdf_file, 'r') as f2:
         assert f1.read() == f2.read()
+
+
+def test_bsdf_to_json():
+    """Ensure that the BSDF dictionary is serialize-able to JSON."""
+    test_bsdf = BSDF(klems_bsdf_file)
+    bsdf_dict = test_bsdf.to_dict()
+    bsdf_str = json.dumps(bsdf_dict)
+    new_bsdf = BSDF.from_dict(json.loads(bsdf_str))
+
+    os.remove(new_bsdf.bsdf_file)


### PR DESCRIPTION
This commit changes the BSDF dictionary to use a string to store the BSDF data instead of bytes, which are not serialize-able to JSON.

I was not able to compress the string further by removing white spaces since this messed with the re-serialization process (it could not identify the file type as TensorTree or Klems after all white space was removed). Maybe if we recorded the number of white spaces removed in each part so that we could put them back correctly, a strategy like that could work. But, at that point, I question whether we are actually saving much space in the resulting JSON..