### PR TITLE
fix(metal): Use better specularity default for Metal

### DIFF
--- a/honeybee_radiance/modifier/material/bsdf.py
+++ b/honeybee_radiance/modifier/material/bsdf.py
@@ -32,8 +32,8 @@ class BSDF(Material):
             rbdif gbdif bbdif
             rtdif gtdif btdif
 
-    The __init__ method sets additional diffuse reflectance for front and  back as well
-    as addition diffuse transmittance to 0. You can set-up these values by using their
+    The __init__ method sets additional diffuse reflectance for front and back as well
+    as additional diffuse transmittance to 0. You can setup these values by using their
     respective property.
 
     Args:

--- a/honeybee_radiance/modifier/material/metal.py
+++ b/honeybee_radiance/modifier/material/metal.py
@@ -10,6 +10,9 @@ from .plastic import Plastic
 class Metal(Plastic):
     """Radiance metal material.
 
+    Metal is similar to plastic, but specular highlights are modified by the
+    material color. Specularity of metals is usually .9 or greater.
+
     Args:
         identifier: Text string for a unique Material ID. Must not contain spaces
             or special characters. This will be used to identify the object across
@@ -20,8 +23,8 @@ class Metal(Plastic):
             (Default: 0).
         b_reflectance: Reflectance for blue. The value should be between 0 and 1
             (Default: 0).
-        specularity: Fraction of specularity. Specularity fractions greater than 0.1
-            are not realistic (Default: 0).
+        specularity: Fraction of specularity. Specularity of metals is usually
+            0.9 or greater. (Default: 0.9).
         roughness: Roughness is specified as the rms slope of surface facets. A
             value of 0 corresponds to a perfectly smooth surface, and a value of 1
             would be a very rough surface. Roughness values greater than 0.2 are not
@@ -48,6 +51,12 @@ class Metal(Plastic):
     """
 
     __slots__ = ()
+
+    def __init__(self, identifier, r_reflectance=0.0, g_reflectance=0.0, b_reflectance=0.0,
+                 specularity=0.9, roughness=0.0, modifier=None, dependencies=None):
+        """Create metal material."""
+        Plastic.__init__(self, identifier, r_reflectance, g_reflectance, b_reflectance,
+                         specularity, roughness, modifier, dependencies)
 
     def _update_values(self):
         "update value dictionaries."

--- a/honeybee_radiance/modifier/material/plastic.py
+++ b/honeybee_radiance/modifier/material/plastic.py
@@ -22,7 +22,7 @@ class Plastic(Material):
         b_reflectance: Reflectance for blue. The value should be between 0 and 1
             (Default: 0).
         specularity: Fraction of specularity. Specularity fractions greater than 0.1
-            are not realistic (Default: 0).
+            are not common in non-metallic materials (Default: 0).
         roughness: Roughness is specified as the rms slope of surface facets. A
             value of 0 corresponds to a perfectly smooth surface, and a value of 1
             would be a very rough surface. Roughness values greater than 0.2 are not
@@ -125,8 +125,7 @@ class Plastic(Material):
     def specularity(self):
         """Fraction of specularity.
 
-        In most cases specularity fractions greater than 0.1 are not realistic
-        (Default: 0).
+        Specularity fractions greater than 0.1 are not common in non-metallic materials.
         """
         return self._specularity
 
@@ -150,7 +149,7 @@ class Plastic(Material):
 
     @property
     def average_reflectance(self):
-        """Calculate average reflectance of plastic material."""
+        """Calculate average reflectance of the material."""
         return (0.265 * self.r_reflectance + 0.670 * self.g_reflectance +
                 0.065 * self.b_reflectance) * (1 - self.specularity) + self.specularity
 
@@ -158,7 +157,7 @@ class Plastic(Material):
     def from_single_reflectance(
         cls, identifier, rgb_reflectance=0.0, specularity=0.0, roughness=0.0,
         modifier=None, dependencies=None):
-        """Create plastic material with single reflectance value.
+        """Create material with single reflectance value.
 
         Args:
             identifier: Text string for a unique Material ID. Must not contain spaces
@@ -167,7 +166,7 @@ class Plastic(Material):
             rgb_reflectance: Reflectance for red, green and blue. The value should be
                 between 0 and 1 (Default: 0).
             specularity: Fraction of specularity. Specularity fractions greater than 0.1
-                are not realistic (Default: 0).
+                are not common in non-metallic materials (Default: 0).
             roughness: Roughness is specified as the rms slope of surface facets. A value
                 of 0 corresponds to a perfectly smooth surface, and a value of 1 would be
                 a very rough surface. Roughness values greater than 0.2 are not very
@@ -191,7 +190,7 @@ class Plastic(Material):
 
     @classmethod
     def from_primitive_dict(cls, primitive_dict):
-        """Initialize Plastic from a primitive dict.
+        """Initialize material from a primitive dict.
 
         Args:
             data: A dictionary in the format below.
@@ -200,7 +199,7 @@ class Plastic(Material):
 
             {
             "modifier": {},  # primitive modifier (Default: None)
-            "type": "plastic",  # primitive type
+            "type": string,  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
             "values": [],  # values
@@ -235,7 +234,7 @@ class Plastic(Material):
 
     @classmethod
     def from_dict(cls, data):
-        """Initialize Plastic from a dictionary.
+        """Initialize material from a dictionary.
 
         Args:
             data: A dictionary in the format below.
@@ -243,7 +242,7 @@ class Plastic(Material):
         .. code-block:: python
 
             {
-            "type": "plastic",  # Material type
+            "type": string,  # Material type
             "identifier": "",  # Material identifier
             "display_name": string  # Material display name
             "r_reflectance": float,  # Reflectance for red

--- a/honeybee_radiance/modifier/material/trans.py
+++ b/honeybee_radiance/modifier/material/trans.py
@@ -23,7 +23,7 @@ class Trans(Material):
         b_reflectance: Reflectance for blue. The value should be between 0 and 1
             (Default: 0).
         specularity: Fraction of specularity. Specularity fractions greater than 0.1
-            are not realistic (Default: 0).
+            are not common in non-metallic materials (Default: 0).
         roughness: Roughness is specified as the rms slope of surface facets. A
             value of 0 corresponds to a perfectly smooth surface, and a value of 1
             would be a very rough surface. Roughness values greater than 0.2 are not
@@ -122,8 +122,8 @@ class Trans(Material):
     def specularity(self):
         """Fraction of specularity.
 
-        In most cases specularity fractions greater than 0.1 are not realistic
-        (Default: 0).
+        In most cases specularity fractions greater than 0.1 are not common in
+        non-metallic materials (Default: 0).
         """
         return self._specularity
 
@@ -274,13 +274,13 @@ class Trans(Material):
             rgb_reflectance: Reflectance for red, green and blue. The value should be
                 between 0 and 1 (Default: 0).
             specularity: Fraction of specularity. Specularity fractions greater than 0.1
-                are not realistic (Default: 0).
+                are not common in non-metallic materials (Default: 0).
             roughness: Roughness is specified as the rms slope of surface facets. A value
                 of 0 corresponds to a perfectly smooth surface, and a value of 1 would be
                 a very rough surface. Roughness values greater than 0.2 are not very
                 realistic. (Default: 0).
             transmitted_diff: The transmitted diffuse component is the fraction of
-                transmitted light that is transmitted diffusely in as scattering fashion.
+                transmitted light that is transmitted diffusely in a scattering fashion.
             transmitted_spec: The transmitted specular component is the fraction of
                 transmitted light that is not diffusely scattered.
             modifier: Material modifier (Default: None).

--- a/tests/material_metal_test.py
+++ b/tests/material_metal_test.py
@@ -7,10 +7,10 @@ def test_metal():
     assert mt.r_reflectance == 0
     assert mt.g_reflectance == 0
     assert mt.b_reflectance == 0
-    assert mt.specularity == 0
+    assert mt.specularity == 0.9
     assert mt.roughness == 0
     assert mt.to_radiance(
-        minimal=True) == 'void metal test_metal 0 0 5 0.0 0.0 0.0 0.0 0.0'
+        minimal=True) == 'void metal test_metal 0 0 5 0.0 0.0 0.0 0.9 0.0'
 
 
 def test_assign_values():


### PR DESCRIPTION
This PR is really only tweaking the docstrings and the default specularity input for the Metal modifier so that we can say Metal is fully supported.

This commit conserves the previous implementation, where everything on the Plastic class is used to describe Metal. It's just that there were still plastic-specific docstrings that have now been tweaked to apply to both Plastic and Metal. Also, the default specularity for metal has been changed to 0.9, since 0.0 (the Plastic default) is not a realistic for metal materials.