### PR TITLE
Add sky and sun matrix

### DIFF
--- a/honeybee_radiance/lightsource/sky/__init__.py
+++ b/honeybee_radiance/lightsource/sky/__init__.py
@@ -2,3 +2,5 @@
 from .certainirradiance import CertainIrradiance
 from .cie import CIE
 from .climatebased import ClimateBased
+from .sunmatrix import SunMatrix
+from .skymatrix import SkyMatrix

--- a/honeybee_radiance/lightsource/sky/certainirradiance.py
+++ b/honeybee_radiance/lightsource/sky/certainirradiance.py
@@ -99,13 +99,19 @@ class CertainIrradiance(_PointInTime):
 
         .. code-block:: python
 
-                {
+            {
+                'type': 'CertainIrradiance',
                 'irradiance': 558.659,
                 'ground_reflectance': 0.2,
                 'ground_hemisphere': {},  # see ground.Ground class [optional],
                 'sky_hemisphere': {}  # see hemisphere.Hemisphere class [optional]
-                }
+            }
         """
+        assert 'type' in input_dict, \
+            'Input dict is missing type. Not a valid CertainIrradiance dictionary.'
+        assert input_dict['type'] == 'CertainIrradiance', \
+            'Input type must be CertainIrradiance not %s' % input_dict['type']
+
         sky = cls(
             input_dict['irradiance'],
             input_dict['ground_reflectance']
@@ -132,6 +138,7 @@ class CertainIrradiance(_PointInTime):
     def to_dict(self):
         """Translate sky to a dictionary."""
         return {
+            'type': 'CertainIrradiance',
             'irradiance': self.irradiance,
             'ground_reflectance': self.ground_reflectance,
             'ground_hemisphere': self.ground_hemisphere.to_dict(),
@@ -140,6 +147,12 @@ class CertainIrradiance(_PointInTime):
 
     def to_file(self, folder, name=None, mkdir=False):
         """Write sky hemisphere to a sky_hemisphere.rad Radiance file.
+
+        Args:
+            folder: Target folder.
+            name: File name.
+            mkdir: A boolean to note if the directory should be created if doesn't
+                exist (default: False).
 
         Returns:
             Full path to the newly created file.

--- a/honeybee_radiance/lightsource/sky/cie.py
+++ b/honeybee_radiance/lightsource/sky/cie.py
@@ -221,15 +221,22 @@ class CIE(_PointInTime):
 
         .. code-block:: python
 
-                {
+            {
+                'type': 'CIE',
                 'altitude': 0.0,
                 'azimuth': 0.0,
                 'sky_type': 0,
                 'ground_reflectance': 0.2,
                 'ground_hemisphere': {},  # see ground.Ground class [optional],
                 'sky_hemisphere': {}  # see hemisphere.Hemisphere class [optional]
-                }
+            }
+
         """
+        assert 'type' in input_dict, \
+            'Input dict is missing type. Not a valid CIE dictionary.'
+        assert input_dict['type'] == 'CIE', \
+            'Input type must be CIE not %s' % input_dict['type']
+
         sky = cls(
             input_dict['altitude'],
             input_dict['azimuth'],
@@ -261,6 +268,7 @@ class CIE(_PointInTime):
     def to_dict(self):
         """Translate sky to a dictionary."""
         return {
+            'type': 'CIE',
             'altitude': self.altitude,
             'azimuth': self.azimuth,
             'sky_type': self.sky_type,
@@ -271,6 +279,12 @@ class CIE(_PointInTime):
 
     def to_file(self, folder, name=None, mkdir=False):
         """Write sky hemisphere to a sky_hemisphere.rad Radiance file.
+
+        Args:
+            folder: Target folder.
+            name: File name.
+            mkdir: A boolean to note if the directory should be created if doesn't
+                exist (default: False).
 
         Returns:
             Full path to the newly created file.

--- a/honeybee_radiance/lightsource/sky/climatebased.py
+++ b/honeybee_radiance/lightsource/sky/climatebased.py
@@ -225,7 +225,8 @@ class ClimateBased(_PointInTime):
 
         .. code-block:: python
 
-                {
+            {
+                'type': 'ClimateBased',
                 'altitude': 0.0,
                 'azimuth': 0.0,
                 'direct_normal_irradiance': 0,
@@ -233,8 +234,14 @@ class ClimateBased(_PointInTime):
                 'ground_reflectance': 0.2,
                 'ground_hemisphere': {},  # see ground.Ground class [optional],
                 'sky_hemisphere': {}  # see hemisphere.Hemisphere class [optional]
-                }
+            }
+
         """
+        assert 'type' in input_dict, \
+            'Input dict is missing type. Not a valid ClimateBased dictionary.'
+        assert input_dict['type'] == 'ClimateBased', \
+            'Input type must be ClimateBased not %s' % input_dict['type']
+
         sky = cls(
             input_dict['altitude'],
             input_dict['azimuth'],
@@ -275,6 +282,7 @@ class ClimateBased(_PointInTime):
     def to_dict(self):
         """Translate sky to a dictionary."""
         return {
+            'type': 'ClimateBased',
             'altitude': self.altitude,
             'azimuth': self.azimuth,
             'direct_normal_irradiance': self.direct_normal_irradiance,
@@ -286,6 +294,12 @@ class ClimateBased(_PointInTime):
 
     def to_file(self, folder, name=None, mkdir=False):
         """Write sky hemisphere to a sky_hemisphere.rad Radiance file.
+
+        Args:
+            folder: Target folder.
+            name: File name.
+            mkdir: A boolean to note if the directory should be created if doesn't
+                exist (default: False).
 
         Returns:
             Full path to the newly created file.

--- a/honeybee_radiance/lightsource/sky/hemisphere.py
+++ b/honeybee_radiance/lightsource/sky/hemisphere.py
@@ -24,8 +24,7 @@ class Hemisphere(object):
     For more information see Chapter `6.3.2  Example: CIE Overcast Sky` in
     Rendering with Radiance. The chapter is also accessible online at the
     link below.
-    https://www.radiance-online.org/community/workshops/2003-berkeley/presentations/\
-Mardaljevic/rwr_ch6.pdf
+    https://www.radiance-online.org/community/workshops/2003-berkeley/presentations/Mardaljevic/rwr_ch6.pdf
 
     Properties:
         * r_emittance
@@ -93,6 +92,12 @@ Mardaljevic/rwr_ch6.pdf
 
     def to_file(self, folder='.', name=None, mkdir=False):
         """Write sky hemisphere to a sky_hemisphere.rad Radiance file.
+
+        Args:
+            folder: Target folder.
+            name: File name.
+            mkdir: A boolean to note if the directory should be created if doesn't
+                exist (default: False).
 
         Returns:
             Full path to the newly created file.

--- a/honeybee_radiance/lightsource/sky/skydome.py
+++ b/honeybee_radiance/lightsource/sky/skydome.py
@@ -2,27 +2,30 @@
 
 Here is an example of the output.
 
-#@rfluxmtx h=u u=Y
-void glow grd_glow
-0
-0
-4 1 1 1 0
+.. code-block:: shell
 
-grd_glow source ground
-0
-0
-4 0 0 -1 180
+    #@rfluxmtx h=u u=Y
+    void glow grd_glow
+    0
+    0
+    4 1 1 1 0
 
-#@rfluxmtx h=r1 u=Y
-void glow sky_glow
-0
-0
-4 1 1 1 0
+    grd_glow source ground
+    0
+    0
+    4 0 0 -1 180
 
-sky_glow source sky
-0
-0
-4 0 0 1 180
+    #@rfluxmtx h=r1 u=Y
+    void glow sky_glow
+    0
+    0
+    4 1 1 1 0
+
+    sky_glow source sky
+    0
+    0
+    4 0 0 1 180
+
 """
 
 from ._skybase import _Skydome

--- a/honeybee_radiance/lightsource/sky/skydome.py
+++ b/honeybee_radiance/lightsource/sky/skydome.py
@@ -1,0 +1,54 @@
+"""Virtual skydome for daylight coefficient studies with constant radiance.
+
+Here is an example of the output.
+
+#@rfluxmtx h=u u=Y
+void glow grd_glow
+0
+0
+4 1 1 1 0
+
+grd_glow source ground
+0
+0
+4 0 0 -1 180
+
+#@rfluxmtx h=r1 u=Y
+void glow sky_glow
+0
+0
+4 1 1 1 0
+
+sky_glow source sky
+0
+0
+4 0 0 1 180
+"""
+
+from ._skybase import _Skydome
+import honeybee.typing as typing
+
+
+class Skydome(_Skydome):
+    """Virtual skydome for daylight coefficient studies with constant radiance.
+
+    Use this sky to calculate daylight matrix.
+    """
+
+    def to_radiance(self, density=1):
+        """Radiance definition for Skydome.
+
+        Args:
+            density: Sky patch subdivision density. This values is similar to -m option
+                in gendaymtx command. Default is 1 which means 145 sky patches and 1
+                patch for the ground.
+
+                One can add to the resolution typically by factors of two (2, 4, 8, ...)
+                which yields a higher resolution sky using the Reinhart patch subdivision
+                For example, setting density to 4 yields a sky with 2305 patches plus one
+                patch for the ground.
+        """
+        density = typing.int_in_range(density, 1, input_name='Sky subdivision density')
+        return '#@rfluxmtx h=u u=Y\n%s\n\n#@rfluxmtx h=r%d u=Y\n%s\n' % (
+            self.sky_hemisphere, density, self.ground_hemisphere
+        )

--- a/honeybee_radiance/lightsource/sky/skymatrix.py
+++ b/honeybee_radiance/lightsource/sky/skymatrix.py
@@ -1,0 +1,163 @@
+"""Generate a point-in-time climate-based sky."""
+from __future__ import division
+
+from .sunmatrix import SunMatrix
+import honeybee.typing as typing
+from ladybug.wea import Wea
+
+
+class SkyMatrix(SunMatrix):
+    """Annual Climate-based Sky matrix.
+
+    The output of SkyMatrix is similar to using command Radiance's gendaymtx command with
+    default options. For more information see gendaymtx documentation.
+
+    https://www.radiance-online.org/learning/documentation/manual-pages/pdfs/gendaymtx.pdf
+
+    Args:
+        wea: A Ladybug wea object.
+        north: A number between -360 and 360 for the counterclockwise difference between
+            the North and the positive Y-axis in degrees. 90 is West and 270 is East
+            (Default: 0)
+        density: Sky patch subdivision density. This values is similar to -m option
+            in gendaymtx command. Default is 1 which means 145 sky patches and 1
+            patch for the ground.
+
+            One can add to the resolution typically by factors of two (2, 4, 8, ...)
+            which yields a higher resolution sky using the Reinhart patch subdivision
+            For example, setting density to 4 yields a sky with 2305 patches plus one
+            patch for the ground.
+
+    Properties:
+        * wea
+        * location
+        * north
+        * is_point_in_time
+        * is_climate_based
+    """
+
+    __slots__ = ('_density',)
+
+    def __init__(self, wea, north=0, density=1):
+        """Create a climate-based sky matrix."""
+        SunMatrix.__init__(self, wea, north)
+        self.density = density
+
+    @property
+    def density(self):
+        """Set and get sky patch subdivision density.
+
+        This values is similar to -m option in gendaymtx command. Default is 1 which
+        means 145 sky patches and 1 patch for the ground.
+
+        One can add to the resolution typically by factors of two (2, 4, 8, ...) which
+        yields a higher resolution sky using the Reinhart patch subdivision. For example,
+        setting density to 4 yields a sky with 2305 patches plus one patch for the
+        ground.
+        """
+        return self._density
+
+    @density.setter
+    def density(self, value):
+        typing.int_in_range(value, 1, input_name='SkyMatrix subdivision density')
+        self._density = value
+
+    @classmethod
+    def from_dict(cls, input_dict):
+        """Create the sky from a dictionary.
+
+        Args:
+            input_dict: A python dictionary in the following format
+
+        .. code-block:: python
+
+                {
+                'type': 'SkyMatrix',
+                'wea': {},
+                'north': 0.0  # optional
+                'density': 1  # optional
+                }
+        """
+        if 'type' not in input_dict or input_dict['type'] != 'SkyMatrix':
+            raise ValueError('Input dict "type" must be "SkyMatrix".')
+        if 'north' in input_dict:
+            north = input_dict['north']
+        else:
+            north = 0
+        if 'density' in input_dict:
+            density = input_dict['density']
+        else:
+            density = 1
+
+        sky = cls(Wea.from_dict(input_dict['wea']), north, density)
+
+        return sky
+
+    # TODO: add support for additional parameters
+    # TODO: add gendaymtx to radiance-command and use it for validating inputs
+    def to_radiance(
+            self, output_type=0, wea_file=None, output_name=None, cumulative=False,
+            components=0):
+        """Return Radiance command to generate the sky.
+
+        Note that you need to write the wea to a file (in.wea) before running this
+        command.
+
+        Alternatively you can use write method which will write the wea data to a file.
+
+        Args:
+            output_type: An integer between 0 to 1 for output type.
+                * 0 = output in W/m2/sr visible (default)
+                * 1 = output in W/m2/sr solar
+            wea_file: Path to wea file (default: in.wea).
+            output_name: A name for output files (default: sky_mtx).
+            cumulative: A boolean to generate cumulative sky. This option is only
+                available in Radiance 5.3 and higher versions (default: False).
+            components: An integer between 0-2 to note the distribution of which
+                components should be included. 0 might be used to include both solar and
+                sky contribution. 1 may be used to produce a sun-only matrix, with no sky
+                contributions.  Alternatively, 2 may be used to exclude any direct solar
+                component from the output.  If there is a sun in the description,
+                gendaymtx will include its contribution in the four nearest sky patches,
+                distributing energy according to centroid proximity (default: 0).
+        """
+        output_type = typing.int_in_range(output_type, 0, 1, 'SkyMatrix output type')
+        wea_file = wea_file or 'in.wea'
+        output_name = output_name or 'sky'
+
+        options = ['-O{}'.format(output_type)]
+        if self.density != 1:
+            options.append('-m %d' % self.density)
+        if self.north != 0:
+            options.append('-r {}'.format(self.north))
+        if cumulative:
+            options.append('-A')
+        if components == 1:
+            # sun-only
+            options.append('-d')
+        elif components == 2:
+            # sky only
+            options.append('-s')
+        options.append(wea_file)
+        # add all the other options here
+        command = 'gendaymtx {0} > {1}.mtx'.format(' '.join(options), output_name)
+
+        return command
+
+    def to_dict(self):
+        """Translate this matrix to a dictionary."""
+
+        return {
+            'type': 'SkyMatrix',
+            'wea': self.wea.to_dict(),
+            'north': self.north,
+            'density': self.density
+        }
+
+    def __eq__(self, value):
+        if type(value) != type(self) \
+            or value.wea != self.wea \
+            or value.north != self.north \
+                or value.density != self.density:
+            return False
+        return True

--- a/honeybee_radiance/lightsource/sky/skymatrix.py
+++ b/honeybee_radiance/lightsource/sky/skymatrix.py
@@ -114,12 +114,12 @@ class SkyMatrix(SunMatrix):
             cumulative: A boolean to generate cumulative sky. This option is only
                 available in Radiance 5.3 and higher versions (default: False).
             components: An integer between 0-2 to note the distribution of which
-                components should be included. 0 might be used to include both solar and
+                components should be included. 0 might be used to include both sun and
                 sky contribution. 1 may be used to produce a sun-only matrix, with no sky
-                contributions.  Alternatively, 2 may be used to exclude any direct solar
-                component from the output.  If there is a sun in the description,
-                gendaymtx will include its contribution in the four nearest sky patches,
-                distributing energy according to centroid proximity (default: 0).
+                contributions.  Alternatively, 2 may be used to exclude any sun component
+                from the output.  If there is a sun in the description, gendaymtx will
+                include its contribution in the four nearest sky patches, distributing
+                energy according to centroid proximity (default: 0).
         """
         output_type = typing.int_in_range(output_type, 0, 1, 'SkyMatrix output type')
         wea_file = wea_file or 'in.wea'

--- a/honeybee_radiance/lightsource/sky/sunmatrix.py
+++ b/honeybee_radiance/lightsource/sky/sunmatrix.py
@@ -1,0 +1,192 @@
+"""Generate a point-in-time climate-based sky."""
+from __future__ import division
+import honeybee.typing as typing
+import ladybug.futil as futil
+from ladybug.wea import Wea
+import os
+
+
+class SunMatrix(object):
+    """Annual Climate-based Sun matrix.
+
+    The output of SkyMatrix is similar to using command Radiance's gendaymtx command with
+    ``-n -D`` options. The options are available in Radiance 5.3 and after that. For more
+    information see gendaymtx documentation.
+
+    https://www.radiance-online.org/learning/documentation/manual-pages/pdfs/gendaymtx.pdf
+
+    Args:
+        wea: A Ladybug wea object.
+        north: A number between -360 and 360 for the counterclockwise difference between
+            the North and the positive Y-axis in degrees. 90 is West and 270 is East
+            (Default: 0)
+
+    Properties:
+        * wea
+        * location
+        * north
+        * is_point_in_time
+        * is_climate_based
+    """
+
+    __slots__ = ('_wea', '_north')
+
+    def __init__(self, wea, north=0):
+        """Create a climate-based sun matrix."""
+        self.wea = wea
+        self.north = north
+
+    @property
+    def wea(self):
+        """Get and set wea."""
+        return self._wea
+
+    @wea.setter
+    def wea(self, value):
+        assert isinstance(value, Wea), \
+            'wea must be from type Wea not {}'.format(type(value))
+        self._wea = value
+
+    @property
+    def north(self):
+        """Get and set north direction.
+
+        A number between -360 and 360 for the counterclockwise difference between
+        the North and the positive Y-axis in degrees. 90 is West and 270 is East.
+        """
+        return self._north
+
+    @north.setter
+    def north(self, value):
+        value = typing.float_in_range(value, -360, +360, 'Skymatrix north')
+        self._north = value
+
+    @property
+    def is_climate_based(self):
+        """Return True if the sky is created based on values from weather data."""
+        return True
+
+    @property
+    def is_point_in_time(self):
+        """Return True if the sky is generated for a single point in time."""
+        return False
+
+    @property
+    def location(self):
+        """Location information for sky matrix."""
+        return self.wea.location
+
+    @classmethod
+    def from_dict(cls, input_dict):
+        """Create the sky from a dictionary.
+
+        Args:
+            input_dict: A python dictionary in the following format
+
+        .. code-block:: python
+
+            {
+                'type': 'SunMatrix',
+                'wea': {},
+                'north': 0.0  # optional
+            }
+        """
+        if 'type' not in input_dict or input_dict['type'] != 'SunMatrix':
+            raise ValueError('Input dict "type" must be "SunMatrix".')
+        if 'north' in input_dict:
+            sky = cls(Wea.from_dict(input_dict['wea']), input_dict['north'])
+        else:
+            sky = cls(input_dict['wea'])
+
+        return sky
+
+    # TODO: add support for additional parameters
+    # TODO: add gendaymtx to radiance-command and use it for validating inputs
+    def to_radiance(self, output_type=1, wea_file=None, output_name=None):
+        """Return Radiance command to generate the sky.
+
+        Note that you need to write the wea to a file (in.wea) before running this
+        command.
+
+        Alternatively you can use write method which will write the wea data to a file.
+
+        Args:
+            output_type: An integer between 0 to 2 for output type.
+                * 0 = output in W/m2/sr visible
+                * 1 = output in W/m2/sr solar (default)
+            wea_file: Path to wea file (default: in.wea).
+            output_name: A name for output files (default: suns).
+        """
+        output_type = typing.int_in_range(output_type, 0, 1, 'SunMatrix output type')
+        wea_file = wea_file or 'in.wea'
+        output_name = output_name or 'suns'
+        if self.north == 0:
+            command = 'gendaymtx -n -D {0}.mtx -M {0}.mod -O{1} {2}'.format(
+                output_name, output_type, wea_file
+            )
+        else:
+            command = 'gendaymtx -n -D {0}.mtx -M {0}.mod -O{1} -r {3} {2}'.format(
+                output_name, output_type, wea_file, self.north
+            )
+
+        return command
+
+    def to_dict(self):
+        """Translate this matrix to a dictionary."""
+
+        return {
+            'type': 'SunMatrix',
+            'wea': self.wea.to_dict(),
+            'north': self.north
+        }
+
+    def write_wea(self, folder='.', name=None, hoys=None):
+        """Write wea to a file.
+
+        Args:
+            folder: Path to target folder (default: '.').
+            name: Optional name for wea file (default: in.wea)
+            hoys: Optional list of hoys to filter the annual hours. If None it will
+                generate an annual wea file.
+
+        Returns:
+            Path to wea file.
+        """
+        name = name or 'in.wea'
+        file_path = os.path.join(folder, name)
+        return self.wea.write(file_path=file_path, hoys=hoys)
+
+    def to_file(self, folder, name=None, hoys=None, mkdir=False):
+        """Write matrix to a Radiance file.
+
+        This method also writes the wea information to a wea file.
+
+        Args:
+            folder: Target folder.
+            name: File name.
+            mkdir: A boolean to note if the directory should be created if doesn't
+                exist (default: False).
+
+        Returns:
+            Full path to the newly created file.
+        """
+        name = typing.valid_string(name) if name \
+            else '%s.rad' % self.__class__.__name__.lower()
+        # write wea file first
+        wea_file = self.write_wea(folder, hoys=hoys)
+        content = self.to_radiance(wea_file=os.path.split(wea_file)[-1])
+        return futil.write_to_file_by_name(folder, name, '!' + content, mkdir)
+
+    def __eq__(self, value):
+        if type(value) != type(self) \
+            or value.wea != self.wea \
+                or value.north != self.north:
+            return False
+        return True
+
+    def __ne__(self, value):
+        return not self.__eq__(value)
+
+    def __repr__(self):
+        """Matrix representation."""
+        return '%s: %s' % (self.__class__.__name__, self.wea.location.city)

--- a/honeybee_radiance/lightsource/sky/sunmatrix.py
+++ b/honeybee_radiance/lightsource/sky/sunmatrix.py
@@ -111,7 +111,7 @@ class SunMatrix(object):
         Alternatively you can use write method which will write the wea data to a file.
 
         Args:
-            output_type: An integer between 0 to 2 for output type.
+            output_type: An integer between 0 to 1 for output type.
                 * 0 = output in W/m2/sr visible
                 * 1 = output in W/m2/sr solar (default)
             wea_file: Path to wea file (default: in.wea).
@@ -164,6 +164,8 @@ class SunMatrix(object):
         Args:
             folder: Target folder.
             name: File name.
+            hoys: Optional list of hoys to filter the annual hours. If None it will
+                generate an annual wea file.
             mkdir: A boolean to note if the directory should be created if doesn't
                 exist (default: False).
 
@@ -178,7 +180,7 @@ class SunMatrix(object):
         return futil.write_to_file_by_name(folder, name, '!' + content, mkdir)
 
     def __eq__(self, value):
-        if type(value) != type(self) \
+        if not isinstance(value, self.__class__) \
             or value.wea != self.wea \
                 or value.north != self.north:
             return False

--- a/tests/sky_mtx_test.py
+++ b/tests/sky_mtx_test.py
@@ -1,0 +1,63 @@
+from honeybee_radiance.lightsource.sky import SkyMatrix
+from ladybug.wea import Wea
+import os
+
+
+def test_check_defaults():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sky_mtx = SkyMatrix(wea)
+    assert sky_mtx.wea == wea
+    assert sky_mtx.north == 0
+    assert sky_mtx.density == 1
+    assert sky_mtx.location == wea.location
+    sky_mtx_radiance = sky_mtx.to_radiance()
+    # gendaymtx -O0 in.wea > sky.mtx
+    assert '> sky.mtx' in sky_mtx_radiance
+    assert '-O0 in.wea' in sky_mtx_radiance
+    assert sky_mtx.is_climate_based is True
+    assert sky_mtx.is_point_in_time is False
+
+
+def test_north():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sky_mtx = SkyMatrix(wea, 120)
+    assert sky_mtx.north == 120
+    assert '-r 120' in sky_mtx.to_radiance()
+
+
+def tets_to_radiance_options():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sky_mtx = SkyMatrix(wea, density=4)
+    assert '-m 4' in sky_mtx.to_radiance()
+    assert '-O1' in sky_mtx.to_radiance(output_type=1)
+    assert '-A' in sky_mtx.to_radiance(cumulative=True)
+    assert '-d' in sky_mtx.to_radiance(components=1)
+    assert '-s' in sky_mtx.to_radiance(components=2)
+
+def test_to_and_from_dict():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sky_mtx = SkyMatrix(wea)
+    sky_mtx_from_dict = sky_mtx.from_dict(sky_mtx.to_dict())
+
+    # update this once Wea class has equality method implemeneted
+    assert sky_mtx.wea.location == sky_mtx_from_dict.wea.location
+    assert sky_mtx.wea.direct_normal_irradiance.values == \
+        sky_mtx_from_dict.wea.direct_normal_irradiance.values
+    assert sky_mtx.wea.direct_normal_irradiance.datetimes == \
+        sky_mtx_from_dict.wea.direct_normal_irradiance.datetimes
+
+
+def test_to_file():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sky_mtx = SkyMatrix(wea)
+    sky_mtx_file = sky_mtx.to_file('./tests/assets/temp', mkdir=True)
+    assert os.path.isfile(sky_mtx_file)
+    with open(sky_mtx_file, 'r') as skyf:
+        content = skyf.read()
+
+    assert sky_mtx.to_radiance() in str(content)

--- a/tests/sun_mtx_test.py
+++ b/tests/sun_mtx_test.py
@@ -1,0 +1,59 @@
+from honeybee_radiance.lightsource.sky import SunMatrix
+from ladybug.wea import Wea
+import os
+
+
+def test_check_defaults():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sun_mtx = SunMatrix(wea)
+    assert sun_mtx.wea == wea
+    assert sun_mtx.north == 0
+    assert sun_mtx.location == wea.location
+    sun_mtx_radiance = sun_mtx.to_radiance()
+    assert 'gendaymtx -n -D suns.mtx' in sun_mtx_radiance
+    assert '-M suns.mod' in sun_mtx_radiance
+    assert '-O1 in.wea' in sun_mtx_radiance
+    assert sun_mtx.is_climate_based is True
+    assert sun_mtx.is_point_in_time is False
+
+
+def test_north():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sun_mtx = SunMatrix(wea, 120)
+    assert sun_mtx.north == 120
+    assert '-r 120' in sun_mtx.to_radiance()
+
+
+def tets_to_radiance_options():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sun_mtx = SunMatrix(wea)
+    assert '-O0' in sun_mtx.to_radiance(output_type=0)
+
+
+def test_to_and_from_dict():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sun_mtx = SunMatrix(wea)
+    sun_mtx_from_dict = sun_mtx.from_dict(sun_mtx.to_dict())
+
+    # update this once Wea class has equality method implemeneted
+    assert sun_mtx.wea.location == sun_mtx_from_dict.wea.location
+    assert sun_mtx.wea.direct_normal_irradiance.values == \
+        sun_mtx_from_dict.wea.direct_normal_irradiance.values
+    assert sun_mtx.wea.direct_normal_irradiance.datetimes == \
+        sun_mtx_from_dict.wea.direct_normal_irradiance.datetimes
+
+
+def test_to_file():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sun_mtx = SunMatrix(wea)
+    sun_mtx_file = sun_mtx.to_file('./tests/assets/temp', mkdir=True)
+    assert os.path.isfile(sun_mtx_file)
+    with open(sun_mtx_file, 'r') as skyf:
+        content = skyf.read()
+
+    assert sun_mtx.to_radiance() in str(content)


### PR DESCRIPTION
This PR adds skymtx and sunmtx classes. I decided not to create a daylightmtx class as the separation is actually really helpful to keep the `to_radiance` method clean and clear.

The PR also improves documentation of other sky modules.