### PR TITLE
feat(stategeo): Add StateGeometry class to handle state-assigned shades

### DIFF
--- a/honeybee_radiance/dynamic/__init__.py
+++ b/honeybee_radiance/dynamic/__init__.py
@@ -1,0 +1,5 @@
+"""Objects for creating and exporting dynamic geometry."""
+
+from .group import DynamicShadeGroup, DynamicSubFaceGroup
+from .state import RadianceShadeState, RadianceSubFaceState
+from .stategeo import StateGeometry

--- a/honeybee_radiance/dynamic/group.py
+++ b/honeybee_radiance/dynamic/group.py
@@ -2,7 +2,7 @@
 """Object representing a group of sub-faces or shades that change states in unison."""
 from __future__ import division
 
-from ..state import RadianceShadeState, RadianceSubFaceState
+from .state import RadianceShadeState, RadianceSubFaceState
 from ..geometry import Polygon
 from ..modifier.material import BSDF
 from ..lib.modifiers import white_glow
@@ -167,16 +167,16 @@ class DynamicShadeGroup(object):
                 if not self._instance_in_array(mod, modifiers):
                     modifiers.append(mod)
                 for shd in state._shades:
-                    mod = shd.properties.radiance.modifier
+                    mod = shd.modifier
                     if not self._instance_in_array(mod, modifiers):
                         modifiers.append(mod)
-        else:  # use modifier_direct and modifier_blk
+        else:  # use modifier_direct
             for state in states:
                 mod = state.modifier_direct
                 if not self._instance_in_array(mod, modifiers):
                     modifiers.append(mod)
                 for shd in state._shades:
-                    mod = shd.properties.radiance.modifier_blk
+                    mod = shd.modifier_direct
                     if not self._instance_in_array(mod, modifiers):
                         modifiers.append(mod)
         modifiers = list(set(modifiers))

--- a/honeybee_radiance/dynamic/stategeo.py
+++ b/honeybee_radiance/dynamic/stategeo.py
@@ -1,0 +1,352 @@
+# coding: utf-8
+"""Dynamic geometry that can be assigned to individual states."""
+from ..modifier import Modifier
+from ..geometry import Polygon
+from ..mutil import dict_to_modifier  # imports all modifiers classes
+from ..lib.modifiers import black, generic_exterior_shade
+
+from honeybee.typing import valid_rad_string
+from ladybug_geometry.geometry3d.pointvector import Point3D
+from ladybug_geometry.geometry3d.face import Face3D
+
+import math
+
+
+class StateGeometry(object):
+    """A single planar geometry that can be assigned to Radiance states.
+
+    Args:
+        identifier: Text string for a unique geometry ID. Must not contain any
+            spaces or special characters.
+        geometry: A ladybug-geometry Face3D.
+        modifier: A Honeybee Radiance Modifier object for the geometry. If None,
+            it will be the Generic Exterior Shade modifier in the lib. (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * geometry
+        * modifier
+        * modifier_direct
+        * parent
+        * has_parent
+        * vertices
+        * normal
+        * center
+        * area
+    """
+    __slots__ = ('_identifier', '_display_name', '_geometry', '_modifier',
+                 '_modifier_direct', '_parent')
+
+    def __init__(self, identifier, geometry, modifier=None):
+        """Initialize StateGeometry."""
+        # process the identifier
+        self._identifier = valid_rad_string(identifier, 'state geometry identifier')
+        self._display_name = self._identifier
+        # process the geometry
+        assert isinstance(geometry, Face3D), \
+            'Expected ladybug_geometry Face3D. Got {}'.format(type(geometry))
+        self._geometry = geometry
+        # process the modifier
+        self.modifier = modifier
+        self._modifier_direct = None
+        self._parent = None  # _parent will be set when the Geo is added to a state
+
+    @classmethod
+    def from_dict(cls, data):
+        """Initialize a StateGeometry from a dictionary.
+
+        Note that the dictionary must be a non-abridged version for this
+        classmethod to work.
+
+        Args:
+            data: A dictionary representation of an StateGeometry with the
+                format below.
+
+        .. code-block:: python
+
+            {
+            'type': 'StateGeometry',
+            'identifier': str,  # Text for the unique object identifier
+            'display_name': str,  # Optional text for the display name
+            'geometry': {},  # A ladybug_geometry Face3D dictionary
+            'modifier': {},  # A Honeybee Radiance Modifier dictionary
+            'modifier_direct': {}  # A Honeybee Radiance Modifier dictionary
+            }
+        """
+        # check the type of dictionary
+        assert data['type'] == 'StateGeometry', 'Expected StateGeometry dictionary. ' \
+            'Got {}.'.format(data['type'])
+        geo = cls(data['identifier'], Face3D.from_dict(data['geometry']))
+
+        if 'modifier' in data and data['modifier'] is not None:
+            geo.modifier = dict_to_modifier(data['modifier'])
+        if 'modifier_direct' in data and data['modifier_direct'] is not None:
+            geo.modifier_direct = dict_to_modifier(data['modifier_direct'])
+        if 'display_name' in data and data['display_name'] is not None:
+            geo.display_name = data['display_name']
+        return geo
+
+    @classmethod
+    def from_dict_abridged(cls, data, modifiers):
+        """Create StateGeometry from an abridged dictionary.
+
+        Args:
+            data: A dictionary representation of StateGeometryAbridged with
+                the format below.
+            modifiers: A dictionary of modifiers with modifier identifiers as keys,
+                which will be used to re-assign modifiers.
+
+        .. code-block:: python
+
+            {
+            'type': 'StateGeometryAbridged',
+            'identifier': str,  # Text for the unique object identifier
+            'display_name': str,  # Optional text for the display name
+            'geometry': {},  # A ladybug_geometry Face3D dictionary
+            'modifier': str  # A Honeybee Radiance Modifier identifier
+            'modifier_direct': str  # A Honeybee Radiance Modifier identifier
+            }
+        """
+        # check the type of dictionary
+        assert data['type'] == 'StateGeometryAbridged', \
+            'Expected StateGeometryAbridged dictionary. Got {}.'.format(data['type'])
+        geo = cls(data['identifier'], Face3D.from_dict(data['geometry']))
+
+        if 'modifier' in data and data['modifier'] is not None:
+            geo.modifier = modifiers[data['modifier']]
+        if 'modifier_direct' in data and data['modifier_direct'] is not None:
+            geo.modifier_direct = modifiers[data['modifier_direct']]
+        if 'display_name' in data and data['display_name'] is not None:
+            geo.display_name = data['display_name']
+        return geo
+
+    @classmethod
+    def from_vertices(cls, identifier, vertices, modifier=None):
+        """Create StateGeometry from vertices with each vertex as an iterable of 3 floats.
+
+        Note that this method is not recommended for a geometry with one or more holes
+        since the distinction between hole vertices and boundary vertices cannot
+        be derived from a single list of vertices.
+
+        Args:
+            identifier: Text string for a unique geometry ID. Must not contain any
+                spaces or special characters.
+            vertices: A flattened list of 3 or more vertices as (x, y, z).
+            modifier: A Honeybee Radiance Modifier object for the geometry. If None, it
+                will be the Generic Exterior Shade modifier in the lib. (Default: None).
+        """
+        geometry = Face3D(tuple(Point3D(*v) for v in vertices))
+        return cls(identifier, geometry, modifier)
+
+    @property
+    def identifier(self):
+        """Get a text string for the unique object identifer.
+    
+        This identifier remains constant as the object is mutated, copied, and
+        serialized to different formats (eg. dict, idf, rad). As such, this
+        property is used to reference the object across a Model.
+        """
+        return self._identifier
+
+    @property
+    def display_name(self):
+        """Get or set a string for the object name without any character restrictions.
+
+        If not set, this will be equal to the identifier.
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, value):
+        try:
+            self._display_name = str(value)
+        except UnicodeEncodeError:  # Python 2 machine lacking the character set
+            self._display_name = value  # keep it as unicode
+
+    @property
+    def geometry(self):
+        """Get a ladybug_geometry Face3D object representing the Shade."""
+        return self._geometry
+
+    @property
+    def modifier(self):
+        """Get or set the object modifier."""
+        if self._modifier:  # set by user
+            return self._modifier
+        return generic_exterior_shade
+
+    @modifier.setter
+    def modifier(self, value):
+        if value is not None:
+            assert isinstance(value, Modifier), \
+                'Expected Radiance Modifier for shade. Got {}'.format(type(value))
+            value.lock()  # lock editing in case modifier has multiple references
+        self._modifier = value
+
+    @property
+    def modifier_direct(self):
+        """Get or set a modifier to be used in direct solar studies.
+
+        If None, this will be a completely black material if the object's modifier is
+        opaque and will be equal to the modifier if the object's modifier is non-opaque.
+        """
+        if self._modifier_direct:  # set by user
+            return self._modifier_direct
+        mod = self.modifier  # assign a default based on whether the modifier is opaque
+        if mod.is_void or mod.is_opaque:
+            return black
+        else:
+            return mod
+
+    @modifier_direct.setter
+    def modifier_direct(self, value):
+        if value is not None:
+            assert isinstance(value, Modifier), \
+                'Expected Radiance Modifier. Got {}'.format(type(value))
+            value.lock()  # lock editing in case modifier has multiple references
+        self._modifier_direct = value
+
+    @property
+    def is_opaque(self):
+        """Boolean noting whether this geomtry has an opaque modifier."""
+        return True if self.modifier.is_void else self.modifier.is_opaque
+
+    @property
+    def parent(self):
+        """Get the parent State if assigned. None if not assigned."""
+        return self._parent
+
+    @property
+    def has_parent(self):
+        """Get a boolean noting whether this StateGeometry has a parent State."""
+        return self._parent is not None
+
+    @property
+    def vertices(self):
+        """Get a list of vertices for the geometry (in counter-clockwise order)."""
+        return self._geometry.vertices
+
+    @property
+    def normal(self):
+        """Get a ladybug_geometry Vector3D for the direction the geometry is pointing.
+        """
+        return self._geometry.normal
+
+    @property
+    def center(self):
+        """Get a ladybug_geometry Point3D for the center of the geometry.
+
+        Note that this is the center of the bounding rectangle around this geometry
+        and not the area centroid.
+        """
+        return self._geometry.center
+
+    @property
+    def area(self):
+        """Get the area of the geometry."""
+        return self._geometry.area
+
+    def move(self, moving_vec):
+        """Move this StateGeometry along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the face.
+        """
+        self._geometry = self.geometry.move(moving_vec)
+
+    def rotate(self, axis, angle, origin):
+        """Rotate this StateGeometry by a certain angle around an axis and origin.
+
+        Args:
+            axis: A ladybug_geometry Vector3D axis representing the axis of rotation.
+            angle: An angle for rotation in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
+
+    def rotate_xy(self, angle, origin):
+        """Rotate this StateGeometry counterclockwise in the XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
+
+    def reflect(self, plane):
+        """Reflect this StateGeometry across a plane.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        self._geometry = self.geometry.reflect(plane.n, plane.o)
+
+    def scale(self, factor, origin=None):
+        """Scale this StateGeometry by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        self._geometry = self.geometry.scale(factor, origin)
+
+    def to_dict(self, abridged=False):
+        """Return StateGeometry as a dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+        """
+        # assign required properties
+        base = {'type': 'StateGeometryAbridged'} if abridged else \
+            {'type': 'StateGeometry'}
+        base['identifier'] = self.identifier
+        base['display_name'] = self.display_name
+        base['geometry'] = self.geometry.to_dict()
+
+        # assign optional properties
+        if self._modifier:
+            base['modifier'] = self._modifier.identifier if abridged else \
+                self._modifier.to_dict()
+        if self._modifier_direct is not None:
+            base['modifier_direct'] = self._modifier_direct.identifier if abridged \
+                else self._modifier.to_dict()
+        return base
+
+    def to_radiance(self, direct=False, minimal=False):
+        """Generate a RAD string representation of this StateGeometry.
+
+        Note that the resulting string lacks modifiers.
+
+        Args:
+            direct: Boolean to note whether to write the "direct" version of the
+                state, which will have the modifier_direct applied. (Default: False)
+            minimal: Boolean to note whether the radiance string should be written
+                in a minimal format (with spaces instead of line breaks). Default: False.
+        """
+        modifier = self.modifier_direct if direct else self.modifier
+        base_poly = Polygon(self.identifier, self.vertices, modifier)
+        return base_poly.to_radiance(minimal, False, False)
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def __copy__(self):
+        new_geo = StateGeometry(self.identifier, self.geometry, self._modifier)
+        new_geo._modifier_direct = self._modifier_direct
+        new_geo._display_name = self.display_name
+        return new_geo
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return 'StateGeometry: %s' % self.display_name

--- a/honeybee_radiance/properties/_base.py
+++ b/honeybee_radiance/properties/_base.py
@@ -2,7 +2,7 @@
 """Base class of Radiance Properties for all planar geometry objects."""
 from ..modifier import Modifier
 from ..mutil import dict_to_modifier  # imports all modifiers classes
-from ..state import _RadianceState
+from ..dynamic.state import _RadianceState
 from ..lib.modifiers import black
 
 from honeybee.typing import valid_rad_string

--- a/honeybee_radiance/properties/aperture.py
+++ b/honeybee_radiance/properties/aperture.py
@@ -2,7 +2,7 @@
 """Aperture Radiance Properties."""
 from ._base import _DynamicRadianceProperties
 from ..modifier import Modifier
-from ..state import RadianceSubFaceState
+from ..dynamic.state import RadianceSubFaceState
 from ..lib.modifiers import black
 from ..lib.modifiersets import generic_modifier_set_visible
 

--- a/honeybee_radiance/properties/door.py
+++ b/honeybee_radiance/properties/door.py
@@ -2,7 +2,7 @@
 """Door Radiance Properties."""
 from ._base import _DynamicRadianceProperties
 from ..modifier import Modifier
-from ..state import RadianceSubFaceState
+from ..dynamic.state import RadianceSubFaceState
 from ..lib.modifiers import black
 from ..lib.modifiersets import generic_modifier_set_visible
 

--- a/honeybee_radiance/properties/model.py
+++ b/honeybee_radiance/properties/model.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Model Radiance Properties."""
-from .dynamic import DynamicShadeGroup, DynamicSubFaceGroup
+from ..dynamic.group import DynamicShadeGroup, DynamicSubFaceGroup
 from ..modifierset import ModifierSet
 from ..mutil import dict_to_modifier  # imports all modifiers classes
 from ..modifier.material import BSDF
@@ -526,7 +526,7 @@ class ModelRadianceProperties(object):
                 modifiers.append(mod)
         for st in obj.properties.radiance._states:
             stm = (st._modifier, st._modifier_direct) + \
-                tuple(s.properties.radiance.modifier for s in st._shades)
+                tuple(s.modifier for s in st._shades)
             for mod in stm:
                 if mod is not None:
                     if not self._instance_in_array(mod, modifiers):
@@ -548,7 +548,7 @@ class ModelRadianceProperties(object):
                 modifiers.append(mod)
         for st in obj.properties.radiance._states:
             for s in st._shades:
-                mod = s.properties.radiance.modifier
+                mod = s.modifier
                 if mod is not None:
                     if not self._instance_in_array(mod, modifiers):
                         modifiers.append(mod)
@@ -564,7 +564,7 @@ class ModelRadianceProperties(object):
                 modifiers.append(generic_context)
         for st in obj.properties.radiance._states:
             stm = (st._modifier, st._modifier_direct) + \
-                tuple(s.properties.radiance.modifier for s in st._shades)
+                tuple(s.modifier for s in st._shades)
             for mod in stm:
                 if mod is not None:
                     if not self._instance_in_array(mod, modifiers):

--- a/honeybee_radiance/properties/shade.py
+++ b/honeybee_radiance/properties/shade.py
@@ -2,8 +2,8 @@
 """Shade Radiance Properties."""
 from ._base import _DynamicRadianceProperties
 from ..modifier import Modifier
-from ..state import _RadianceState, RadianceShadeState
-from ..lib.modifiers import generic_context, generic_exterior_shade
+from ..dynamic.state import RadianceShadeState
+from ..lib.modifiers import generic_context
 from ..lib.modifiersets import generic_modifier_set_visible
 
 
@@ -59,8 +59,6 @@ class ShadeRadianceProperties(_DynamicRadianceProperties):
             return self._modifier
         elif not self._host.has_parent:  # orphaned shade
             return generic_context
-        elif isinstance(self._host._parent, _RadianceState):  # radiance state parent
-            return generic_exterior_shade
         else:  # shade with a parent modifier set
             m_set = self._parent_modifier_set(self._host.parent)
             if m_set is None:

--- a/honeybee_radiance/sensorgrid.py
+++ b/honeybee_radiance/sensorgrid.py
@@ -49,11 +49,14 @@ class SensorGrid(object):
         .. code-block:: python
 
             {
+            "type": "SensorGrid",
             "identifier": str,  # SensorGrid identifier
             "display_name": str,  # SensorGrid display name
             "sensors": []  # list of Sensor dictionaries
             }
         """
+        assert ag_dict['type'] == 'SensorGrid', \
+            'Expected SensorGrid dictionary. Got {}.'.format(ag_dict['type'])
         sensors = (Sensor.from_dict(sensor) for sensor in ag_dict['sensors'])
         new_obj = cls(identifier=ag_dict["identifier"], sensors=sensors)
         if 'display_name' in ag_dict and ag_dict['display_name'] is not None:
@@ -275,8 +278,9 @@ class SensorGrid(object):
     def to_dict(self):
         """Convert SensorGrid to a dictionary."""
         base = {
-            "identifier": self.identifier,
-            "sensors": [sen.to_dict() for sen in self.sensors]
+            'type': 'SensorGrid',
+            'identifier': self.identifier,
+            'sensors': [sen.to_dict() for sen in self.sensors]
         }
         if self._display_name is not None:
             base['display_name'] = self.display_name

--- a/honeybee_radiance/view.py
+++ b/honeybee_radiance/view.py
@@ -32,7 +32,7 @@ class View(object):
             * 0 - Perspective (v)
             * 1 - Hemispherical fisheye (h)
             * 2 - Parallel (l)
-            * 3 - Cylindrical panoroma (c)
+            * 3 - Cylindrical panorama (c)
             * 4 - Angular fisheye (a)
             * 5 - Planisphere [stereographic] projection (s)
 
@@ -160,7 +160,7 @@ class View(object):
             * v - Perspective (v)
             * h - Hemispherical fisheye (h)
             * l - Parallel (l)
-            * c - Cylindrical panorma (c)
+            * c - Cylindrical panorama (c)
             * a - Angular fisheye (a)
             * s - Planisphere [stereographic] projection (s)
         """
@@ -375,6 +375,7 @@ class View(object):
         .. code-block:: python
 
             {
+            'type': 'View',
             'identifier': str,  # View identifier
             "display_name": str,  # View display name
             'position': [],  # list with position value
@@ -384,11 +385,13 @@ class View(object):
             'v_size': number,  # v_size value
             'shift': number,  # shift value
             'lift': number,  # lift value
-            'type': number,  # type value
+            'view_type': number,  # view_type value
             'fore_clip': number,  # fore_clip value
             'aft_clip': number  # aft_clip value
             }
         """
+        assert view_dict['type'] == 'View', \
+            'Expected View dictionary. Got {}.'.format(view_dict['type'])
 
         view = cls(
             identifier=view_dict['identifier'],
@@ -422,6 +425,7 @@ class View(object):
         }
 
         base = {
+            'type': 'View',
             'identifier': identifier,
             'position': None,
             'direction': None,
@@ -430,7 +434,7 @@ class View(object):
             'v_size': None,
             'shift': None,
             'lift': None,
-            'type': None,
+            'view_type': None,
             'fore_clip': None,
             'aft_clip': None
         }
@@ -442,7 +446,7 @@ class View(object):
             if opt in mapper:
                 base[mapper[opt]] = value
             elif opt[:2] == 'vt':
-                base['type'] = opt
+                base['view_type'] = opt
             else:
                 print('%s is not a view parameter and is ignored.' % opt)
 
@@ -615,6 +619,7 @@ class View(object):
     def to_dict(self):
         """Translate view to a dictionary."""
         base = {
+            'type': 'View',
             'identifier': self.identifier,
             'position': self.position.value,
             'direction': self.direction.value,
@@ -623,7 +628,7 @@ class View(object):
             'v_size': self.v_size.value,
             'shift': self.shift.value,
             'lift': self.lift.value,
-            'type': self.type.value,
+            'view_type': self.type.value,
             'fore_clip': self.fore_clip.value,
             'aft_clip': self.aft_clip.value
         }

--- a/tests/aperture_extend_test.py
+++ b/tests/aperture_extend_test.py
@@ -1,12 +1,11 @@
 """Tests the features that honeybee_radiance adds to honeybee_core Aperture."""
-from honeybee.shade import Shade
 from honeybee.aperture import Aperture
 from honeybee.face import Face
 from honeybee.room import Room
 from honeybee.boundarycondition import boundary_conditions
 
 from honeybee_radiance.properties.aperture import ApertureRadianceProperties
-from honeybee_radiance.state import RadianceSubFaceState
+from honeybee_radiance.dynamic import RadianceSubFaceState, StateGeometry
 from honeybee_radiance.modifier import Modifier
 from honeybee_radiance.modifier.material import Glass
 
@@ -104,9 +103,9 @@ def test_set_states():
     """Test the setting of states on an Aperture."""
     pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
     ap = Aperture('TestWindow', Face3D(pts))
-    shd1 = Shade.from_vertices(
+    shd1 = StateGeometry.from_vertices(
         'wall_overhang1', [[0, 0, 10], [10, 0, 10], [10, 2, 10], [0, 2, 10]])
-    shd2 = Shade.from_vertices(
+    shd2 = StateGeometry.from_vertices(
         'wall_overhang2', [[0, 0, 5], [10, 0, 5], [10, 2, 5], [0, 2, 5]])
 
     ecglass1 = Glass.from_single_transmittance('ElectrochromicState1', 0.4)
@@ -156,7 +155,7 @@ def move_state_shades():
     pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
     ap = Aperture('TestWindow', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceSubFaceState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'ElectrochromicWindow1'
@@ -178,7 +177,7 @@ def scale_state_shades():
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     ap = Aperture('TestWindow', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceSubFaceState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'ElectrochromicWindow1'
@@ -200,7 +199,7 @@ def rotate_state_shades():
     pts = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
     ap = Aperture('TestWindow', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceSubFaceState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'ElectrochromicWindow1'
@@ -225,7 +224,7 @@ def rotate_xy_state_shades():
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     ap = Aperture('TestWindow', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceSubFaceState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'ElectrochromicWindow1'
@@ -249,7 +248,7 @@ def reflect_state_shades():
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     ap = Aperture('TestWindow', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceSubFaceState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'ElectrochromicWindow1'
@@ -306,9 +305,9 @@ def test_to_from_dict_with_states():
     """Test the Aperture from_dict method with radiance properties."""
     ap = Aperture.from_vertices(
         'wall_aperture', [[0, 0, 0], [10, 0, 0], [10, 0, 10], [0, 0, 10]])
-    shd1 = Shade.from_vertices(
+    shd1 = StateGeometry.from_vertices(
         'wall_overhang1', [[0, 0, 10], [10, 0, 10], [10, 2, 10], [0, 2, 10]])
-    shd2 = Shade.from_vertices(
+    shd2 = StateGeometry.from_vertices(
         'wall_overhang2', [[0, 0, 5], [10, 0, 5], [10, 2, 5], [0, 2, 5]])
 
     ecglass1 = Glass.from_single_transmittance('ElectrochromicState1', 0.4)

--- a/tests/door_extend_test.py
+++ b/tests/door_extend_test.py
@@ -1,12 +1,11 @@
 """Tests the features that honeybee_radiance adds to honeybee_core Door."""
-from honeybee.shade import Shade
 from honeybee.door import Door
 from honeybee.face import Face
 from honeybee.room import Room
 from honeybee.boundarycondition import boundary_conditions
 
 from honeybee_radiance.properties.door import DoorRadianceProperties
-from honeybee_radiance.state import RadianceSubFaceState
+from honeybee_radiance.dynamic import RadianceSubFaceState, StateGeometry
 from honeybee_radiance.modifier import Modifier
 from honeybee_radiance.modifier.material import Plastic, Glass
 
@@ -134,9 +133,9 @@ def test_to_from_dict_with_states():
     """Test the Door from_dict method with radiance properties."""
     dr = Door.from_vertices(
         'front_door', [[0, 0, 0], [10, 0, 0], [10, 0, 10], [0, 0, 10]])
-    shd1 = Shade.from_vertices(
+    shd1 = StateGeometry.from_vertices(
         'wall_overhang1', [[0, 0, 10], [10, 0, 10], [10, 2, 10], [0, 2, 10]])
-    shd2 = Shade.from_vertices(
+    shd2 = StateGeometry.from_vertices(
         'wall_overhang2', [[0, 0, 5], [10, 0, 5], [10, 2, 5], [0, 2, 5]])
 
     ecglass1 = Glass.from_single_transmittance('ElectrochromicState1', 0.4)

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -9,7 +9,8 @@ from honeybee.boundarycondition import boundary_conditions, Ground, Outdoors
 from honeybee.facetype import face_types
 
 from honeybee_radiance.properties.model import ModelRadianceProperties
-from honeybee_radiance.state import RadianceSubFaceState, RadianceShadeState
+from honeybee_radiance.dynamic import RadianceSubFaceState, RadianceShadeState, \
+    StateGeometry
 from honeybee_radiance.modifierset import ModifierSet
 from honeybee_radiance.modifier import Modifier
 from honeybee_radiance.modifier.material import Plastic, Glass, Trans, BSDF
@@ -441,7 +442,7 @@ def test_writer_to_rad_folder_dynamic():
 
     south_face = room[3]
     south_face.apertures_by_ratio(0.5, 0.01)
-    shd1 = Shade.from_vertices(
+    shd1 = StateGeometry.from_vertices(
         'outdoor_awning', [[0, 0, 2], [5, 0, 2], [5, 2, 2], [0, 2, 2]])
 
     ecglass1 = Glass.from_single_transmittance('ElectrochromicState1', 0.4)

--- a/tests/sensorgrid_test.py
+++ b/tests/sensorgrid_test.py
@@ -65,6 +65,7 @@ def test_to_and_from_dict():
     sg = SensorGrid('sg', sensors)
     sg_dict = sg.to_dict()
     assert sg_dict == {
+        'type': 'SensorGrid',
         'identifier': 'sg',
         'sensors': [
             {'pos': (0, 0, 0), 'dir': (0,  0, 1)},

--- a/tests/shade_extend_test.py
+++ b/tests/shade_extend_test.py
@@ -3,7 +3,7 @@ from honeybee.shade import Shade
 from honeybee.aperture import Aperture
 
 from honeybee_radiance.properties.shade import ShadeRadianceProperties
-from honeybee_radiance.state import RadianceShadeState
+from honeybee_radiance.dynamic import RadianceShadeState, StateGeometry
 from honeybee_radiance.modifier import Modifier
 from honeybee_radiance.modifier.material import Plastic, Glass
 
@@ -99,9 +99,9 @@ def test_set_states():
     """Test the setting of states on a Shade."""
     pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
     shd = Shade('TreeTrunk', Face3D(pts))
-    shd1 = Shade.from_vertices(
+    shd1 = StateGeometry.from_vertices(
         'tree_foliage1', [[0, 0, 5], [2, 0, 5], [2, 2, 5], [0, 2, 5]])
-    shd2 = Shade.from_vertices(
+    shd2 = StateGeometry.from_vertices(
         'tree_foliage2', [[0, 0, 5], [-2, 0, 5], [-2, 2, 5], [0, 2, 5]])
 
     trans1 = Glass.from_single_transmittance('TreeTrans1', 0.5)
@@ -144,7 +144,7 @@ def move_state_shades():
     pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
     ap = Shade('TestShade', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceShadeState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'DeciduousTrees'
@@ -166,7 +166,7 @@ def scale_state_shades():
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     ap = Shade('TestShade', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceShadeState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'DeciduousTrees'
@@ -188,7 +188,7 @@ def rotate_state_shades():
     pts = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
     ap = Shade('TestShade', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceShadeState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'DeciduousTrees'
@@ -213,7 +213,7 @@ def rotate_xy_state_shades():
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     ap = Shade('TestShade', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceShadeState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'DeciduousTrees'
@@ -237,7 +237,7 @@ def reflect_state_shades():
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     ap = Shade('TestShade', Face3D(pts))
     pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
-    shade = Shade('RectangleShade', Face3D(pts_1))
+    shade = StateGeometry('RectangleShade', Face3D(pts_1))
 
     tint1 = RadianceShadeState(shades=[shade])
     ap.properties.radiance.dynamic_group_identifier = 'DeciduousTrees'
@@ -294,9 +294,9 @@ def test_to_from_dict_with_states():
     """Test the Shade from_dict method with radiance properties."""
     pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
     shd = Shade('TreeTrunk', Face3D(pts))
-    shd1 = Shade.from_vertices(
+    shd1 = StateGeometry.from_vertices(
         'tree_foliage1', [[0, 0, 5], [2, 0, 5], [2, 2, 5], [0, 2, 5]])
-    shd2 = Shade.from_vertices(
+    shd2 = StateGeometry.from_vertices(
         'tree_foliage2', [[0, 0, 5], [-2, 0, 5], [-2, 2, 5], [0, 2, 5]])
 
     trans1 = Glass.from_single_transmittance('TreeTrans1', 0.5)


### PR DESCRIPTION
This commit creates a separate StateGeometry class for dynamic radiance shades and gets rid of the use of honeybee-core Shades for this purpose.

Resolves https://github.com/ladybug-tools/honeybee-schema/issues/112

Also, now that there are 3 different modules involved with dynamic geometry, I decided to put all of them in the same `dynamic` sub-package.

Lastly, made a small edit to the SensorGrid and View dictionaries: adding the 'type' key into the dictionary in order to keep it in line with all of the other schemas.