### PR TITLE
fix(model): Update Model.to.rad_folder to work with recent edits

### DIFF
--- a/honeybee_radiance/properties/model.py
+++ b/honeybee_radiance/properties/model.py
@@ -212,75 +212,50 @@ class ModelRadianceProperties(object):
                  group_ids.add(subface.properties.radiance._dynamic_group_identifier)
         return list(group_ids)
 
-    def faces_by_opaque(self):
-        """Get all Faces in the model separated into opaque and nonopaque lists.
+    def faces_by_blk(self):
+        """Get all Faces in the model separated by their blk property.
 
         This method will also ensure that any faces with Surface boundary condition
         only have one of such objects in the output lists.
 
         Returns:
-            A tuple with 4 lists:
+            A tuple with 2 lists:
 
-            -   opaque_faces: A list of all opaque faces without a unique
-                modifier_blk (just using the default black).
+            -   faces: A list of all  faces without a unique modifier_blk.
 
-            -   opaque_faces_blk: A list of all opaque faces that have a
-                unique modifier_blk.
-
-            -   nonopaque_faces: A list of all nonopaque faces without a
-                unique modifier_blk (just using their own modifier in blk studies).
-
-            -   nonopaque_faces_blk: A list of all non opaque faces that
-                have a unique modifier_blk.
+            -   faces_blk: A list of all opaque faces that have a unique modifier_blk.
         """
-        opaque_faces = []
-        opaque_faces_blk = []
-        nonopaque_faces = []
-        nonopaque_faces_blk = []
+        faces = []
+        faces_blk = []
         interior_faces = set()
         for face in self.host.faces:
             if isinstance(face.boundary_condition, Surface):
                 if face.identifier in interior_faces:
                     continue
                 interior_faces.add(face.boundary_condition.boundary_condition_object)
-            if face.properties.radiance.is_opaque:
-                if face.properties.radiance._modifier_blk:
-                    opaque_faces_blk.append(face)
-                else:
-                    opaque_faces.append(face)
+            if face.properties.radiance._modifier_blk:
+                faces_blk.append(face)
             else:
-                if face.properties.radiance._modifier_blk:
-                    nonopaque_faces_blk.append(face)
-                else:
-                    nonopaque_faces.append(face)
-        return opaque_faces, opaque_faces_blk, nonopaque_faces, nonopaque_faces_blk
-    
-    def subfaces_by_interior_exterior(self):
-        """Get model sub-faces (Apertures, Doors) separated into interior/exterior lists.
+                faces.append(face)
+        return faces, faces_blk
+
+    def subfaces_by_blk(self):
+        """Get model sub-faces (Apertures, Doors) separated by their blk property.
 
         Dynamic sub-faces will be excluded from the output lists.
         This method will also ensure that any interior sub-faces (with Surface
         boundary condition) only have one of such objects in the output lists.
 
         Returns:
-            A tuple with 4 lists:
+            A tuple with 2 lists:
 
-            -   exterior_subfaces: A list of all exterior sub-faces without a unique
-                modifier_blk (just using the default black).
+            -   subfaces: A list of all sub-faces without a unique modifier_blk
+                (just using the default black).
 
-            -   exterior_subfaces_blk: A list of all exterior sub-faces that have a
-                unique modifier_blk.
-
-            -   interior_subfaces: A list of all interior sub-faces without a
-                unique modifier_blk (just using the default black).
-
-            -   interior_subfaces_blk: A list of all interior sub-faces that
-                have a unique modifier_blk.
+            -   subfaces_blk: A list of all sub-faces that have a unique modifier_blk.
         """
-        exterior_subfaces = []
-        exterior_subfaces_blk = []
-        interior_subfaces = []
-        interior_subfaces_blk = []
+        subfaces = []
+        subfaces_blk = []
         interior_ids = set()
         for subf in self.host.apertures + self.host.doors:
             if subf.properties.radiance.dynamic_group_identifier:
@@ -289,61 +264,35 @@ class ModelRadianceProperties(object):
                 if subf.identifier in interior_ids:
                     continue
                 interior_ids.add(subf.boundary_condition.boundary_condition_object)
-                if subf.properties.radiance._modifier_blk:
-                    interior_subfaces_blk.append(subf)
-                else:
-                    interior_subfaces.append(subf)
+            if subf.properties.radiance._modifier_blk:
+                subfaces_blk.append(subf)
             else:
-                if subf.properties.radiance._modifier_blk:
-                    exterior_subfaces_blk.append(subf)
-                else:
-                    exterior_subfaces.append(subf)
-        return exterior_subfaces, exterior_subfaces_blk, \
-            interior_subfaces, interior_subfaces_blk
+                subfaces.append(subf)
+        return subfaces, subfaces_blk
 
-    def indoor_shades_by_opaque(self):
-        """Get all indoor Shades in the model separated into opaque and nonopaque lists.
+    def shades_by_blk(self):
+        """Get all Shades in the model separated by their blk property.
 
         Dynamic shades will be excluded from the output lists.
 
         Returns:
-            A tuple with 4 lists:
+            A tuple with 2 lists:
 
-            -   opaque_shades: A list of all opaque shades without a unique
-                modifier_blk (just using the default black).
+            -   shades: A list of all opaque shades without a unique modifier_blk
+                (just using the default black or transparent modifier).
 
-            -   opaque_shades_blk: A list of all opaque shades that have a
-                unique modifier_blk.
-
-            -   nonopaque_shades: A list of all nonopaque shades without a
-                unique modifier_blk (just using their own modifier in blk studies).
-
-            -   nonopaque_shades_blk: A list of all non opaque shades that
-                have a unique modifier_blk.
+            -   shades_blk: A list of all opaque shades that have a unique modifier_blk.
         """
-        return self._separate_shades_by_opaque(self.host.indoor_shades)
-
-    def outdoor_shades_by_opaque(self):
-        """Get all outdoor Shades in the model separated into opaque and nonopaque lists.
-
-        Dynamic shades will be excluded from the output lists.
-
-        Returns:
-            A tuple with 4 lists:
-
-            -   opaque_shades: A list of all opaque shades without a unique
-                modifier_blk (just using the default black).
-
-            -   opaque_shades_blk: A list of all opaque shades that have a
-                unique modifier_blk.
-
-            -   nonopaque_shades: A list of all nonopaque shades without a
-                unique modifier_blk (just using their own modifier in blk studies).
-
-            -   nonopaque_shades_blk: A list of all non opaque shades that
-                have a unique modifier_blk.
-        """
-        return self._separate_shades_by_opaque(self.host.outdoor_shades)
+        shades = []
+        shades_blk = []
+        for shade in self.host.shades:
+            if shade.properties.radiance.dynamic_group_identifier:
+                continue  # shade will be accounted for in the dynamic objects
+            if shade.properties.radiance._modifier_blk:
+                shades_blk.append(shade)
+            else:
+                shades.append(shade)
+        return shades, shades_blk
 
     def check_duplicate_modifier_identifiers(self, raise_exception=True):
         """Check that there are no duplicate Modifier identifiers in the model."""
@@ -589,31 +538,6 @@ class ModelRadianceProperties(object):
                 if mod is not None:
                     if not self._instance_in_array(mod, modifiers):
                         modifiers.append(mod)
-
-    @staticmethod
-    def _separate_shades_by_opaque(shades):
-        """Sort a list of shade objects into 4 lists.
-        
-        These are: opaque, opaque_blk, nonopaque, nonopaque_blk
-        """
-        opaque = []
-        opaque_blk = []
-        nonopaque = []
-        nonopaque_blk = []
-        for shade in shades:
-            if shade.properties.radiance.dynamic_group_identifier:
-                continue  # shade will be accounted for in the dynamic objects
-            if shade.properties.radiance.is_opaque:
-                if shade.properties.radiance._modifier_blk:
-                    opaque_blk.append(shade)
-                else:
-                    opaque.append(shade)
-            else:
-                if shade.properties.radiance._modifier_blk:
-                    nonopaque_blk.append(shade)
-                else:
-                    nonopaque.append(shade)
-        return opaque, opaque_blk, nonopaque, nonopaque_blk
 
     @staticmethod
     def _instance_in_array(object_instance, object_array):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 honeybee-core==1.30.3
-honeybee-radiance-folder==1.0.1
+honeybee-radiance-folder==2.0.1
 honeybee-radiance-command==1.0.0

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -392,39 +392,19 @@ def test_writer_to_rad_folder():
     model.to.rad_folder(model, folder)
 
     model_folder = ModelFolder(folder)
-    rad_name = '{}.rad'.format(model.identifier)
-    mat_name = '{}.mat'.format(model.identifier)
-    blk_name = '{}.blk'.format(model.identifier)
 
-    ap_dir = os.path.join(folder, model_folder.STATIC_APERTURE_EXTERIOR)
-    assert os.path.isfile(os.path.join(ap_dir, rad_name))
-    assert os.path.isfile(os.path.join(ap_dir, mat_name))
-    assert os.path.isfile(os.path.join(ap_dir, blk_name))
+    ap_dir = model_folder.aperture_folder(full=True)
+    assert os.path.isfile(os.path.join(ap_dir, '{}.rad'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(ap_dir, '{}.mat'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(ap_dir, '{}.blk'.format(model.identifier)))
 
-    int_ap_dir = os.path.join(folder, model_folder.STATIC_APERTURE_INTERIOR)
-    assert os.path.isfile(os.path.join(int_ap_dir, rad_name))
-    assert os.path.isfile(os.path.join(int_ap_dir, mat_name))
-    assert os.path.isfile(os.path.join(int_ap_dir, blk_name))
-
-    opaque_dir = os.path.join(folder, model_folder.STATIC_OPAQUE_ROOT)
-    assert os.path.isfile(os.path.join(opaque_dir, rad_name))
-    assert os.path.isfile(os.path.join(opaque_dir, mat_name))
-    assert os.path.isfile(os.path.join(opaque_dir, blk_name))
-
-    opaque_indoor_dir = os.path.join(folder, model_folder.STATIC_OPAQUE_INDOOR)
-    assert os.path.isfile(os.path.join(opaque_indoor_dir, rad_name))
-    assert os.path.isfile(os.path.join(opaque_indoor_dir, mat_name))
-    assert os.path.isfile(os.path.join(opaque_indoor_dir, blk_name))
-
-    opaque_outdoor_dir = os.path.join(folder, model_folder.STATIC_OPAQUE_OUTDOOR)
-    assert os.path.isfile(os.path.join(opaque_outdoor_dir, rad_name))
-    assert os.path.isfile(os.path.join(opaque_outdoor_dir, mat_name))
-    assert os.path.isfile(os.path.join(opaque_outdoor_dir, blk_name))
-
-    nonopaque_outdoor_dir = os.path.join(folder, model_folder.STATIC_NONOPAQUE_OUTDOOR)
-    assert os.path.isfile(os.path.join(nonopaque_outdoor_dir, rad_name))
-    assert os.path.isfile(os.path.join(nonopaque_outdoor_dir, mat_name))
-    assert os.path.isfile(os.path.join(nonopaque_outdoor_dir, blk_name))
+    scene_dir = model_folder.scene_folder(full=True)
+    assert os.path.isfile(os.path.join(scene_dir, '{}_envelope.rad'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(scene_dir, '{}_envelope.mat'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(scene_dir, '{}_envelope.blk'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(scene_dir, '{}_shades.rad'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(scene_dir, '{}_shades.mat'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(scene_dir, '{}_shades.blk'.format(model.identifier)))
 
     # clean up the folder
     nukedir(folder, rmdir=True)
@@ -511,7 +491,7 @@ def test_writer_to_rad_folder_dynamic():
 
     model_folder = ModelFolder(folder)
 
-    ap_dir = os.path.join(folder, model_folder.DYNAMIC_APERTURE_EXTERIOR)
+    ap_dir = model_folder.aperture_group_folder(full=True)
     assert os.path.isfile(os.path.join(ap_dir, 'states.json'))
     group_name = south_face.apertures[0].properties.radiance.dynamic_group_identifier
     assert os.path.isfile(os.path.join(ap_dir, '{}..black.rad'.format(group_name)))
@@ -522,34 +502,32 @@ def test_writer_to_rad_folder_dynamic():
         d_file = (os.path.join(ap_dir, '{}..direct..{}.rad'.format(group_name, i)))
         assert os.path.isfile(d_file)
 
-    nono_out_dir = os.path.join(folder, model_folder.DYNAMIC_NONOPAQUE_OUTDOOR)
-    assert os.path.isfile(os.path.join(nono_out_dir, 'states.json'))
+    out_scene_dir = model_folder.dynamic_scene_folder(full=True, indoor=False)
+    assert os.path.isfile(os.path.join(out_scene_dir, 'states.json'))
     grp_name = tree_canopy.properties.radiance.dynamic_group_identifier
     for i in range(len(tree_canopy.properties.radiance.states)):
-        d_file = (os.path.join(nono_out_dir, '{}..default..{}.rad'.format(grp_name, i)))
+        d_file = (os.path.join(out_scene_dir, '{}..default..{}.rad'.format(grp_name, i)))
         assert os.path.isfile(d_file)
     for i in range(len(tree_canopy.properties.radiance.states)):
-        d_file = (os.path.join(nono_out_dir, '{}..direct..{}.rad'.format(grp_name, i)))
+        d_file = (os.path.join(out_scene_dir, '{}..direct..{}.rad'.format(grp_name, i)))
         assert os.path.isfile(d_file)
-
-    o_out_dir = os.path.join(folder, model_folder.DYNAMIC_OPAQUE_OUTDOOR)
-    assert os.path.isfile(os.path.join(o_out_dir, 'states.json'))
     grp_name = ground.properties.radiance.dynamic_group_identifier
     for i in range(len(ground.properties.radiance.states)):
-        d_file = (os.path.join(o_out_dir, '{}..default..{}.rad'.format(grp_name, i)))
+        d_file = (os.path.join(out_scene_dir, '{}..default..{}.rad'.format(grp_name, i)))
         assert os.path.isfile(d_file)
     for i in range(len(ground.properties.radiance.states)):
-        d_file = (os.path.join(o_out_dir, '{}..direct..{}.rad'.format(grp_name, i)))
+        d_file = (os.path.join(out_scene_dir, '{}..direct..{}.rad'.format(grp_name, i)))
+        d_file = (os.path.join(out_scene_dir, '{}..direct..{}.rad'.format(grp_name, i)))
         assert os.path.isfile(d_file)
 
-    o_in_dir = os.path.join(folder, model_folder.DYNAMIC_OPAQUE_INDOOR)
-    assert os.path.isfile(os.path.join(o_in_dir, 'states.json'))
+    in_scene_dir = model_folder.dynamic_scene_folder(full=True, indoor=True)
+    assert os.path.isfile(os.path.join(in_scene_dir, 'states.json'))
     grp_name = shd2.properties.radiance.dynamic_group_identifier
     for i in range(len(shd2.properties.radiance.states)):
-        d_file = (os.path.join(o_in_dir, '{}..default..{}.rad'.format(grp_name, i)))
+        d_file = (os.path.join(in_scene_dir, '{}..default..{}.rad'.format(grp_name, i)))
         assert os.path.isfile(d_file)
     for i in range(len(shd2.properties.radiance.states)):
-        d_file = (os.path.join(o_in_dir, '{}..direct..{}.rad'.format(grp_name, i)))
+        d_file = (os.path.join(in_scene_dir, '{}..direct..{}.rad'.format(grp_name, i)))
         assert os.path.isfile(d_file)
 
     # clean up the folder
@@ -586,11 +564,11 @@ def test_writer_to_rad_folder_multiphase():
 
     model_folder = ModelFolder(folder)
 
-    bsdf_dir = os.path.join(folder, model_folder.BSDF[0])
+    bsdf_dir = model_folder.bsdf_folder(full=True)
     assert os.path.isfile(os.path.join(bsdf_dir, 'clear.xml'))
     assert os.path.isfile(os.path.join(bsdf_dir, 'diffuse50.xml'))
 
-    ap_dir = os.path.join(folder, model_folder.DYNAMIC_APERTURE_EXTERIOR)
+    ap_dir = model_folder.aperture_group_folder(full=True)
     assert os.path.isfile(os.path.join(ap_dir, 'states.json'))
 
     group_name = south_aperture.properties.radiance.dynamic_group_identifier
@@ -683,7 +661,7 @@ def test_writer_to_rad_folder_shade_drop():
 
     model_folder = ModelFolder(folder)
 
-    ap_dir = os.path.join(folder, model_folder.DYNAMIC_APERTURE_EXTERIOR)
+    ap_dir = model_folder.aperture_group_folder(full=True)
     assert os.path.isfile(os.path.join(ap_dir, 'states.json'))
 
     group_name = entry.properties.radiance.dynamic_group_identifier


### PR DESCRIPTION
This commit brings honeybee-radiance in line with the recent refactor of honeybee-radiance folder.

I don't expect the edits to result in any significant performance improvements since roughly the same number of checks are still performed (there may be a small improvement form just writing fewer files, albeit with the same overall file contents).

However, the changes greatly simplified the code. Previously, the Model.to.rad_folder method was over 200 lines long, which was realistically as short as it could be given that there were 16 folders that had to be written to.

For the static files (where much of the new simplification occurred), I mostly stuck to writing three files into the folders (.rad, .mat, and .blk). However, I separated the scene in two: 3 envelope files (containing honeybee Faces) and 3 shade files (containing honeybee Shades). I did this since the to.rad_folder code was simpler this way and there may be some cases where this separation is useful to people looking over the file contents.