### PR TITLE
feat(cli): Add commands to translate model JSON to rad and rad_folder

### DIFF
--- a/honeybee_radiance/cli/__init__.py
+++ b/honeybee_radiance/cli/__init__.py
@@ -8,6 +8,7 @@ except ImportError:
     )
 
 from honeybee.cli import main
+from .translate import translate
 from .sky import sky
 from .grid import grid
 from .sunpath import sunpath
@@ -18,6 +19,7 @@ def radiance():
     pass
 
 # add sub-commands to radiance
+radiance.add_command(translate)
 radiance.add_command(sky)
 radiance.add_command(grid)
 radiance.add_command(sunpath)

--- a/honeybee_radiance/cli/translate.py
+++ b/honeybee_radiance/cli/translate.py
@@ -1,0 +1,197 @@
+"""honeybee radiance translation commands."""
+
+try:
+    import click
+except ImportError:
+    raise ImportError(
+        'click is not installed. Try `pip install . [cli]` command.'
+    )
+
+from honeybee_radiance.reader import string_to_dicts
+from honeybee_radiance.mutil import dict_to_modifier, modifier_class_from_type_string
+
+from ladybug.futil import write_to_file_by_name
+from honeybee.model import Model
+
+import sys
+import os
+import logging
+import json
+
+_logger = logging.getLogger(__name__)
+
+
+@click.group(help='Commands for translating Honeybee JSON files to/from RAD.')
+def translate():
+    pass
+
+@translate.command('model-to-rad-folder')
+@click.argument('model-json')
+@click.option('--folder', help='Folder on this computer, into which the Radiance '
+              'folders will be written. If None, the files will be output in the'
+              'same location as the model_json.', default=None, show_default=True)
+@click.option('--folder-type', help='An integer between 0-2 to note the type of '
+              'folders to be written out with the Model.\n0: grid-based\n1: view-based'
+              '\n2: includes both views and grids', default=2, show_default=True)
+@click.option('--minimal', help='Boolean to note whether the radiance strings should '
+              'be written in a minimal format (with spaces instead of line breaks).',
+              default=False, show_default=True)
+@click.option('--log-file', help='Optional log file to output the progress of the'
+              'translation. By default this will be printed out to stdout',
+              type=click.File('w'), default='-')
+def model_to_rad_folder(model_json, folder, folder_type, minimal, log_file):
+    """Translate a Model JSON file into a Radiance Folder.
+    \n
+    Args:
+        model_json: Full path to a Model JSON file.
+    """
+    try:
+        # check that the model JSON is there
+        assert os.path.isfile(model_json), \
+            'No Model JSON file found at {}.'.format(model_json)
+
+        # set the default folder if it's not specified
+        if folder is None:
+            folder = os.path.split(os.path.abspath(model_json))[0]
+
+        # re-serialize the Model to Python
+        log_file.write('Re-serializing Model JSON.\n')
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        model = Model.from_dict(data)
+        log_file.write('Model re-serialization successful.\n')
+
+        # translate the model to a radiance folder
+        log_file.write('Translating Model to Radiance folder.\n')
+        rad_fold = model.to.rad_folder(model, folder, folder_type, minimal)
+        log_file.write('Model translation successful.\n')
+        log_file.write('Radiance folder output to: {}'.format(rad_fold))
+    except Exception as e:
+        _logger.exception('Model translation failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@translate.command('model-to-rad')
+@click.argument('model-json')
+@click.option('--blk', help='Boolean to note whether the "blacked out" version '
+              'of the geometry should be output, which is useful for direct studies '
+              'and isolation studies of individual apertures.',
+              default=False, show_default=True)
+@click.option('--minimal', help='Boolean to note whether the radiance strings should '
+              'be written in a minimal format (with spaces instead of line breaks).',
+              default=False, show_default=True)
+@click.option('--log-file', help='Optional RAD file to output the RAD string of the '
+              'translation. By default this will be printed out to stdout',
+              type=click.File('w'), default='-')
+def model_to_rad(model_json, blk, minimal, log_file):
+    """Translate a Model JSON file to a Radiance string.
+    \n
+    The resulting strings will include all geometry (Rooms, Faces, Shades, Apertures,
+    Doors) and all modifiers. However, it does not include any states for dynamic
+    geometry and will only write the default state for each dynamic object. To
+    correctly account for dynamic objects, model-to-rad-folder should be used.
+    \n
+    Args:
+        model_json: Full path to a Model JSON file.
+    """
+    try:
+        # check that the model JSON is there
+        assert os.path.isfile(model_json), \
+            'No Model JSON file found at {}.'.format(model_json)
+
+        # re-serialize the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        model = Model.from_dict(data)
+
+        # translate the model to a rad string and put it in a dictionary
+        model_str, modifier_str = model.to.rad(model, blk, minimal)
+        rad_dict = {'model_str': model_str, 'modifier_str': modifier_str}
+
+        # write out the rad string
+        log_file.write(json.dumps(rad_dict))
+    except Exception as e:
+        _logger.exception('Model translation failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+@translate.command('modifiers-to-rad')
+@click.argument('modifier-json')
+@click.option('--minimal', help='Boolean to note whether the radiance strings should '
+              'be written in a minimal format (with spaces instead of line breaks).',
+              default=False, show_default=True)
+@click.option('--log-file', help='Optional RAD file to output the RAD string of the '
+              'translation. By default this will be printed out to stdout',
+              type=click.File('w'), default='-')
+def modifier_to_rad(modifier_json, minimal, log_file):
+    """Translate a Modifier JSON file to an RAD using direct-to-rad translators.
+    \n
+    Args:
+        modifier_json: Full path to a Modifier JSON file. This file should
+            either be an array of non-abridged Modifiers or a dictionary where
+            the values are non-abridged Modifiers.
+    """
+    try:
+        # check that the modifier JSON is there
+        assert os.path.isfile(modifier_json), \
+            'No Modifier JSON file found at {}.'.format(modifier_json)
+
+        # re-serialize the Modifiers to Python
+        with open(modifier_json) as json_file:
+            data = json.load(json_file)
+        mod_list = data.values() if isinstance(data, dict) else data
+        mod_objs = []
+        for mod_dict in mod_list:
+            m_class = modifier_class_from_type_string(mod_dict['type'].lower())
+            mod_objs.append(m_class.from_dict(mod_dict))
+
+        # create the RAD strings
+        rad_str_list = []
+        rad_str_list.extend([mod.to_radiance(minimal) for mod in mod_objs])
+        rad_str = '\n\n'.join(rad_str_list)
+
+        # write out the RAD file
+        log_file.write(rad_str)
+    except Exception as e:
+        _logger.exception('Modifier translation failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+@translate.command('modifiers-from-rad')
+@click.argument('modifier-rad')
+@click.option('--log-file', help='Optional JSON file to output the JSON string of the'
+              'translation. By default this will be printed out to stdout',
+              type=click.File('w'), default='-')
+def modifier_from_rad(modifier_rad, log_file):
+    """Translate a Modifier JSON file to a honeybee JSON as an array of modifiers.
+    \n
+    Args:
+        modifier_rad: Full path to a Modifier JSON file. Only the modifiers
+            and materials in this file will be extracted.
+    """
+    try:
+        # check that the modifier JSON is there
+        assert os.path.isfile(modifier_rad), \
+            'No Modifier JSON file found at {}.'.format(modifier_rad)
+
+        # re-serialize the Modifiers to Python
+        mod_objs = []
+        with open(modifier_rad) as f:
+            rad_dicts = string_to_dicts(f.read())
+            for mod_dict in rad_dicts:
+                mod_objs.append(dict_to_modifier(mod_dict))
+
+        # create the honeybee dictionaries
+        json_dicts = [mod.to_dict() for mod in mod_objs]
+
+        # write out the JSON file
+        log_file.write(json.dumps(json_dicts))
+    except Exception as e:
+        _logger.exception('Modifier translation failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/honeybee_radiance/lightsource/ground.py
+++ b/honeybee_radiance/lightsource/ground.py
@@ -82,7 +82,7 @@ Mardaljevic/rwr_ch6.pdf
         .. code-block:: python
 
                 {
-                'type': 'SkyHemisphere',
+                'type': 'Ground',
                 'r_emittance': r_emittance,
                 'g_emittance': g_emittance,
                 'b_emittance': b_emittance

--- a/honeybee_radiance/lightsource/sky/_skybase.py
+++ b/honeybee_radiance/lightsource/sky/_skybase.py
@@ -41,11 +41,11 @@ class _Skydome(object):
         return False
 
     @classmethod
-    def from_dict(cls, input_dict):
+    def from_dict(cls, data):
         """Create the sky baseclass from a dictionary.
 
         Args:
-            input_dict: A python dictionary in the following format
+            data: A python dictionary in the following format
 
         .. code-block:: python
 
@@ -56,18 +56,18 @@ class _Skydome(object):
             }
 
         """
-        assert 'type' in input_dict, \
+        assert 'type' in data, \
             'Input dict is missing type. Not a valid SkyDome dictionary.'
-        assert input_dict['type'] == 'SkyDome', \
-            'Input type must be SkyDome not %s' % input_dict['type']
+        assert data['type'] == 'SkyDome', \
+            'Input type must be SkyDome not %s' % data['type']
 
         sky = cls()
 
-        if 'ground_hemisphere' in input_dict:
-            sky._ground_hemisphere = Ground.from_dict(input_dict['ground_hemisphere'])
+        if 'ground_hemisphere' in data and data['ground_hemisphere'] is not None:
+            sky._ground_hemisphere = Ground.from_dict(data['ground_hemisphere'])
 
-        if 'sky_hemisphere' in input_dict:
-            sky._sky_hemisphere = Hemisphere.from_dict(input_dict['sky_hemisphere'])
+        if 'sky_hemisphere' in data and data['sky_hemisphere'] is not None:
+            sky._sky_hemisphere = Hemisphere.from_dict(data['sky_hemisphere'])
 
         return sky
 
@@ -143,11 +143,11 @@ class _PointInTime(_Skydome):
         return True
 
     @classmethod
-    def from_dict(cls, input_dict):
+    def from_dict(cls, data):
         """Create the sky baseclass from a dictionary.
 
         Args:
-            input_dict: A python dictionary in the following format
+            data: A python dictionary in the following format
 
         .. code-block:: python
 
@@ -157,13 +157,13 @@ class _PointInTime(_Skydome):
                 'sky_hemisphere': {}  # see hemisphere.Hemisphere class [optional]
                 }
         """
-        sky = cls(input_dict['ground_reflectance'])
+        sky = cls(data['ground_reflectance'])
 
-        if 'ground_hemisphere' in input_dict:
-            sky._ground_hemisphere = Ground.from_dict(input_dict['ground_hemisphere'])
+        if 'ground_hemisphere' in data and data['ground_hemisphere'] is not None:
+            sky._ground_hemisphere = Ground.from_dict(data['ground_hemisphere'])
 
-        if 'sky_hemisphere' in input_dict:
-            sky._sky_hemisphere = Hemisphere.from_dict(input_dict['sky_hemisphere'])
+        if 'sky_hemisphere' in data and data['sky_hemisphere'] is not None:
+            sky._sky_hemisphere = Hemisphere.from_dict(data['sky_hemisphere'])
 
         return sky
 

--- a/honeybee_radiance/lightsource/sky/certainirradiance.py
+++ b/honeybee_radiance/lightsource/sky/certainirradiance.py
@@ -91,11 +91,11 @@ class CertainIrradiance(_PointInTime):
         return False
 
     @classmethod
-    def from_dict(cls, input_dict):
+    def from_dict(cls, data):
         """Create the sky from a dictionary.
 
         Args:
-            input_dict: A python dictionary in the following format
+            data: A python dictionary in the following format
 
         .. code-block:: python
 
@@ -107,21 +107,21 @@ class CertainIrradiance(_PointInTime):
                 'sky_hemisphere': {}  # see hemisphere.Hemisphere class [optional]
             }
         """
-        assert 'type' in input_dict, \
+        assert 'type' in data, \
             'Input dict is missing type. Not a valid CertainIrradiance dictionary.'
-        assert input_dict['type'] == 'CertainIrradiance', \
-            'Input type must be CertainIrradiance not %s' % input_dict['type']
+        assert data['type'] == 'CertainIrradiance', \
+            'Input type must be CertainIrradiance not %s' % data['type']
 
         sky = cls(
-            input_dict['irradiance'],
-            input_dict['ground_reflectance']
+            data['irradiance'],
+            data['ground_reflectance']
         )
 
-        if 'ground_hemisphere' in input_dict:
-            sky._ground_hemisphere = Ground.from_dict(input_dict['ground_hemisphere'])
+        if 'ground_hemisphere' in data and data['ground_hemisphere'] is not None:
+            sky._ground_hemisphere = Ground.from_dict(data['ground_hemisphere'])
 
-        if 'sky_hemisphere' in input_dict:
-            sky._sky_hemisphere = Hemisphere.from_dict(input_dict['sky_hemisphere'])
+        if 'sky_hemisphere' in data and data['sky_hemisphere'] is not None:
+            sky._sky_hemisphere = Hemisphere.from_dict(data['sky_hemisphere'])
 
         return sky
 

--- a/honeybee_radiance/lightsource/sky/cie.py
+++ b/honeybee_radiance/lightsource/sky/cie.py
@@ -68,7 +68,7 @@ class CIE(_PointInTime):
 
     @property
     def altitude(self):
-        """Get and set solar altitude.
+        """Get or set a number between -90 and 90 for the solar altitude.
 
         The altitude is measured in degrees above the horizon.
         """
@@ -76,12 +76,12 @@ class CIE(_PointInTime):
 
     @altitude.setter
     def altitude(self, value):
-        value = typing.float_in_range(value, 0, 90, 'Solar altitude')
+        value = typing.float_in_range(value, -90, 90, 'Solar altitude')
         self._altitude = value
 
     @property
     def azimuth(self):
-        """Get and set solar azimuth.
+        """Get or set a number between 0 and 360 for the solar azimuth.
 
         The azimuth is measured in degrees east of North. East is 90, South is 180 and
         West is 270. Note that this input is different from Radiance convention. In

--- a/honeybee_radiance/lightsource/sky/cie.py
+++ b/honeybee_radiance/lightsource/sky/cie.py
@@ -213,11 +213,11 @@ class CIE(_PointInTime):
             sky_type, north_angle, ground_reflectance)
 
     @classmethod
-    def from_dict(cls, input_dict):
+    def from_dict(cls, data):
         """Create the sky from a dictionary.
 
         Args:
-            input_dict: A python dictionary in the following format
+            data: A python dictionary in the following format
 
         .. code-block:: python
 
@@ -232,23 +232,23 @@ class CIE(_PointInTime):
             }
 
         """
-        assert 'type' in input_dict, \
+        assert 'type' in data, \
             'Input dict is missing type. Not a valid CIE dictionary.'
-        assert input_dict['type'] == 'CIE', \
-            'Input type must be CIE not %s' % input_dict['type']
+        assert data['type'] == 'CIE', \
+            'Input type must be CIE not %s' % data['type']
 
         sky = cls(
-            input_dict['altitude'],
-            input_dict['azimuth'],
-            input_dict['sky_type'],
-            input_dict['ground_reflectance']
+            data['altitude'],
+            data['azimuth'],
+            data['sky_type'],
+            data['ground_reflectance']
         )
 
-        if 'ground_hemisphere' in input_dict:
-            sky._ground_hemisphere = Ground.from_dict(input_dict['ground_hemisphere'])
+        if 'ground_hemisphere' in data and data['ground_hemisphere'] is not None:
+            sky._ground_hemisphere = Ground.from_dict(data['ground_hemisphere'])
 
-        if 'sky_hemisphere' in input_dict:
-            sky._sky_hemisphere = Hemisphere.from_dict(input_dict['sky_hemisphere'])
+        if 'sky_hemisphere' in data and data['sky_hemisphere'] is not None:
+            sky._sky_hemisphere = Hemisphere.from_dict(data['sky_hemisphere'])
 
         return sky
 

--- a/honeybee_radiance/lightsource/sky/climatebased.py
+++ b/honeybee_radiance/lightsource/sky/climatebased.py
@@ -217,11 +217,11 @@ class ClimateBased(_PointInTime):
             ground_reflectance)
 
     @classmethod
-    def from_dict(cls, input_dict):
+    def from_dict(cls, data):
         """Create the sky from a dictionary.
 
         Args:
-            input_dict: A python dictionary in the following format
+            data: A python dictionary in the following format
 
         .. code-block:: python
 
@@ -237,24 +237,24 @@ class ClimateBased(_PointInTime):
             }
 
         """
-        assert 'type' in input_dict, \
+        assert 'type' in data, \
             'Input dict is missing type. Not a valid ClimateBased dictionary.'
-        assert input_dict['type'] == 'ClimateBased', \
-            'Input type must be ClimateBased not %s' % input_dict['type']
+        assert data['type'] == 'ClimateBased', \
+            'Input type must be ClimateBased not %s' % data['type']
 
         sky = cls(
-            input_dict['altitude'],
-            input_dict['azimuth'],
-            input_dict['direct_normal_irradiance'],
-            input_dict['diffuse_horizontal_irradiance'],
-            input_dict['ground_reflectance']
+            data['altitude'],
+            data['azimuth'],
+            data['direct_normal_irradiance'],
+            data['diffuse_horizontal_irradiance'],
+            data['ground_reflectance']
         )
 
-        if 'ground_hemisphere' in input_dict:
-            sky._ground_hemisphere = Ground.from_dict(input_dict['ground_hemisphere'])
+        if 'ground_hemisphere' in data and data['ground_hemisphere'] is not None:
+            sky._ground_hemisphere = Ground.from_dict(data['ground_hemisphere'])
 
-        if 'sky_hemisphere' in input_dict:
-            sky._sky_hemisphere = Hemisphere.from_dict(input_dict['sky_hemisphere'])
+        if 'sky_hemisphere' in data and data['sky_hemisphere'] is not None:
+            sky._sky_hemisphere = Hemisphere.from_dict(data['sky_hemisphere'])
 
         return sky
 

--- a/honeybee_radiance/lightsource/sky/climatebased.py
+++ b/honeybee_radiance/lightsource/sky/climatebased.py
@@ -57,7 +57,7 @@ class ClimateBased(_PointInTime):
 
     @property
     def altitude(self):
-        """Get and set solar altitude.
+        """Get or set a number between -90 and 90 for the solar altitude.
 
         The altitude is measured in degrees above the horizon.
         """
@@ -65,12 +65,12 @@ class ClimateBased(_PointInTime):
 
     @altitude.setter
     def altitude(self, value):
-        value = typing.float_in_range(value, 0, 90, 'Solar altitude')
+        value = typing.float_in_range(value, -90, 90, 'Solar altitude')
         self._altitude = value
 
     @property
     def azimuth(self):
-        """Get and set solar azimuth.
+        """Get or set a number between 0 and 360 for the solar azimuth.
 
         The azimuth is measured in degrees east of North. East is 90, South is 180 and
         West is 270. Note that this input is different from Radiance convention. In

--- a/honeybee_radiance/modifier/material/bsdf.py
+++ b/honeybee_radiance/modifier/material/bsdf.py
@@ -358,7 +358,7 @@ class BSDF(Material):
             "thickness": number,  # default: 0
             "function_file": string,  # default: '.'
             "transform": string,  # default: None
-            "bsdf_data": bytes,  # bsdf file data as bytes
+            "bsdf_data": string,  # bsdf file data as string
             "front_diffuse_reflectance": [number, number, number],  # optional
             "back_diffuse_reflectance": [number, number, number],  # optional
             "diffuse_transmittance": [number, number, number]  # optional

--- a/honeybee_radiance/properties/aperture.py
+++ b/honeybee_radiance/properties/aperture.py
@@ -177,7 +177,7 @@ class ApertureRadianceProperties(_DynamicRadianceProperties):
         """
         if 'dynamic_group_identifier' in abridged_data and \
                 abridged_data['dynamic_group_identifier'] is not None:
-            self.dynamic_group_identifier = dynamic_group_identifier
+            self.dynamic_group_identifier = abridged_data['dynamic_group_identifier']
         if 'states' in abridged_data and abridged_data['states'] is not None:
             self.states = [RadianceSubFaceState.from_dict_abridged(st, modifiers)
                            for st in abridged_data['states']]

--- a/honeybee_radiance/properties/door.py
+++ b/honeybee_radiance/properties/door.py
@@ -178,7 +178,7 @@ class DoorRadianceProperties(_DynamicRadianceProperties):
         """
         if 'dynamic_group_identifier' in abridged_data and \
                 abridged_data['dynamic_group_identifier'] is not None:
-            self.dynamic_group_identifier = dynamic_group_identifier
+            self.dynamic_group_identifier = abridged_data['dynamic_group_identifier']
         if 'states' in abridged_data and abridged_data['states'] is not None:
             self.states = [RadianceSubFaceState.from_dict_abridged(st, modifiers)
                            for st in abridged_data['states']]

--- a/honeybee_radiance/properties/shade.py
+++ b/honeybee_radiance/properties/shade.py
@@ -155,7 +155,7 @@ class ShadeRadianceProperties(_DynamicRadianceProperties):
         """
         if 'dynamic_group_identifier' in abridged_data and \
                 abridged_data['dynamic_group_identifier'] is not None:
-            self.dynamic_group_identifier = dynamic_group_identifier
+            self.dynamic_group_identifier = abridged_data['dynamic_group_identifier']
         if 'states' in abridged_data and abridged_data['states'] is not None:
             self.states = [RadianceShadeState.from_dict_abridged(st, modifiers)
                            for st in abridged_data['states']]

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -226,7 +226,8 @@ def model_to_rad(model, blk=False, minimal=False):
     return '\n\n'.join(model_str), '\n\n'.join(modifier_str)
 
 
-def model_to_rad_folder(model, folder=None, folder_type=2, minimal=False):
+def model_to_rad_folder(model, folder=None, folder_type=2, config_file=None,
+                        minimal=False):
     r"""Write a honeybee model to a rad folder.
 
     The rad files in the resulting folders will include all geometry
@@ -244,6 +245,9 @@ def model_to_rad_folder(model, folder=None, folder_type=2, minimal=False):
                 * 0: grid-based
                 * 1: view-based
                 * 2: includes both views and grids
+        config_file: An optional config file path to modify the default folder
+            names. If None, ``folder.cfg`` in ``honeybee-radiance-folder``
+            will be used. (Default: None).
         minimal: Boolean to note whether the radiance strings should be written
             in a minimal format (with spaces instead of line breaks). Default: False.
     """
@@ -253,7 +257,7 @@ def model_to_rad_folder(model, folder=None, folder_type=2, minimal=False):
         folder = os.path.join(folders.default_simulation_folder, model_id, 'Radiance')
     if not os.path.isdir(folder):
         preparedir(folder)  # create the directory if it's not there
-    model_folder = ModelFolder(folder)
+    model_folder = ModelFolder(folder, config_file)
     model_folder.write(folder_type=folder_type, cfg=folder_config.full, overwrite=True)
 
     # gather and write static apertures to the folder

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -314,6 +314,8 @@ def model_to_rad_folder(model, folder=None, folder_type=2, minimal=False):
         new_bsdf_path = os.path.join(bsdf_folder, bsdf_name)
         shutil.copy(bdf_mod.bsdf_file, new_bsdf_path)
 
+    return folder
+
 
 def _write_dynamic_shade_files(folder, sub_folder, group, minimal=False):
     """Write out the files that need to go into any dynamic model folder.

--- a/tests/assets/model/model_complete_multiroom_radiance.json
+++ b/tests/assets/model/model_complete_multiroom_radiance.json
@@ -1,0 +1,1867 @@
+{
+    "type": "Model",
+    "identifier": "Multi_Room_Radiance_House",
+    "display_name": "Multi_Room_Radiance_House",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [
+                {
+                    "type": "ConstructionSetAbridged",
+                    "identifier": "Default Generic Construction Set",
+                    "wall_set": {
+                        "type": "WallConstructionSetAbridged",
+                        "exterior_construction": "Generic Exterior Wall",
+                        "interior_construction": "Generic Interior Wall",
+                        "ground_construction": "Generic Underground Wall"
+                    },
+                    "floor_set": {
+                        "type": "FloorConstructionSetAbridged",
+                        "exterior_construction": "Generic Exposed Floor",
+                        "interior_construction": "Generic Interior Floor",
+                        "ground_construction": "Generic Ground Slab"
+                    },
+                    "roof_ceiling_set": {
+                        "type": "RoofCeilingConstructionSetAbridged",
+                        "exterior_construction": "Generic Roof",
+                        "interior_construction": "Generic Interior Ceiling",
+                        "ground_construction": "Generic Underground Roof"
+                    },
+                    "aperture_set": {
+                        "type": "ApertureConstructionSetAbridged",
+                        "window_construction": "Generic Double Pane",
+                        "interior_construction": "Generic Single Pane",
+                        "skylight_construction": "Generic Double Pane",
+                        "operable_construction": "Generic Double Pane"
+                    },
+                    "door_set": {
+                        "type": "DoorConstructionSetAbridged",
+                        "exterior_construction": "Generic Exterior Door",
+                        "interior_construction": "Generic Interior Door",
+                        "exterior_glass_construction": "Generic Double Pane",
+                        "interior_glass_construction": "Generic Single Pane",
+                        "overhead_construction": "Generic Exterior Door"
+                    },
+                    "shade_construction": "Generic Shade",
+                    "air_boundary_construction": "Generic Air Boundary"
+                }
+            ],
+            "global_construction_set": "Default Generic Construction Set",
+            "constructions": [
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Door",
+                    "layers": [
+                        "Generic 25mm Wood"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "identifier": "Generic Single Pane",
+                    "layers": [
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "ShadeConstruction",
+                    "identifier": "Generic Shade",
+                    "solar_reflectance": 0.35,
+                    "visible_reflectance": 0.35,
+                    "is_specular": false
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Ceiling",
+                    "layers": [
+                        "Generic LW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Wall",
+                    "layers": [
+                        "Generic Gypsum Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exposed Floor",
+                    "layers": [
+                        "Generic Painted Metal",
+                        "Generic Ceiling Air Gap",
+                        "Generic 50mm Insulation",
+                        "Generic LW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Floor",
+                    "layers": [
+                        "Generic Acoustic Tile",
+                        "Generic Ceiling Air Gap",
+                        "Generic LW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Ground Slab",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Roof",
+                    "layers": [
+                        "Generic Roof Membrane",
+                        "Generic 50mm Insulation",
+                        "Generic LW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exterior Wall",
+                    "layers": [
+                        "Generic Brick",
+                        "Generic LW Concrete",
+                        "Generic 50mm Insulation",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Underground Wall",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "AirBoundaryConstructionAbridged",
+                    "identifier": "Generic Air Boundary",
+                    "air_mixing_per_area": 0.1,
+                    "air_mixing_schedule": "Always On"
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Underground Roof",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "identifier": "Generic Double Pane",
+                    "layers": [
+                        "Generic Low-e Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exterior Door",
+                    "layers": [
+                        "Generic Painted Metal",
+                        "Generic 25mm Insulation",
+                        "Generic Painted Metal"
+                    ]
+                }
+            ],
+            "materials": [
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Roof Membrane",
+                    "roughness": "MediumRough",
+                    "thickness": 0.01,
+                    "conductivity": 0.16,
+                    "density": 1120.0,
+                    "specific_heat": 1460.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.65,
+                    "visible_absorptance": 0.65
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Acoustic Tile",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.02,
+                    "conductivity": 0.06,
+                    "density": 368.0,
+                    "specific_heat": 590.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.2,
+                    "visible_absorptance": 0.2
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 25mm Wood",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0254,
+                    "conductivity": 0.15,
+                    "density": 608.0,
+                    "specific_heat": 1630.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic HW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.2,
+                    "conductivity": 1.95,
+                    "density": 2240.0,
+                    "specific_heat": 900.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "identifier": "Generic Window Air Gap",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0127,
+                    "conductivity": 0.16,
+                    "density": 800.0,
+                    "specific_heat": 1090.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Brick",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.9,
+                    "density": 1920.0,
+                    "specific_heat": 790.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.65,
+                    "visible_absorptance": 0.65
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 50mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "identifier": "Generic Low-e Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.45,
+                    "solar_reflectance": 0.36,
+                    "solar_reflectance_back": 0.36,
+                    "visible_transmittance": 0.71,
+                    "visible_reflectance": 0.21,
+                    "visible_reflectance_back": 0.21,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.047,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Painted Metal",
+                    "roughness": "Smooth",
+                    "thickness": 0.0015,
+                    "conductivity": 45.0,
+                    "density": 7690.0,
+                    "specific_heat": 410.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic LW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 25mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "identifier": "Generic Clear Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.77,
+                    "solar_reflectance": 0.07,
+                    "solar_reflectance_back": 0.07,
+                    "visible_transmittance": 0.88,
+                    "visible_reflectance": 0.08,
+                    "visible_reflectance_back": 0.08,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.84,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                }
+            ],
+            "hvacs": [],
+            "program_types": [],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Always On",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Always On_Day Schedule",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Always On_Day Schedule",
+                    "schedule_type_limit": "Fractional"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                }
+            ]
+        },
+        "radiance": {
+            "type": "ModelRadianceProperties",
+            "modifier_sets": [
+                {
+                    "type": "ModifierSetAbridged",
+                    "identifier": "Generic_Interior_Visible_Modifier_Set",
+                    "wall_set": {
+                        "exterior_modifier": "generic_wall_0.50",
+                        "interior_modifier": "generic_wall_0.50",
+                        "type": "WallModifierSetAbridged"
+                    },
+                    "floor_set": {
+                        "exterior_modifier": "generic_floor_0.20",
+                        "interior_modifier": "generic_floor_0.20",
+                        "type": "FloorModifierSetAbridged"
+                    },
+                    "roof_ceiling_set": {
+                        "exterior_modifier": "generic_ceiling_0.80",
+                        "interior_modifier": "generic_ceiling_0.80",
+                        "type": "RoofCeilingModifierSetAbridged"
+                    },
+                    "aperture_set": {
+                        "skylight_modifier": "generic_exterior_window_vis_0.64",
+                        "operable_modifier": "generic_exterior_window_vis_0.64",
+                        "interior_modifier": "generic_interior_window_vis_0.88",
+                        "type": "ApertureModifierSetAbridged",
+                        "window_modifier": "generic_exterior_window_vis_0.64"
+                    },
+                    "door_set": {
+                        "overhead_modifier": "generic_opaque_door_0.50",
+                        "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
+                        "interior_glass_modifier": "generic_interior_window_vis_0.88",
+                        "exterior_modifier": "generic_opaque_door_0.50",
+                        "interior_modifier": "generic_opaque_door_0.50",
+                        "type": "DoorModifierSetAbridged"
+                    },
+                    "shade_set": {
+                        "exterior_modifier": "generic_exterior_shade_0.35",
+                        "interior_modifier": "generic_interior_shade_0.50",
+                        "type": "ShadeModifierSetAbridged"
+                    },
+                    "air_boundary_modifier": "air_boundary"
+                },
+                {
+                    "type": "ModifierSetAbridged",
+                    "identifier": "Attic_Modifier_Set",
+                    "wall_set": {
+                        "exterior_modifier": null,
+                        "interior_modifier": null,
+                        "type": "WallModifierSetAbridged"
+                    },
+                    "floor_set": {
+                        "exterior_modifier": null,
+                        "interior_modifier": null,
+                        "type": "FloorModifierSetAbridged"
+                    },
+                    "roof_ceiling_set": {
+                        "exterior_modifier": "PolyIso",
+                        "interior_modifier": null,
+                        "type": "RoofCeilingModifierSetAbridged"
+                    },
+                    "aperture_set": {
+                        "skylight_modifier": null,
+                        "operable_modifier": null,
+                        "interior_modifier": null,
+                        "type": "ApertureModifierSetAbridged",
+                        "window_modifier": null
+                    },
+                    "door_set": {
+                        "overhead_modifier": null,
+                        "exterior_glass_modifier": null,
+                        "interior_glass_modifier": null,
+                        "exterior_modifier": null,
+                        "interior_modifier": null,
+                        "type": "DoorModifierSetAbridged"
+                    },
+                    "shade_set": {
+                        "exterior_modifier": null,
+                        "interior_modifier": null,
+                        "type": "ShadeModifierSetAbridged"
+                    },
+                    "air_boundary_modifier": null
+                }
+            ],
+            "global_modifier_set": "Generic_Interior_Visible_Modifier_Set",
+            "modifiers": [
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "air_boundary",
+                    "r_transmissivity": 1.0,
+                    "g_transmissivity": 1.0,
+                    "b_transmissivity": 1.0,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_interior_shade_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_opaque_door_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_floor_0.20",
+                    "r_reflectance": 0.2,
+                    "g_reflectance": 0.2,
+                    "b_reflectance": 0.2,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "Triple_Pane_0.35",
+                    "r_transmissivity": 0.38172294125333217,
+                    "g_transmissivity": 0.38172294125333217,
+                    "b_transmissivity": 0.38172294125333217,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_exterior_shade_0.35",
+                    "r_reflectance": 0.35,
+                    "g_reflectance": 0.35,
+                    "b_reflectance": 0.35,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "PolyIso",
+                    "r_reflectance": 0.45,
+                    "g_reflectance": 0.45,
+                    "b_reflectance": 0.45,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "generic_exterior_window_vis_0.64",
+                    "r_transmissivity": 0.6975761815384331,
+                    "g_transmissivity": 0.6975761815384331,
+                    "b_transmissivity": 0.6975761815384331,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_wall_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_ceiling_0.80",
+                    "r_reflectance": 0.8,
+                    "g_reflectance": 0.8,
+                    "b_reflectance": 0.8,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "generic_interior_window_vis_0.88",
+                    "r_transmissivity": 0.9584154328610596,
+                    "g_transmissivity": 0.9584154328610596,
+                    "b_transmissivity": 0.9584154328610596,
+                    "refraction_index": null,
+                    "dependencies": []
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "First_Floor",
+            "display_name": "First_Floor",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "RoomRadiancePropertiesAbridged"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Bottom",
+                    "display_name": "First_Floor_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Front",
+                    "display_name": "First_Floor_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Front_Glz0",
+                            "display_name": "First_Floor_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged",
+                                    "modifier": "Triple_Pane_0.35"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Right",
+                    "display_name": "First_Floor_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Right_Glz0",
+                            "display_name": "First_Floor_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged",
+                                    "modifier": "Triple_Pane_0.35"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Back",
+                    "display_name": "First_Floor_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Back_Glz0",
+                            "display_name": "First_Floor_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged",
+                                    "modifier": "Triple_Pane_0.35"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Left",
+                    "display_name": "First_Floor_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "First_Floor_Left_Glz0",
+                            "display_name": "First_Floor_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged",
+                                    "modifier": "Triple_Pane_0.35"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        2.170820393249937
+                                    ],
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        0.8291796067500631
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        2.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "First_Floor_Top",
+                    "display_name": "First_Floor_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "Second_Floor_Bottom",
+                            "Second_Floor"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "Second_Floor",
+            "display_name": "Second_Floor",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "RoomRadiancePropertiesAbridged"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Bottom",
+                    "display_name": "Second_Floor_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "First_Floor_Top",
+                            "First_Floor"
+                        ]
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Front",
+                    "display_name": "Second_Floor_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Front_Glz0",
+                            "display_name": "Second_Floor_Front_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        10.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        10.0,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Right",
+                    "display_name": "Second_Floor_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Right_Glz0",
+                            "display_name": "Second_Floor_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        10.0,
+                                        2.76393202250021,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        10.0,
+                                        7.23606797749979,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Back",
+                    "display_name": "Second_Floor_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Back_Glz0",
+                            "display_name": "Second_Floor_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        2.76393202250021,
+                                        0.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        7.23606797749979,
+                                        0.0,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Left",
+                    "display_name": "Second_Floor_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Second_Floor_Left_Glz0",
+                            "display_name": "Second_Floor_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        5.170820393249937
+                                    ],
+                                    [
+                                        0.0,
+                                        7.23606797749979,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        3.829179606750063
+                                    ],
+                                    [
+                                        0.0,
+                                        2.76393202250021,
+                                        5.170820393249937
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Second_Floor_Top",
+                    "display_name": "Second_Floor_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "AtticFace1",
+                            "Attic"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "Attic",
+            "display_name": "Attic",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "RoomRadiancePropertiesAbridged",
+                    "modifier_set": "Attic_Modifier_Set"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "AtticFace1",
+                    "display_name": "AtticFace1",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "Second_Floor_Top",
+                            "Second_Floor"
+                        ]
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "AtticFace2",
+                    "display_name": "AtticFace2",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                10.0,
+                                9.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                9.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "AtticFace3",
+                    "display_name": "AtticFace3",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                9.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                9.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "AtticFace4",
+                    "display_name": "AtticFace4",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                6.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                9.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "AtticFace5",
+                    "display_name": "AtticFace5",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                6.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                9.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/assets/model/model_radiance_dynamic_states.json
+++ b/tests/assets/model/model_radiance_dynamic_states.json
@@ -1,0 +1,1858 @@
+{
+    "type": "Model",
+    "identifier": "Tiny_House",
+    "display_name": "Tiny_House",
+    "units": "Meters",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [
+                {
+                    "type": "ConstructionSetAbridged",
+                    "identifier": "Default Generic Construction Set",
+                    "wall_set": {
+                        "type": "WallConstructionSetAbridged",
+                        "exterior_construction": "Generic Exterior Wall",
+                        "interior_construction": "Generic Interior Wall",
+                        "ground_construction": "Generic Underground Wall"
+                    },
+                    "floor_set": {
+                        "type": "FloorConstructionSetAbridged",
+                        "exterior_construction": "Generic Exposed Floor",
+                        "interior_construction": "Generic Interior Floor",
+                        "ground_construction": "Generic Ground Slab"
+                    },
+                    "roof_ceiling_set": {
+                        "type": "RoofCeilingConstructionSetAbridged",
+                        "exterior_construction": "Generic Roof",
+                        "interior_construction": "Generic Interior Ceiling",
+                        "ground_construction": "Generic Underground Roof"
+                    },
+                    "aperture_set": {
+                        "type": "ApertureConstructionSetAbridged",
+                        "window_construction": "Generic Double Pane",
+                        "interior_construction": "Generic Single Pane",
+                        "skylight_construction": "Generic Double Pane",
+                        "operable_construction": "Generic Double Pane"
+                    },
+                    "door_set": {
+                        "type": "DoorConstructionSetAbridged",
+                        "exterior_construction": "Generic Exterior Door",
+                        "interior_construction": "Generic Interior Door",
+                        "exterior_glass_construction": "Generic Double Pane",
+                        "interior_glass_construction": "Generic Single Pane",
+                        "overhead_construction": "Generic Exterior Door"
+                    },
+                    "shade_construction": "Generic Shade",
+                    "air_boundary_construction": "Generic Air Boundary"
+                }
+            ],
+            "global_construction_set": "Default Generic Construction Set",
+            "constructions": [
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Door",
+                    "layers": [
+                        "Generic 25mm Wood"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "identifier": "Generic Single Pane",
+                    "layers": [
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "ShadeConstruction",
+                    "identifier": "Generic Shade",
+                    "solar_reflectance": 0.35,
+                    "visible_reflectance": 0.35,
+                    "is_specular": false
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Ceiling",
+                    "layers": [
+                        "Generic LW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Wall",
+                    "layers": [
+                        "Generic Gypsum Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exposed Floor",
+                    "layers": [
+                        "Generic Painted Metal",
+                        "Generic Ceiling Air Gap",
+                        "Generic 50mm Insulation",
+                        "Generic LW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Interior Floor",
+                    "layers": [
+                        "Generic Acoustic Tile",
+                        "Generic Ceiling Air Gap",
+                        "Generic LW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Ground Slab",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Roof",
+                    "layers": [
+                        "Generic Roof Membrane",
+                        "Generic 50mm Insulation",
+                        "Generic LW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exterior Wall",
+                    "layers": [
+                        "Generic Brick",
+                        "Generic LW Concrete",
+                        "Generic 50mm Insulation",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Underground Wall",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "AirBoundaryConstructionAbridged",
+                    "identifier": "Generic Air Boundary",
+                    "air_mixing_per_area": 0.1,
+                    "air_mixing_schedule": "Always On"
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Underground Roof",
+                    "layers": [
+                        "Generic 50mm Insulation",
+                        "Generic HW Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "identifier": "Generic Double Pane",
+                    "layers": [
+                        "Generic Low-e Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "identifier": "Generic Exterior Door",
+                    "layers": [
+                        "Generic Painted Metal",
+                        "Generic 25mm Insulation",
+                        "Generic Painted Metal"
+                    ]
+                }
+            ],
+            "materials": [
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Roof Membrane",
+                    "roughness": "MediumRough",
+                    "thickness": 0.01,
+                    "conductivity": 0.16,
+                    "density": 1120.0,
+                    "specific_heat": 1460.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.65,
+                    "visible_absorptance": 0.65
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Acoustic Tile",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.02,
+                    "conductivity": 0.06,
+                    "density": 368.0,
+                    "specific_heat": 590.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.2,
+                    "visible_absorptance": 0.2
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 25mm Wood",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0254,
+                    "conductivity": 0.15,
+                    "density": 608.0,
+                    "specific_heat": 1630.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic HW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.2,
+                    "conductivity": 1.95,
+                    "density": 2240.0,
+                    "specific_heat": 900.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "identifier": "Generic Window Air Gap",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0127,
+                    "conductivity": 0.16,
+                    "density": 800.0,
+                    "specific_heat": 1090.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Brick",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.9,
+                    "density": 1920.0,
+                    "specific_heat": 790.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.65,
+                    "visible_absorptance": 0.65
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 50mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "identifier": "Generic Low-e Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.45,
+                    "solar_reflectance": 0.36,
+                    "solar_reflectance_back": 0.36,
+                    "visible_transmittance": 0.71,
+                    "visible_reflectance": 0.21,
+                    "visible_reflectance_back": 0.21,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.047,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic Painted Metal",
+                    "roughness": "Smooth",
+                    "thickness": 0.0015,
+                    "conductivity": 45.0,
+                    "density": 7690.0,
+                    "specific_heat": 410.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic LW Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "identifier": "Generic 25mm Insulation",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "identifier": "Generic Clear Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.77,
+                    "solar_reflectance": 0.07,
+                    "solar_reflectance_back": 0.07,
+                    "visible_transmittance": 0.88,
+                    "visible_reflectance": 0.08,
+                    "visible_reflectance_back": 0.08,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.84,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                }
+            ],
+            "hvacs": [],
+            "program_types": [],
+            "schedules": [
+                {
+                    "type": "ScheduleRulesetAbridged",
+                    "identifier": "Always On",
+                    "day_schedules": [
+                        {
+                            "type": "ScheduleDay",
+                            "identifier": "Always On_Day Schedule",
+                            "values": [
+                                1.0
+                            ],
+                            "times": [
+                                [
+                                    0,
+                                    0
+                                ]
+                            ],
+                            "interpolate": false
+                        }
+                    ],
+                    "default_day_schedule": "Always On_Day Schedule",
+                    "schedule_type_limit": "Fractional"
+                }
+            ],
+            "schedule_type_limits": [
+                {
+                    "type": "ScheduleTypeLimit",
+                    "identifier": "Fractional",
+                    "lower_limit": 0.0,
+                    "upper_limit": 1.0,
+                    "numeric_type": "Continuous",
+                    "unit_type": "Dimensionless"
+                }
+            ]
+        },
+        "radiance": {
+            "type": "ModelRadianceProperties",
+            "modifier_sets": [
+                {
+                    "type": "ModifierSetAbridged",
+                    "identifier": "Generic_Interior_Visible_Modifier_Set",
+                    "wall_set": {
+                        "exterior_modifier": "generic_wall_0.50",
+                        "interior_modifier": "generic_wall_0.50",
+                        "type": "WallModifierSetAbridged"
+                    },
+                    "floor_set": {
+                        "exterior_modifier": "generic_floor_0.20",
+                        "interior_modifier": "generic_floor_0.20",
+                        "type": "FloorModifierSetAbridged"
+                    },
+                    "roof_ceiling_set": {
+                        "exterior_modifier": "generic_ceiling_0.80",
+                        "interior_modifier": "generic_ceiling_0.80",
+                        "type": "RoofCeilingModifierSetAbridged"
+                    },
+                    "aperture_set": {
+                        "skylight_modifier": "generic_exterior_window_vis_0.64",
+                        "operable_modifier": "generic_exterior_window_vis_0.64",
+                        "interior_modifier": "generic_interior_window_vis_0.88",
+                        "type": "ApertureModifierSetAbridged",
+                        "window_modifier": "generic_exterior_window_vis_0.64"
+                    },
+                    "door_set": {
+                        "overhead_modifier": "generic_opaque_door_0.50",
+                        "exterior_glass_modifier": "generic_exterior_window_vis_0.64",
+                        "interior_glass_modifier": "generic_interior_window_vis_0.88",
+                        "exterior_modifier": "generic_opaque_door_0.50",
+                        "interior_modifier": "generic_opaque_door_0.50",
+                        "type": "DoorModifierSetAbridged"
+                    },
+                    "shade_set": {
+                        "exterior_modifier": "generic_exterior_shade_0.35",
+                        "interior_modifier": "generic_interior_shade_0.50",
+                        "type": "ShadeModifierSetAbridged"
+                    },
+                    "air_boundary_modifier": "air_boundary"
+                }
+            ],
+            "global_modifier_set": "Generic_Interior_Visible_Modifier_Set",
+            "modifiers": [
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_exterior_shade_0.35",
+                    "r_reflectance": 0.35,
+                    "g_reflectance": 0.35,
+                    "b_reflectance": 0.35,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "air_boundary",
+                    "r_transmissivity": 1.0,
+                    "g_transmissivity": 1.0,
+                    "b_transmissivity": 1.0,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "trans",
+                    "identifier": "WinterLeaves",
+                    "r_reflectance": 0.1,
+                    "g_reflectance": 0.1,
+                    "b_reflectance": 0.1,
+                    "specularity": 0.0,
+                    "roughness": 0.1,
+                    "transmitted_diff": 0.1,
+                    "transmitted_spec": 0.6,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_interior_shade_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_opaque_door_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "trans",
+                    "identifier": "SummerLeaves",
+                    "r_reflectance": 0.3,
+                    "g_reflectance": 0.3,
+                    "b_reflectance": 0.3,
+                    "specularity": 0.0,
+                    "roughness": 0.1,
+                    "transmitted_diff": 0.15,
+                    "transmitted_spec": 0.15,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_ceiling_0.80",
+                    "r_reflectance": 0.8,
+                    "g_reflectance": 0.8,
+                    "b_reflectance": 0.8,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "grass",
+                    "r_reflectance": 0.3,
+                    "g_reflectance": 0.3,
+                    "b_reflectance": 0.3,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "ElectrochromicState2",
+                    "r_transmissivity": 0.2945034602948791,
+                    "g_transmissivity": 0.2945034602948791,
+                    "b_transmissivity": 0.2945034602948791,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_context_0.20",
+                    "r_reflectance": 0.2,
+                    "g_reflectance": 0.2,
+                    "b_reflectance": 0.2,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "snow",
+                    "r_reflectance": 0.7,
+                    "g_reflectance": 0.7,
+                    "b_reflectance": 0.7,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "indoor_light_shelf_0.70",
+                    "r_reflectance": 0.7,
+                    "g_reflectance": 0.7,
+                    "b_reflectance": 0.7,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_wall_0.50",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "ElectrochromicState1",
+                    "r_transmissivity": 0.43621953425431875,
+                    "g_transmissivity": 0.43621953425431875,
+                    "b_transmissivity": 0.43621953425431875,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "generic_interior_window_vis_0.88",
+                    "r_transmissivity": 0.9584154328610596,
+                    "g_transmissivity": 0.9584154328610596,
+                    "b_transmissivity": 0.9584154328610596,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "outdoor_light_shelf_0.5",
+                    "r_reflectance": 0.5,
+                    "g_reflectance": 0.5,
+                    "b_reflectance": 0.5,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "custom_triple_pane_0.3",
+                    "r_transmissivity": 0.3272140103902576,
+                    "g_transmissivity": 0.3272140103902576,
+                    "b_transmissivity": 0.3272140103902576,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "plastic",
+                    "identifier": "generic_floor_0.20",
+                    "r_reflectance": 0.2,
+                    "g_reflectance": 0.2,
+                    "b_reflectance": 0.2,
+                    "specularity": 0.0,
+                    "roughness": 0.0,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "generic_exterior_window_vis_0.64",
+                    "r_transmissivity": 0.6975761815384331,
+                    "g_transmissivity": 0.6975761815384331,
+                    "b_transmissivity": 0.6975761815384331,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "ElectrochromicState4",
+                    "r_transmissivity": 0.010907888742458781,
+                    "g_transmissivity": 0.010907888742458781,
+                    "b_transmissivity": 0.010907888742458781,
+                    "refraction_index": null,
+                    "dependencies": []
+                },
+                {
+                    "modifier": null,
+                    "type": "glass",
+                    "identifier": "ElectrochromicState3",
+                    "r_transmissivity": 0.15272298493612294,
+                    "g_transmissivity": 0.15272298493612294,
+                    "b_transmissivity": 0.15272298493612294,
+                    "refraction_index": null,
+                    "dependencies": []
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "Room",
+            "identifier": "Tiny_House_Zone",
+            "display_name": "Tiny_House_Zone",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "RoomRadiancePropertiesAbridged"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_House_Zone_Bottom",
+                    "display_name": "Tiny_House_Zone_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_House_Zone_Front",
+                    "display_name": "Tiny_House_Zone_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Front_Aperture",
+                            "display_name": "Front_Aperture",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged",
+                                    "modifier": "custom_triple_pane_0.3"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        4.5,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        4.5,
+                                        10.0,
+                                        1.0
+                                    ],
+                                    [
+                                        2.5,
+                                        10.0,
+                                        1.0
+                                    ],
+                                    [
+                                        2.5,
+                                        10.0,
+                                        2.5
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ],
+                    "doors": [
+                        {
+                            "type": "Door",
+                            "identifier": "Front_Door",
+                            "display_name": "Front_Door",
+                            "properties": {
+                                "type": "DoorPropertiesAbridged",
+                                "energy": {
+                                    "type": "DoorEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "DoorRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        2.0,
+                                        10.0,
+                                        2.5
+                                    ],
+                                    [
+                                        2.0,
+                                        10.0,
+                                        0.1
+                                    ],
+                                    [
+                                        1.0,
+                                        10.0,
+                                        0.1
+                                    ],
+                                    [
+                                        1.0,
+                                        10.0,
+                                        2.5
+                                    ]
+                                ]
+                            },
+                            "is_glass": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ],
+                    "outdoor_shades": [
+                        {
+                            "type": "Shade",
+                            "identifier": "Tiny_House_Zone_Front_OutOverhang0",
+                            "display_name": "Tiny_House_Zone_Front_OutOverhang0",
+                            "properties": {
+                                "type": "ShadePropertiesAbridged",
+                                "energy": {
+                                    "type": "ShadeEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ShadeRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.0,
+                                        10.0,
+                                        2.9999998999999997
+                                    ],
+                                    [
+                                        5.0,
+                                        10.0,
+                                        2.9999998999999997
+                                    ],
+                                    [
+                                        5.0,
+                                        10.25,
+                                        2.9999998999999997
+                                    ],
+                                    [
+                                        0.0,
+                                        10.25,
+                                        2.9999998999999997
+                                    ]
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_House_Zone_Right",
+                    "display_name": "Tiny_House_Zone_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "Tiny_Garage_Left",
+                            "Tiny_Garage"
+                        ]
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Tiny_House_Zone_Right_Glz0",
+                            "display_name": "Tiny_House_Zone_Right_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        5.0,
+                                        3.41886116991581,
+                                        1.974341649025257
+                                    ],
+                                    [
+                                        5.0,
+                                        3.41886116991581,
+                                        1.025658350974743
+                                    ],
+                                    [
+                                        5.0,
+                                        6.58113883008419,
+                                        1.025658350974743
+                                    ],
+                                    [
+                                        5.0,
+                                        6.58113883008419,
+                                        1.974341649025257
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "Tiny_Garage_Left_Glz0",
+                                    "Tiny_Garage_Left",
+                                    "Tiny_Garage"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_House_Zone_Back",
+                    "display_name": "Tiny_House_Zone_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Tiny_House_Zone_Back_Glz0",
+                            "display_name": "Tiny_House_Zone_Back_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged",
+                                    "dynamic_group_identifier": "ElectrochromicWindow",
+                                    "states": [
+                                        {
+                                            "type": "RadianceSubFaceStateAbridged",
+                                            "modifier": "ElectrochromicState1"
+                                        },
+                                        {
+                                            "type": "RadianceSubFaceStateAbridged",
+                                            "modifier": "ElectrochromicState2"
+                                        },
+                                        {
+                                            "type": "RadianceSubFaceStateAbridged",
+                                            "modifier": "ElectrochromicState3",
+                                            "shades": [
+                                                {
+                                                    "type": "StateGeometryAbridged",
+                                                    "identifier": "outdoor_awning",
+                                                    "display_name": "outdoor_awning",
+                                                    "geometry": {
+                                                        "type": "Face3D",
+                                                        "boundary": [
+                                                            [
+                                                                0.0,
+                                                                0.0,
+                                                                2.0
+                                                            ],
+                                                            [
+                                                                5.0,
+                                                                0.0,
+                                                                2.0
+                                                            ],
+                                                            [
+                                                                5.0,
+                                                                2.0,
+                                                                2.0
+                                                            ],
+                                                            [
+                                                                0.0,
+                                                                2.0,
+                                                                2.0
+                                                            ]
+                                                        ],
+                                                        "plane": {
+                                                            "type": "Plane",
+                                                            "n": [
+                                                                0.0,
+                                                                0.0,
+                                                                1.0
+                                                            ],
+                                                            "o": [
+                                                                0.0,
+                                                                0.0,
+                                                                2.0
+                                                            ],
+                                                            "x": [
+                                                                1.0,
+                                                                0.0,
+                                                                0.0
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "RadianceSubFaceStateAbridged",
+                                            "modifier": "ElectrochromicState4",
+                                            "shades": [
+                                                {
+                                                    "type": "StateGeometryAbridged",
+                                                    "identifier": "outdoor_awning",
+                                                    "display_name": "outdoor_awning",
+                                                    "geometry": {
+                                                        "type": "Face3D",
+                                                        "boundary": [
+                                                            [
+                                                                0.0,
+                                                                0.0,
+                                                                2.0
+                                                            ],
+                                                            [
+                                                                5.0,
+                                                                0.0,
+                                                                2.0
+                                                            ],
+                                                            [
+                                                                5.0,
+                                                                2.0,
+                                                                2.0
+                                                            ],
+                                                            [
+                                                                0.0,
+                                                                2.0,
+                                                                2.0
+                                                            ]
+                                                        ],
+                                                        "plane": {
+                                                            "type": "Plane",
+                                                            "n": [
+                                                                0.0,
+                                                                0.0,
+                                                                1.0
+                                                            ],
+                                                            "o": [
+                                                                0.0,
+                                                                0.0,
+                                                                2.0
+                                                            ],
+                                                            "x": [
+                                                                1.0,
+                                                                0.0,
+                                                                0.0
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        0.7322330470336311,
+                                        0.0,
+                                        2.5606601717798214
+                                    ],
+                                    [
+                                        0.7322330470336311,
+                                        0.0,
+                                        0.4393398282201786
+                                    ],
+                                    [
+                                        4.267766952966369,
+                                        0.0,
+                                        0.4393398282201786
+                                    ],
+                                    [
+                                        4.267766952966369,
+                                        0.0,
+                                        2.5606601717798214
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Outdoors",
+                                "sun_exposure": true,
+                                "wind_exposure": true,
+                                "view_factor": {
+                                    "type": "Autocalculate"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_House_Zone_Left",
+                    "display_name": "Tiny_House_Zone_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_House_Zone_Top",
+                    "display_name": "Tiny_House_Zone_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                0.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ],
+            "indoor_shades": [
+                {
+                    "type": "Shade",
+                    "identifier": "indoor_light_shelf",
+                    "display_name": "indoor_light_shelf",
+                    "properties": {
+                        "type": "ShadePropertiesAbridged",
+                        "energy": {
+                            "type": "ShadeEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "ShadeRadiancePropertiesAbridged",
+                            "dynamic_group_identifier": "DynamicLightShelf",
+                            "states": [
+                                {
+                                    "type": "RadianceShadeStateAbridged",
+                                    "modifier": "outdoor_light_shelf_0.5"
+                                },
+                                {
+                                    "type": "RadianceShadeStateAbridged",
+                                    "modifier": "indoor_light_shelf_0.70"
+                                }
+                            ]
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                0.0,
+                                0.0,
+                                2.0
+                            ],
+                            [
+                                -1.0,
+                                0.0,
+                                2.0
+                            ],
+                            [
+                                -1.0,
+                                2.0,
+                                2.0
+                            ],
+                            [
+                                0.0,
+                                2.0,
+                                2.0
+                            ]
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Room",
+            "identifier": "Tiny_Garage",
+            "display_name": "Tiny_Garage",
+            "properties": {
+                "type": "RoomPropertiesAbridged",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "RoomRadiancePropertiesAbridged"
+                }
+            },
+            "faces": [
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_Garage_Bottom",
+                    "display_name": "Tiny_Garage_Bottom",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Floor",
+                    "boundary_condition": {
+                        "type": "Ground"
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_Garage_Front",
+                    "display_name": "Tiny_Garage_Front",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_Garage_Right",
+                    "display_name": "Tiny_Garage_Right",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_Garage_Back",
+                    "display_name": "Tiny_Garage_Back",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_Garage_Left",
+                    "display_name": "Tiny_Garage_Left",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "Wall",
+                    "boundary_condition": {
+                        "type": "Surface",
+                        "boundary_condition_objects": [
+                            "Tiny_House_Zone_Right",
+                            "Tiny_House_Zone"
+                        ]
+                    },
+                    "apertures": [
+                        {
+                            "type": "Aperture",
+                            "identifier": "Tiny_Garage_Left_Glz0",
+                            "display_name": "Tiny_Garage_Left_Glz0",
+                            "properties": {
+                                "type": "AperturePropertiesAbridged",
+                                "energy": {
+                                    "type": "ApertureEnergyPropertiesAbridged"
+                                },
+                                "radiance": {
+                                    "type": "ApertureRadiancePropertiesAbridged"
+                                }
+                            },
+                            "geometry": {
+                                "type": "Face3D",
+                                "boundary": [
+                                    [
+                                        5.0,
+                                        6.58113883008419,
+                                        1.974341649025257
+                                    ],
+                                    [
+                                        5.0,
+                                        6.58113883008419,
+                                        1.025658350974743
+                                    ],
+                                    [
+                                        5.0,
+                                        3.41886116991581,
+                                        1.025658350974743
+                                    ],
+                                    [
+                                        5.0,
+                                        3.41886116991581,
+                                        1.974341649025257
+                                    ]
+                                ]
+                            },
+                            "is_operable": false,
+                            "boundary_condition": {
+                                "type": "Surface",
+                                "boundary_condition_objects": [
+                                    "Tiny_House_Zone_Right_Glz0",
+                                    "Tiny_House_Zone_Right",
+                                    "Tiny_House_Zone"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Face",
+                    "identifier": "Tiny_Garage_Top",
+                    "display_name": "Tiny_Garage_Top",
+                    "properties": {
+                        "type": "FacePropertiesAbridged",
+                        "energy": {
+                            "type": "FaceEnergyPropertiesAbridged"
+                        },
+                        "radiance": {
+                            "type": "FaceRadiancePropertiesAbridged"
+                        }
+                    },
+                    "geometry": {
+                        "type": "Face3D",
+                        "boundary": [
+                            [
+                                10.0,
+                                0.0,
+                                3.0
+                            ],
+                            [
+                                10.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                10.0,
+                                3.0
+                            ],
+                            [
+                                5.0,
+                                0.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    "face_type": "RoofCeiling",
+                    "boundary_condition": {
+                        "type": "Outdoors",
+                        "sun_exposure": true,
+                        "wind_exposure": true,
+                        "view_factor": {
+                            "type": "Autocalculate"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "orphaned_shades": [
+        {
+            "type": "Shade",
+            "identifier": "Ground",
+            "display_name": "Ground",
+            "properties": {
+                "type": "ShadePropertiesAbridged",
+                "energy": {
+                    "type": "ShadeEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "ShadeRadiancePropertiesAbridged",
+                    "dynamic_group_identifier": "SeasonalGround",
+                    "states": [
+                        {
+                            "type": "RadianceShadeStateAbridged",
+                            "modifier": "grass"
+                        },
+                        {
+                            "type": "RadianceShadeStateAbridged",
+                            "modifier": "snow"
+                        }
+                    ]
+                }
+            },
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        -10.0,
+                        0.0
+                    ],
+                    [
+                        10.0,
+                        -10.0,
+                        0.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                ]
+            }
+        },
+        {
+            "type": "Shade",
+            "identifier": "Tree_Canopy",
+            "display_name": "Tree_Canopy",
+            "properties": {
+                "type": "ShadePropertiesAbridged",
+                "energy": {
+                    "type": "ShadeEnergyPropertiesAbridged"
+                },
+                "radiance": {
+                    "type": "ShadeRadiancePropertiesAbridged",
+                    "dynamic_group_identifier": "DeciduousTree",
+                    "states": [
+                        {
+                            "type": "RadianceShadeStateAbridged",
+                            "modifier": "SummerLeaves"
+                        },
+                        {
+                            "type": "RadianceShadeStateAbridged",
+                            "modifier": "WinterLeaves"
+                        }
+                    ]
+                }
+            },
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        3.2679491924311224,
+                        -4.0,
+                        4.0
+                    ],
+                    [
+                        5.0,
+                        -5.0,
+                        4.0
+                    ],
+                    [
+                        6.732050807568877,
+                        -4.000000000000001,
+                        4.0
+                    ],
+                    [
+                        6.732050807568878,
+                        -2.000000000000001,
+                        4.0
+                    ],
+                    [
+                        5.000000000000002,
+                        -1.0,
+                        4.0
+                    ],
+                    [
+                        3.2679491924311233,
+                        -1.9999999999999987,
+                        4.0
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/tests/assets/modifier/modifier_plastic_generic_wall.json
+++ b/tests/assets/modifier/modifier_plastic_generic_wall.json
@@ -1,0 +1,11 @@
+[{
+    "modifier": null,
+    "type": "plastic",
+    "identifier": "generic_wall_0.50",
+    "r_reflectance": 0.5,
+    "g_reflectance": 0.5,
+    "b_reflectance": 0.5,
+    "specularity": 0.0,
+    "roughness": 0.0,
+    "dependencies": []
+}]

--- a/tests/assets/modifier/modifier_trans_tree_foliage.json
+++ b/tests/assets/modifier/modifier_trans_tree_foliage.json
@@ -1,0 +1,13 @@
+[{
+    "modifier": null,
+    "type": "trans",
+    "identifier": "Foliage_0.3",
+    "r_reflectance": 0.3,
+    "g_reflectance": 0.3,
+    "b_reflectance": 0.3,
+    "specularity": 0.0,
+    "roughness": 0.1,
+    "transmitted_diff": 0.15,
+    "transmitted_spec": 0.15,
+    "dependencies": []
+}]

--- a/tests/cli/translate_cli_test.py
+++ b/tests/cli/translate_cli_test.py
@@ -1,0 +1,65 @@
+"""Test cli translate module."""
+import os
+from click.testing import CliRunner
+
+from ladybug.futil import nukedir
+
+from honeybee_radiance.cli.translate import model_to_rad_folder, model_to_rad, \
+    modifier_to_rad, modifier_from_rad
+
+
+def test_model_to_rad_folder():
+    runner = CliRunner()
+    input_hb_model = './tests/assets/model/model_radiance_dynamic_states.json'
+    output_hb_model = './tests/assets/model/model'
+
+    result = runner.invoke(model_to_rad_folder, [input_hb_model])
+    assert result.exit_code == 0
+    assert os.path.isdir(output_hb_model)
+    nukedir(output_hb_model, True)
+
+
+def test_model_to_rad():
+    runner = CliRunner()
+    input_hb_model = './tests/assets/model/model_complete_multiroom_radiance.json'
+
+    result = runner.invoke(model_to_rad, [input_hb_model])
+    assert result.exit_code == 0
+
+    output_hb_model = './tests/assets/model/model_complete_multiroom_radiance.rad'
+    result = runner.invoke(model_to_rad, [input_hb_model, '--log-file', output_hb_model])
+    assert result.exit_code == 0
+    assert os.path.isfile(output_hb_model)
+    os.remove(output_hb_model)
+
+
+def test_modifier_to_from_rad():
+    runner = CliRunner()
+    input_hb_mod = './tests/assets/modifier/modifier_plastic_generic_wall.json'
+    output_hb_rad = './tests/assets/modifier/modifier_plastic_generic_wall.rad'
+
+    result = runner.invoke(modifier_to_rad, [input_hb_mod, '--log-file', output_hb_rad])
+    assert result.exit_code == 0
+    assert os.path.isfile(output_hb_rad)
+
+    result = runner.invoke(
+        modifier_from_rad, [output_hb_rad])
+    assert result.exit_code == 0
+
+    os.remove(output_hb_rad)
+
+
+def test_modifier_to_from_rad_trans():
+    runner = CliRunner()
+    input_hb_mod = './tests/assets/modifier/modifier_trans_tree_foliage.json'
+    output_hb_rad = './tests/assets/modifier/modifier_trans_tree_foliage.rad'
+
+    result = runner.invoke(modifier_to_rad, [input_hb_mod, '--log-file', output_hb_rad])
+    assert result.exit_code == 0
+    assert os.path.isfile(output_hb_rad)
+
+    result = runner.invoke(
+        modifier_from_rad, [output_hb_rad])
+    assert result.exit_code == 0
+
+    os.remove(output_hb_rad)

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -76,7 +76,7 @@ def test_check_duplicate_modifier_set_identifiers():
     face_5 = Face('AtticFace5', Face3D(pts_5))
     attic = Room('Attic', [face_1, face_2, face_3, face_4, face_5], 0.01, 1)
 
-    mod_set = ModifierSet('Attic_Construction_Set')
+    mod_set = ModifierSet('Attic_Modifier_Set')
     mod_set.floor_set.interior_modifier = Plastic('AtticFloor', 0.4)
     mod_set.roof_ceiling_set.exterior_modifier = Plastic('AtticRoof', 0.6)
     attic.properties.radiance.modifier_set = mod_set


### PR DESCRIPTION
This commit adds commands to translate Model JSONs to ordinance strings and radiance folders. These will be important for the testing the Rhino radiance plugin that @mingbopeng is working on.

I also fixes a few bugs in model re-serialization as part of this commit.

Resolves https://github.com/ladybug-tools/honeybee-radiance/issues/88