### PR TITLE
fix(group): Ensure identifiers for states go to states.json

### DIFF
--- a/honeybee_radiance/dynamic/group.py
+++ b/honeybee_radiance/dynamic/group.py
@@ -110,6 +110,7 @@ class DynamicShadeGroup(object):
         states_list = []
         for st_i in range(self.state_count):
             states_list.append({
+                'identifier': '{}_{}'.format(st_i, ident),
                 'default': './{}..default..{}.rad'.format(ident, str(st_i)),
                 'direct': './{}..direct..{}.rad'.format(ident, str(st_i))
                 })
@@ -281,6 +282,7 @@ class DynamicSubFaceGroup(DynamicShadeGroup):
         states_list = []
         for st_i in range(self.state_count):
             states_list.append({
+                'identifier': '{}_{}'.format(st_i, ident),
                 'default': './{}..default..{}.rad'.format(ident, str(st_i)),
                 'direct': './{}..direct..{}.rad'.format(ident, str(st_i)),
                 'black': './{}..black.rad'.format(ident)


### PR DESCRIPTION
I forgot that @mostapharoudsari recently made this required and so this commit is adding an identifier key into the states.json.

Nothing to review here @mostaphaRoudsari . I just wanted you to be aware of the fix.