### PR TITLE
fix(cli): Remove unnecessary loading of CLI in __init__.py

### DIFF
--- a/honeybee_radiance/__init__.py
+++ b/honeybee_radiance/__init__.py
@@ -9,14 +9,3 @@ logger = get_logger(name=__name__)
 
 # load all functions that extends honeybee core library
 import honeybee_radiance._extend_honeybee
-
-# load honeybee-radiance cli commands and add them to honeybee
-try:
-    import honeybee_radiance.cli
-except ImportError as e:
-    if 'click' in str(e):
-        # click is not installed.
-        logger.info(e)
-        pass
-    else:
-        raise ImportError(e)


### PR DESCRIPTION
I have verified that importing the CLI in `__init__` is unnecessary since there is already [an entry point for the CLI that is specified in setup.py](https://github.com/ladybug-tools/honeybee-radiance/blob/master/setup.py#L26).

You can also see that [the CLI of honeybee-energy runs fine without any of this importing in __init__](https://github.com/ladybug-tools/honeybee-energy/blob/master/honeybee_energy/__init__.py).

Furthermore, this unnecessary importing is causing import errors throughout the Grasshopper plugin since the click dependency cannot be successfully imported in IronPython. So this commit removes it.