### PR TITLE
fix(pypi): Remove cli tests from the PyPI package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ladybug-tools/honeybee-radiance",
-    packages=setuptools.find_packages(exclude=["tests"]),
+    packages=setuptools.find_packages(exclude=["tests*"]),
     include_package_data=True,
     install_requires=requirements,
     extras_require={


### PR DESCRIPTION
I just discovered that the way we exclude tests does not exclude sub-folders of tests with .py files in them.

I will make the change here, in honeybee-radiance-command, in the ladybug-tools-template, and in he other repos that I take care of. But @mostapharoudsari may need to implement this on some of the other repos that he maintains and likely have this issue.