### PR TITLE
fix(model): Remove global_modifier_set key from Model schema

### DIFF
--- a/honeybee_radiance/lib/_loadmodifiers.py
+++ b/honeybee_radiance/lib/_loadmodifiers.py
@@ -8,7 +8,7 @@ import json
 
 
 # empty dictionary to hold loaded modifiers
-_rad_modifiers = {}
+_loaded_modifiers = {}
 
 
 # first load the honeybee defaults
@@ -18,7 +18,8 @@ for mod_dict in default_data:
     m_class = modifier_class_from_type_string(mod_dict['type'].lower())
     mod = m_class.from_dict(mod_dict)
     mod.lock()
-    _rad_modifiers[mod_dict['identifier']] = mod
+    _loaded_modifiers[mod_dict['identifier']] = mod
+_default_mods = set(list(_loaded_modifiers.keys()))
 
 
 # then load modifiers from the user-supplied files
@@ -28,7 +29,9 @@ def load_modifier_object(mod_dict):
         m_class = modifier_class_from_type_string(mod_dict['type'].lower())
         mod = m_class.from_dict(mod_dict)
         mod.lock()
-        _rad_modifiers[mod_dict['identifier']] = mod
+        assert mod_dict['identifier'] not in _default_mods, 'Cannot overwrite ' \
+            'default modifier "{}".'.format(mod_dict['identifier'])
+        _loaded_modifiers[mod_dict['identifier']] = mod
     except (TypeError, KeyError):
         pass  # not a Honeybee Modifier JSON; possibly a comment
 
@@ -43,7 +46,7 @@ for f in os.listdir(folders.modifier_lib):
                     for mod_dict in rad_dicts:
                         mod = dict_to_modifier(mod_dict)
                         mod.lock()
-                        _rad_modifiers[mod.identifier] = mod
+                        _loaded_modifiers[mod.identifier] = mod
                 except ValueError:
                     pass  # empty rad file with no modifiers in them
         if f_path.endswith('.json'):

--- a/honeybee_radiance/lib/modifiers.py
+++ b/honeybee_radiance/lib/modifiers.py
@@ -4,44 +4,44 @@ Default values are generic values to set the initial visible / solar reflectance
 transmittance values in your model. There is no guarantee that these values exactly
 match what you are trying to model.
 """
-from ._loadmodifiers import _rad_modifiers
+from ._loadmodifiers import _loaded_modifiers
 
 
 # establish variables for the default modifiers used across the library
 # generic opaque modifiers - visible and solar
-generic_floor = _rad_modifiers['generic_floor_0.20']
-generic_wall = _rad_modifiers['generic_wall_0.50']
-generic_ceiling = _rad_modifiers['generic_ceiling_0.80']
-generic_door = _rad_modifiers['generic_opaque_door_0.50']
+generic_floor = _loaded_modifiers['generic_floor_0.20']
+generic_wall = _loaded_modifiers['generic_wall_0.50']
+generic_ceiling = _loaded_modifiers['generic_ceiling_0.80']
+generic_door = _loaded_modifiers['generic_opaque_door_0.50']
 
 # generic shade modifiers - visible and solar
-generic_interior_shade = _rad_modifiers['generic_interior_shade_0.50']
-generic_exterior_shade = _rad_modifiers['generic_exterior_shade_0.35']
-generic_context = _rad_modifiers['generic_context_0.20']
-generic_interior_window = _rad_modifiers['generic_interior_window_vis_0.88']
-generic_exterior_window = _rad_modifiers['generic_exterior_window_vis_0.64']
+generic_interior_shade = _loaded_modifiers['generic_interior_shade_0.50']
+generic_exterior_shade = _loaded_modifiers['generic_exterior_shade_0.35']
+generic_context = _loaded_modifiers['generic_context_0.20']
+generic_interior_window = _loaded_modifiers['generic_interior_window_vis_0.88']
+generic_exterior_window = _loaded_modifiers['generic_exterior_window_vis_0.64']
 generic_exterior_window_insect_screen = \
-    _rad_modifiers['generic_exterior_screened_window_vis_0.32']
+    _loaded_modifiers['generic_exterior_screened_window_vis_0.32']
 
 # generic glass modifiers - solar
-generic_interior_window_solar = _rad_modifiers['generic_interior_window_sol_0.77']
-generic_exterior_window_solar = _rad_modifiers['generic_exterior_window_sol_0.37']
+generic_interior_window_solar = _loaded_modifiers['generic_interior_window_sol_0.77']
+generic_exterior_window_solar = _loaded_modifiers['generic_exterior_window_sol_0.37']
 generic_exterior_window_insect_screen_solar = \
-    _rad_modifiers['generic_exterior_screened_window_sol_0.19']
+    _loaded_modifiers['generic_exterior_screened_window_sol_0.19']
 
 # generic exterior side opaque modifiers - visible and solar
-generic_floor_exterior = _rad_modifiers['generic_floor_exterior_side_0.50']
-generic_wall_exterior = _rad_modifiers['generic_wall_exterior_side_0.35']
-generic_roof_exterior = _rad_modifiers['generic_ceiling_exterior_side_0.35']
+generic_floor_exterior = _loaded_modifiers['generic_floor_exterior_side_0.50']
+generic_wall_exterior = _loaded_modifiers['generic_wall_exterior_side_0.35']
+generic_roof_exterior = _loaded_modifiers['generic_ceiling_exterior_side_0.35']
 
 # special types of modifiers used within various simulation processes
-air_boundary = _rad_modifiers['air_boundary']
-black = _rad_modifiers['black']
-white_glow = _rad_modifiers['white_glow']
+air_boundary = _loaded_modifiers['air_boundary']
+black = _loaded_modifiers['black']
+white_glow = _loaded_modifiers['white_glow']
 
 
 # make lists of modifier identifiers to look up items in the library
-MODIFIERS = tuple(_rad_modifiers.keys())
+MODIFIERS = tuple(_loaded_modifiers.keys())
 
 
 def modifier_by_identifier(modifier_identifier):
@@ -51,7 +51,7 @@ def modifier_by_identifier(modifier_identifier):
         modifier_identifier: A text string for the identifier of the modifier.
     """
     try:
-        return _rad_modifiers[modifier_identifier]
+        return _loaded_modifiers[modifier_identifier]
     except KeyError:
         raise ValueError(
             '"{}" was not found in the radiancemodifier library.'.format(

--- a/honeybee_radiance/lib/modifiersets.py
+++ b/honeybee_radiance/lib/modifiersets.py
@@ -1,20 +1,20 @@
 """Collection of modifier sets."""
-from ._loadmodifiersets import _json_modifier_sets
+from ._loadmodifiersets import _loaded_modifier_sets
 
 
 # establish variables for the default modifier sets used across the library
 generic_modifier_set_visible = \
-    _json_modifier_sets['Generic_Interior_Visible_Modifier_Set']
+    _loaded_modifier_sets['Generic_Interior_Visible_Modifier_Set']
 generic_modifier_set_solar = \
-    _json_modifier_sets['Generic_Interior_Solar_Modifier_Set']
+    _loaded_modifier_sets['Generic_Interior_Solar_Modifier_Set']
 generic_modifier_set_visible_exterior = \
-    _json_modifier_sets['Generic_Exterior_Visible_Modifier_Set']
+    _loaded_modifier_sets['Generic_Exterior_Visible_Modifier_Set']
 generic_modifier_set_solar_exterior = \
-    _json_modifier_sets['Generic_Exterior_Solar_Modifier_Set']
+    _loaded_modifier_sets['Generic_Exterior_Solar_Modifier_Set']
 
 
 # make lists of modifier sets to look up items in the library
-MODIFIER_SETS = tuple(_json_modifier_sets.keys())
+MODIFIER_SETS = tuple(_loaded_modifier_sets.keys())
 
 
 def modifier_set_by_identifier(modifier_set_identifier):
@@ -24,7 +24,7 @@ def modifier_set_by_identifier(modifier_set_identifier):
         modifier_set_identifier: A text string for the identifier of the ConstructionSet.
     """
     try:
-        return _json_modifier_sets[modifier_set_identifier]
+        return _loaded_modifier_sets[modifier_set_identifier]
     except KeyError:
         raise ValueError('"{}" was not found in the modifier set library.'.format(
             modifier_set_identifier))

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -155,7 +155,7 @@ def model_to_rad(model, blk=False, minimal=False):
             studies to understand the contribution of individual apertures.
         minimal: Boolean to note whether the radiance string should be written
             in a minimal format (with spaces instead of line breaks). Default: False.
-    
+
     Returns:
         A tuple of two strings.
 
@@ -168,6 +168,10 @@ def model_to_rad(model, blk=False, minimal=False):
     modifier_str = ['#   ============== MODIFIERS ==============\n']
     rad_prop = model.properties.radiance
     modifiers = rad_prop.blk_modifiers if blk else rad_prop.modifiers
+    if not blk:
+        # must be imported here to avoid circular imports
+        from .lib.modifiersets import generic_modifier_set_visible
+        modifiers = set(modifiers + generic_modifier_set_visible.modifiers_unique)
     for mod in modifiers:
         modifier_str.append(mod.to_radiance(minimal))
 
@@ -329,7 +333,7 @@ def _write_dynamic_shade_files(folder, sub_folder, group, minimal=False):
         sub_folder: The sub-folder for the three files (relative to the model folder).
         group: A DynamicShadeGroup object to be written into files.
         minimal: Boolean noting whether radiance strings should be written minimally.
-    
+
     Returns:
         A list of dictionaries to be written into the states.json file.
     """
@@ -354,7 +358,7 @@ def _write_dynamic_subface_files(folder, sub_folder, group, minimal=False):
         sub_folder: The sub-folder for the three files (relative to the model folder).
         group: A DynamicSubFaceGroup object to be written into files.
         minimal: Boolean noting whether radiance strings should be written minimally.
-    
+
     Returns:
         A list of dictionaries to be written into the states.json file.
     """
@@ -384,7 +388,7 @@ def _write_mtx_files(folder, sub_folder, group, states_json_list, minimal=False)
         group: A DynamicSubFaceGroup object to be written into files.
         states_json_list: A list to be written into the states.json file.
         minimal: Boolean noting whether radiance strings should be written minimally.
-    
+
     Returns:
         A list of dictionaries to be written into the states.json file.
     """
@@ -509,7 +513,7 @@ def _write_static_files(
 
 def _unique_modifiers(geometry_objects):
     """Get a list of unique modifiers across an array of geometry objects.
-    
+
     Args:
         geometry_objects: An array of geometry objects (Faces, Apertures,
             Doors, Shades) for which unique modifiers will be determined.
@@ -532,7 +536,7 @@ def _unique_modifier_blk_combinations(geometry_objects):
         geometry_objects: An array of geometry objects (Faces, Apertures,
             Doors, Shades) for which unique combinations of modifier and
             modifier_blk will be determined.
-    
+
     Returns:
         A tuple with two objects.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-honeybee-core==1.32.5
+honeybee-core==1.32.6
 honeybee-radiance-folder==2.0.1
 honeybee-radiance-command==1.0.1
 honeybee-standards==2.0.0

--- a/tests/assets/model/model_complete_multiroom_radiance.json
+++ b/tests/assets/model/model_complete_multiroom_radiance.json
@@ -490,7 +490,6 @@
                     "air_boundary_modifier": null
                 }
             ],
-            "global_modifier_set": "Generic_Interior_Visible_Modifier_Set",
             "modifiers": [
                 {
                     "modifier": null,

--- a/tests/assets/model/model_radiance_dynamic_states.json
+++ b/tests/assets/model/model_radiance_dynamic_states.json
@@ -450,7 +450,6 @@
                     "air_boundary_modifier": "air_boundary"
                 }
             ],
-            "global_modifier_set": "Generic_Interior_Visible_Modifier_Set",
             "modifiers": [
                 {
                     "modifier": null,


### PR DESCRIPTION
This commit removes the global_modifier_set key on the Model object and gets rid of the corresponding bugs it creates.

I also added some extra checks to ensure that users do not overwrite the default modifiers or modifier sets with their own user-added objects. The aim is that these default objects in the library should never be overwritten, ensuring all plugins and ladybug tools libraries are in agreement about these defaults. However, these defaults can always be overridden on any honeybee object, whether it's a Room, or one of the Surface objects.

Resolves https://github.com/ladybug-tools/honeybee-radiance/issues/104