### PR TITLE
feat(dictutil): Add module to re-serialize any object from dict

### DIFF
--- a/honeybee_radiance/cli/grid.py
+++ b/honeybee_radiance/cli/grid.py
@@ -23,9 +23,11 @@ def grid():
 
 
 @grid.command('split')
-@click.argument('grid-file')
+@click.argument('grid-file', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.argument('count', type=int)
-@click.option('--folder', help='Output folder.', default='.', show_default=True)
+@click.option('--folder', help='Output folder.', default='.', show_default=True,
+              type=click.Path(file_okay=False, dir_okay=True, resolve_path=True))
 @click.option('--log-file', help='Optional log file to output the name of the newly'
               ' created grids. By default the list will be printed out to stdout',
               type=click.File('w'), default='-')
@@ -54,9 +56,10 @@ def split_grid(grid_file, count, folder, log_file):
 
 
 @grid.command('merge')
-@click.argument('input-folder')
-@click.argument('base-name')
-@click.argument('extension', default='.pts')
+@click.argument('input-folder', type=click.Path(
+    file_okay=False, dir_okay=True, resolve_path=True))
+@click.argument('base-name', type=str)
+@click.argument('extension', default='.pts', type=str)
 @click.option('--folder', help='Optional output folder.', default='.', show_default=True)
 def merge_grid(input_folder, base_name, extension, folder):
     """Merge several radiance grid files into a single file.

--- a/honeybee_radiance/cli/lib.py
+++ b/honeybee_radiance/cli/lib.py
@@ -12,7 +12,6 @@ from honeybee_radiance.lib.modifiersets import modifier_set_by_identifier, \
     MODIFIER_SETS
 
 import sys
-import os
 import logging
 import json
 
@@ -22,6 +21,7 @@ _logger = logging.getLogger(__name__)
 @click.group(help='Commands for retrieving objects from the standards library.')
 def lib():
     pass
+
 
 @lib.command('modifiers')
 @click.option('--output-file', help='Optional file to output the JSON string of '
@@ -37,6 +37,7 @@ def modifiers(output_file):
     else:
         sys.exit(0)
 
+
 @lib.command('modifier-sets')
 @click.option('--output-file', help='Optional file to output the JSON string of '
               'the object. By default, it will be printed out to stdout',
@@ -50,6 +51,7 @@ def modifier_sets(output_file):
         sys.exit(1)
     else:
         sys.exit(0)
+
 
 @lib.command('modifier-by-id')
 @click.argument('modifier-id', type=str)
@@ -70,6 +72,7 @@ def modifier_by_id(modifier_id, output_file):
         sys.exit(1)
     else:
         sys.exit(0)
+
 
 @lib.command('modifier-set-by-id')
 @click.argument('modifier-set-id', type=str)
@@ -98,6 +101,7 @@ def modifier_set_by_id(modifier_set_id, none_defaults, abridged, output_file):
     else:
         sys.exit(0)
 
+
 @lib.command('modifiers-by-id')
 @click.argument('modifier-ids', nargs=-1)
 @click.option('--output-file', help='Optional file to output the JSON strings of '
@@ -118,6 +122,7 @@ def modifiers_by_id(modifier_ids, output_file):
         sys.exit(1)
     else:
         sys.exit(0)
+
 
 @lib.command('modifier-sets-by-id')
 @click.argument('modifier-set-ids', nargs=-1)

--- a/honeybee_radiance/cli/octree.py
+++ b/honeybee_radiance/cli/octree.py
@@ -51,8 +51,7 @@ def octree():
     help='A flag to show the command without running it.'
 )
 def create_octree_from_folder(
-    folder, output, include_aperture, default, add_before, add_after, dry_run
-        ):
+        folder, output, include_aperture, default, add_before, add_after, dry_run):
     """Generate a static octree from a folder.
 
     folder: Path to a Radiance model folder.

--- a/honeybee_radiance/cli/sunpath.py
+++ b/honeybee_radiance/cli/sunpath.py
@@ -38,16 +38,13 @@ def sunpath():
     help='A number representing the time zone of the location you are constructing. This'
     ' can improve the accuracy of the resulting sun plot.  The time zone should follow'
     ' the epw convention and should be between -12 and +12, where 0 is at Greenwich, UK,'
-    ' positive values are to the East of Greenwich and negative values are to the West.'
-    )
+    ' positive values are to the East of Greenwich and negative values are to the West.')
 @click.option(
     '--north', default=0, type=float, show_default=True,
-    help='Angle to north (0-360). 90 is west and 270 is east'
-    )
+    help='Angle to north (0-360). 90 is west and 270 is east')
 @click.option(
     '--start-date', default='JAN-01', show_default=True,
-    help='Start date as MMM-DD (e.g JUL-21). Start date itself will also be included.'
-    )
+    help='Start date as MMM-DD (e.g JUL-21). Start date itself will also be included.')
 @click.option(
     '--start-time', default='00:00', show_default=True,
     help='Start time as HH:MM (e.g 14:10). Start time itself will also be included.')
@@ -60,8 +57,7 @@ def sunpath():
 @click.option(
     '--timestep', default=1, type=int, show_default=True,
     help='An optional integer to set the number of time steps per hour. Default is 1'
-    ' for one value per hour.'
-    )
+    ' for one value per hour.')
 @click.option('--leap-year', is_flag=True, help='Dates are for a leap year.')
 @click.option('--folder', default='.', help='Output folder.')
 @click.option('--name', default='sunpath', help='File name.')
@@ -108,11 +104,11 @@ def sunpath_from_location(
 
 
 @sunpath.command('wea')
-@click.argument('wea', type=click.Path(exists=True))
+@click.argument('wea', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option(
     '--north', default=0, type=float, show_default=True,
-    help='Angle to north (0-360). 90 is west and 270 is east'
-    )
+    help='Angle to north (0-360). 90 is west and 270 is east')
 @click.option('--leap-year', is_flag=True, help='dates are for a leap year.')
 @click.option('--folder', default='.', help='Output folder.')
 @click.option('--name', default='sunpath', help='File name.')
@@ -157,15 +153,14 @@ def sunpath_from_wea(wea, north, folder, name, log_file, leap_year, reverse_vect
 
 
 @sunpath.command('epw')
-@click.argument('epw', type=click.Path(exists=True))
+@click.argument('epw', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option(
     '--north', default=0, type=float, show_default=True,
-    help='Angle to north (0-360). 90 is west and 270 is east'
-    )
+    help='Angle to north (0-360). 90 is west and 270 is east')
 @click.option(
     '--start-date', default='JAN-01', show_default=True,
-    help='Start date as MMM-DD (e.g JUL-21). Start date itself will also be included.'
-    )
+    help='Start date as MMM-DD (e.g JUL-21). Start date itself will also be included.')
 @click.option(
     '--start-time', default='00:00', show_default=True,
     help='Start time as HH:MM (e.g 14:10). Start time itself will also be included.')
@@ -178,11 +173,10 @@ def sunpath_from_wea(wea, north, folder, name, log_file, leap_year, reverse_vect
 @click.option(
     '--timestep', default=1, type=int, show_default=True,
     help='An optional integer to set the number of time steps per hour. Default is 1'
-    ' for one value per hour.'
-    )
+    ' for one value per hour.')
 @click.option('--leap-year', is_flag=True, help='dates are for a leap year.')
 @click.option('--folder', default='.', help='Output folder.')
-@click.option('--name', default='sunpath', help='File name.')
+@click.option('--name', default='sunpath', help='File name.', type=str)
 @click.option(
     '--log-file', help='Optional log file to output the name of the newly'
     ' created modifier files. By default the list will be printed out to stdout',

--- a/honeybee_radiance/cli/translate.py
+++ b/honeybee_radiance/cli/translate.py
@@ -26,7 +26,8 @@ def translate():
 
 
 @translate.command('model-to-rad-folder')
-@click.argument('model-json')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--folder', help='Folder on this computer, into which the Radiance '
               'folders will be written. If None, the files will be output in the'
               'same location as the model_json.', default=None, show_default=True)
@@ -36,9 +37,9 @@ def translate():
 @click.option('--config-file', help='An optional config file path to modify the '
               'default folder names. If None, folder.cfg in honeybee-radiance-folder '
               'will be used.', default=None, show_default=True)
-@click.option('--minimal', help='Boolean to note whether the radiance strings should '
-              'be written in a minimal format (with spaces instead of line breaks).',
-              default=False, show_default=True)
+@click.option('--minimal/--maximal', help='Flag to note whether the radiance strings '
+              'should be written in a minimal format (with spaces instead of line '
+              'breaks).', default=False, show_default=True)
 @click.option('--log-file', help='Optional log file to output the path of the radiance '
               'folder generated from the model. By default this will be printed '
               'to stdout', type=click.File('w'), default='-')
@@ -73,14 +74,15 @@ def model_to_rad_folder(model_json, folder, folder_type, config_file, minimal, l
 
 
 @translate.command('model-to-rad')
-@click.argument('model-json')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--blk', help='Boolean to note whether the "blacked out" version '
               'of the geometry should be output, which is useful for direct studies '
               'and isolation studies of individual apertures.',
               default=False, show_default=True)
-@click.option('--minimal', help='Boolean to note whether the radiance strings should '
-              'be written in a minimal format (with spaces instead of line breaks).',
-              default=False, show_default=True)
+@click.option('--minimal/--maximal', help='Flag to note whether the radiance strings '
+              'should be written in a minimal format (with spaces instead of line '
+              'breaks).', default=False, show_default=True)
 @click.option('--output-file', help='Optional RAD file to output the RAD string of the '
               'translation. By default this will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -121,10 +123,11 @@ def model_to_rad(model_json, blk, minimal, output_file):
 
 
 @translate.command('modifiers-to-rad')
-@click.argument('modifier-json')
-@click.option('--minimal', help='Boolean to note whether the radiance strings should '
-              'be written in a minimal format (with spaces instead of line breaks).',
-              default=False, show_default=True)
+@click.argument('modifier-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.option('--minimal/--maximal', help='Flag to note whether the radiance strings '
+              'should be written in a minimal format (with spaces instead of line '
+              'breaks).', default=False, show_default=True)
 @click.option('--output-file', help='Optional RAD file to output the RAD string of the '
               'translation. By default this will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -165,7 +168,8 @@ def modifier_to_rad(modifier_json, minimal, output_file):
 
 
 @translate.command('modifiers-from-rad')
-@click.argument('modifier-rad')
+@click.argument('modifier-rad', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional JSON file to output the JSON string of the'
               'translation. By default this will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -173,13 +177,13 @@ def modifier_from_rad(modifier_rad, output_file):
     """Translate a Modifier JSON file to a honeybee JSON as an array of modifiers.
     \n
     Args:
-        modifier_rad: Full path to a Modifier JSON file. Only the modifiers
+        modifier_rad: Full path to a Modifier .rad or .mat file. Only the modifiers
             and materials in this file will be extracted.
     """
     try:
-        # check that the modifier JSON is there
+        # check that the modifier file is there
         assert os.path.isfile(modifier_rad), \
-            'No Modifier JSON file found at {}.'.format(modifier_rad)
+            'No Modifier file found at {}.'.format(modifier_rad)
 
         # re-serialize the Modifiers to Python
         mod_objs = []

--- a/honeybee_radiance/dictutil.py
+++ b/honeybee_radiance/dictutil.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+"""Utilities to convertint any dictionary to Python objects.
+
+Note that importing this module will import almost all modules within the
+library in order to be able to re-serialize almost any dictionary produced
+from the library.
+"""
+from honeybee_radiance.putil import dict_to_primitive
+from honeybee_radiance.modifierset import ModifierSet
+from honeybee_radiance.sensorgrid import SensorGrid
+from honeybee_radiance.view import View
+from honeybee_radiance.lightsource.dictutil import dict_to_light_source, \
+    LIGHT_SOURCE_TYPES
+
+
+def dict_to_object(honeybee_radiance_dict, raise_exception=True):
+    """Re-serialize a dictionary of almost any object within honeybee_radiance.
+
+    This includes any Modifier, ModifierSet, LightSource, SensorGrid or View object.
+
+    Args:
+        honeybee_radiance_dict: A dictionary of any Honeybee radiance object. Note
+            that this should be a non-abridged dictionary to be valid.
+        raise_exception: Boolean to note whether an excpetion should be raised
+            if the object is not identified as a part of honeybee_radiance.
+            Default: True.
+
+    Returns:
+        A Python object derived from the input honeybee_radiance_dict.
+    """
+    try:  # get the type key from the dictionary
+        obj_type = honeybee_radiance_dict['type']
+    except KeyError:
+        raise ValueError('Honeybee_radiance dictionary lacks required "type" key.')
+
+    if obj_type == 'ModifierSet':
+        return ModifierSet.from_dict(honeybee_radiance_dict)
+    elif obj_type == 'SensorGrid':
+        return SensorGrid.from_dict(honeybee_radiance_dict)
+    elif obj_type == 'View':
+        return View.from_dict(honeybee_radiance_dict)
+    elif obj_type in LIGHT_SOURCE_TYPES:
+        return dict_to_light_source(honeybee_radiance_dict)
+    else:
+        try:
+            return dict_to_primitive(honeybee_radiance_dict)
+        except ValueError:
+            if raise_exception:
+                raise ValueError(
+                    '{} is not a recognized honeybee radiance object'.format(obj_type))

--- a/honeybee_radiance/lightsource/dictutil.py
+++ b/honeybee_radiance/lightsource/dictutil.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+"""Utilities to convert light source dictionaries to Python objects."""
+from honeybee_radiance.lightsource.sunpath import Sunpath
+from honeybee_radiance.lightsource.ground import Ground
+from honeybee_radiance.lightsource.sky.certainirradiance import CertainIrradiance
+from honeybee_radiance.lightsource.sky.cie import CIE
+from honeybee_radiance.lightsource.sky.climatebased import ClimateBased
+from honeybee_radiance.lightsource.sky.hemisphere import Hemisphere
+from honeybee_radiance.lightsource.sky.skydome import Skydome
+from honeybee_radiance.lightsource.sky.skymatrix import SkyMatrix
+from honeybee_radiance.lightsource.sky.sunmatrix import SunMatrix
+
+
+LIGHT_SOURCE_TYPES = \
+    ('Sunpath', 'Ground', 'CertainIrradiance', 'CIE', 'ClimateBased',
+     'Hemisphere', 'SkyDome', 'SkyMatrix', 'SunMatrix')
+
+
+def dict_to_light_source(light_source_dict, raise_exception=True):
+    """Get a Python object of any light source from a dictionary.
+
+    Args:
+        load_dict: A dictionary of any Honeybee energy load. Note
+            that this should be a non-abridged dictionary to be valid.
+        raise_exception: Boolean to note whether an excpetion should be raised
+            if the object is not identified as a load. Default: True.
+
+    Returns:
+        A Python object derived from the input load_dict.
+    """
+    try:  # get the type key from the dictionary
+        light_type = light_source_dict['type']
+    except KeyError:
+        raise ValueError('Load dictionary lacks required "type" key.')
+
+    if light_type == 'Sunpath':
+        return Sunpath.from_dict(light_source_dict)
+    elif light_type == 'Ground':
+        return Ground.from_dict(light_source_dict)
+    elif light_type == 'CertainIrradiance':
+        return CertainIrradiance.from_dict(light_source_dict)
+    elif light_type == 'CIE':
+        return CIE.from_dict(light_source_dict)
+    elif light_type == 'ClimateBased':
+        return ClimateBased.from_dict(light_source_dict)
+    elif light_type == 'Hemisphere':
+        return Hemisphere.from_dict(light_source_dict)
+    elif light_type == 'SkyDome':
+        return Skydome.from_dict(light_source_dict)
+    elif light_type == 'SkyMatrix':
+        return SkyMatrix.from_dict(light_source_dict)
+    elif light_type == 'SunMatrix':
+        return SunMatrix.from_dict(light_source_dict)
+    elif raise_exception:
+        raise ValueError(
+            '{} is not a recognized radiance Light Source type'.format(light_type))

--- a/honeybee_radiance/lightsource/dictutil.py
+++ b/honeybee_radiance/lightsource/dictutil.py
@@ -6,14 +6,22 @@ from honeybee_radiance.lightsource.sky.certainirradiance import CertainIrradianc
 from honeybee_radiance.lightsource.sky.cie import CIE
 from honeybee_radiance.lightsource.sky.climatebased import ClimateBased
 from honeybee_radiance.lightsource.sky.hemisphere import Hemisphere
-from honeybee_radiance.lightsource.sky.skydome import Skydome
+from honeybee_radiance.lightsource.sky.skydome import SkyDome
 from honeybee_radiance.lightsource.sky.skymatrix import SkyMatrix
 from honeybee_radiance.lightsource.sky.sunmatrix import SunMatrix
 
 
-LIGHT_SOURCE_TYPES = \
-    ('Sunpath', 'Ground', 'CertainIrradiance', 'CIE', 'ClimateBased',
-     'Hemisphere', 'SkyDome', 'SkyMatrix', 'SunMatrix')
+LIGHT_SOURCE_TYPES = {
+    'Sunpath': Sunpath,
+    'Ground': Ground,
+    'CertainIrradiance': CertainIrradiance,
+    'CIE': CIE,
+    'ClimateBased': ClimateBased,
+    'Hemisphere': Hemisphere,
+    'SkyDome': SkyDome,
+    'SkyMatrix': SkyMatrix,
+    'SunMatrix': SunMatrix
+}
 
 
 def dict_to_light_source(light_source_dict, raise_exception=True):
@@ -33,24 +41,9 @@ def dict_to_light_source(light_source_dict, raise_exception=True):
     except KeyError:
         raise ValueError('Load dictionary lacks required "type" key.')
 
-    if light_type == 'Sunpath':
-        return Sunpath.from_dict(light_source_dict)
-    elif light_type == 'Ground':
-        return Ground.from_dict(light_source_dict)
-    elif light_type == 'CertainIrradiance':
-        return CertainIrradiance.from_dict(light_source_dict)
-    elif light_type == 'CIE':
-        return CIE.from_dict(light_source_dict)
-    elif light_type == 'ClimateBased':
-        return ClimateBased.from_dict(light_source_dict)
-    elif light_type == 'Hemisphere':
-        return Hemisphere.from_dict(light_source_dict)
-    elif light_type == 'SkyDome':
-        return Skydome.from_dict(light_source_dict)
-    elif light_type == 'SkyMatrix':
-        return SkyMatrix.from_dict(light_source_dict)
-    elif light_type == 'SunMatrix':
-        return SunMatrix.from_dict(light_source_dict)
-    elif raise_exception:
-        raise ValueError(
-            '{} is not a recognized radiance Light Source type'.format(light_type))
+    try:
+        return LIGHT_SOURCE_TYPES[light_type].from_dict(light_source_dict)
+    except KeyError:
+        if raise_exception:
+            raise ValueError(
+                '{} is not a recognized radiance Light Source type'.format(light_type))

--- a/honeybee_radiance/lightsource/sky/_skybase.py
+++ b/honeybee_radiance/lightsource/sky/_skybase.py
@@ -4,8 +4,8 @@ import honeybee.typing as typing
 import ladybug.futil as futil
 
 
-class _Skydome(object):
-    """Virtual Skydome base-class with Radiance ground and sky sphere.
+class _SkyDome(object):
+    """Virtual SkyDome base-class with Radiance ground and sky sphere.
 
     Properties:
         * ground_hemisphere
@@ -107,7 +107,7 @@ class _Skydome(object):
         return self.to_radiance()
 
 
-class _PointInTime(_Skydome):
+class _PointInTime(_SkyDome):
     """Point-in-time sky base-class with Radiance ground and sky sphere.
 
     Properties:
@@ -121,7 +121,7 @@ class _PointInTime(_Skydome):
     __slots__ = ('_ground_reflectance',)
 
     def __init__(self, ground_reflectance):
-        _Skydome.__init__(self)
+        _SkyDome.__init__(self)
         self.ground_reflectance = ground_reflectance
 
     @property

--- a/honeybee_radiance/lightsource/sky/cie.py
+++ b/honeybee_radiance/lightsource/sky/cie.py
@@ -294,7 +294,7 @@ class CIE(_PointInTime):
             else '%.3f_%.3f_%s.sky' % (
                 self.altitude, self.azimuth,
                 self.sky_type_human_readable.replace(' ', '_').lower()
-            )
+        )
         return futil.write_to_file_by_name(folder, name, content, mkdir)
 
     def __eq__(self, value):

--- a/honeybee_radiance/lightsource/sky/climatebased.py
+++ b/honeybee_radiance/lightsource/sky/climatebased.py
@@ -309,7 +309,7 @@ class ClimateBased(_PointInTime):
             else '%.3f_%.3f_%d_%d.sky' % (
                 self.altitude, self.azimuth,
                 self.direct_normal_irradiance, self.diffuse_horizontal_irradiance
-            )
+        )
         return futil.write_to_file_by_name(folder, name, content, mkdir)
 
     def __eq__(self, value):

--- a/honeybee_radiance/lightsource/sky/skydome.py
+++ b/honeybee_radiance/lightsource/sky/skydome.py
@@ -28,18 +28,18 @@ Here is an example of the output.
 
 """
 
-from ._skybase import _Skydome
+from ._skybase import _SkyDome
 import honeybee.typing as typing
 
 
-class Skydome(_Skydome):
+class SkyDome(_SkyDome):
     """Virtual skydome for daylight coefficient studies with constant radiance.
 
     Use this sky to calculate daylight matrix.
     """
 
     def to_radiance(self, density=1):
-        """Radiance definition for Skydome.
+        """Radiance definition for SkyDome.
 
         Args:
             density: Sky patch subdivision density. This values is similar to -m option

--- a/honeybee_radiance/sensorgrid.py
+++ b/honeybee_radiance/sensorgrid.py
@@ -10,8 +10,7 @@ import ladybug.futil as futil
 import os
 try:
     from itertools import izip as zip
-except:
-    # python 3
+except ImportError:  # python 3
     pass
 
 
@@ -207,7 +206,7 @@ class SensorGrid(object):
     @property
     def room_identifier(self):
         """Get or set text for the Room identifier to which this SensorGrid belongs.
-        
+
         This will be used in the info_dict method to narrow down the
         number of aperture groups that have to be run with this sensor grid.
         If None, the grid will be run with all aperture groups in the model.
@@ -217,18 +216,18 @@ class SensorGrid(object):
     @room_identifier.setter
     def room_identifier(self, n):
         self._room_identifier = typing.valid_string(n)
-    
+
     @property
     def light_path(self):
         """Get or set list of lists for the light path from the grid to the sky.
-        
+
         Each sub-list contains identifiers of aperture groups through which light
         passes. (eg. [['SouthWindow1'], ['static_apertures', 'NorthWindow2']]).
         Setting this property will override any auto-calculation of the light
         path from the model upon export to the simulation.
         """
         return self._light_path
-    
+
     @light_path.setter
     def light_path(self, l_path):
         if l_path is not None:
@@ -239,7 +238,7 @@ class SensorGrid(object):
                     'light_path sub-list. Got {}.'.format(type(ap_list))
                 for ap in ap_list:
                     assert isinstance(ap, str), 'Expected text for light_path ' \
-                    'aperture group identifier. Got {}.'.format(type(ap))
+                        'aperture group identifier. Got {}.'.format(type(ap))
         self._light_path = l_path
 
     def info_dict(self, model=None):

--- a/honeybee_radiance/view.py
+++ b/honeybee_radiance/view.py
@@ -385,7 +385,7 @@ class View(object):
     @property
     def room_identifier(self):
         """Get or set text for the Room identifier to which this View belongs.
-        
+
         This will be used in the info_dict method to narrow down the
         number of aperture groups that have to be run with this view. If None,
         the view will be run with all aperture groups in the model.
@@ -399,14 +399,14 @@ class View(object):
     @property
     def light_path(self):
         """Get or set list of lists for the light path from the view to the sky.
-        
+
         Each sub-list contains identifiers of aperture groups through which light
         passes. (eg. [['SouthWindow1'], ['static_apertures', 'NorthWindow2']]).
         Setting this property will override any auto-calculation of the light
         path from the model upon export to the simulation.
         """
         return self._light_path
-    
+
     @light_path.setter
     def light_path(self, l_path):
         if l_path is not None:
@@ -417,7 +417,7 @@ class View(object):
                     'light_path sub-list. Got {}.'.format(type(ap_list))
                 for ap in ap_list:
                     assert isinstance(ap, str), 'Expected text for light_path ' \
-                    'aperture group identifier. Got {}.'.format(type(ap))
+                        'aperture group identifier. Got {}.'.format(type(ap))
         self._light_path = l_path
 
     @classmethod

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -268,21 +268,21 @@ def model_to_rad_folder(model, folder=None, folder_type=2, config_file=None,
     aps, aps_blk = model.properties.radiance.subfaces_by_blk()
     mods, mods_blk, mod_combs, mod_names = _collect_modifiers(aps, aps_blk)
     _write_static_files(
-        folder, model_folder.aperture_folder(full=True), model_id,
+        folder, model_folder.aperture_folder(full=True), 'aperture',
         aps, aps_blk, mods, mods_blk, mod_combs, mod_names, False, minimal)
 
     # gather and write static faces
     faces, faces_blk = model.properties.radiance.faces_by_blk()
     f_mods, f_mods_blk, mod_combs, mod_names = _collect_modifiers(faces, faces_blk)
     _write_static_files(
-        folder, model_folder.scene_folder(full=True), '{}_envelope'.format(model_id),
+        folder, model_folder.scene_folder(full=True), 'envelope',
         faces, faces_blk, f_mods, f_mods_blk, mod_combs, mod_names, True, minimal)
 
     # gather and write static shades
     shades, shades_blk = model.properties.radiance.shades_by_blk()
     s_mods, s_mods_blk, mod_combs, mod_names = _collect_modifiers(shades, shades_blk)
     _write_static_files(
-        folder, model_folder.scene_folder(full=True), '{}_shades'.format(model_id),
+        folder, model_folder.scene_folder(full=True), 'shades',
         shades, shades_blk, s_mods, s_mods_blk, mod_combs, mod_names, False, minimal)
 
     # write dynamic sub-face groups (apertures and doors)

--- a/tests/dictutil_test.py
+++ b/tests/dictutil_test.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+from honeybee_radiance.dictutil import dict_to_object
+from honeybee_radiance.modifier.material import Glass
+from honeybee_radiance.modifierset import ModifierSet
+from honeybee_radiance.lightsource.sky import CIE
+from honeybee_radiance.lightsource.sky import SkyMatrix
+from honeybee_radiance.sensor import Sensor
+from honeybee_radiance.sensorgrid import SensorGrid
+from honeybee_radiance.view import View
+from ladybug.wea import Wea
+
+
+def test_dict_to_object_modifier():
+    """Test the dict_to_object method with Modifier objects."""
+    gl_obj = Glass('test_glass', 0.6, 0.7, 0.8, 1.52)
+    gl_dict = gl_obj.to_dict()
+    new_gl = dict_to_object(gl_dict)
+    assert isinstance(new_gl, Glass)
+
+
+def test_dict_to_object_modifier_set():
+    """Test the dict_to_object method with Modifier objects."""
+    default_set = ModifierSet('Tinted_Window_Set')
+    glass_material = Glass.from_single_transmittance('test_glass', 0.6)
+    glass_material_dark = Glass.from_single_transmittance('test_glass_dark', 0.3)
+    default_set.aperture_set.exterior_modifier = glass_material
+    default_set.aperture_set.skylight_modifier = glass_material_dark
+
+    mod_set_dict = default_set.to_dict()
+    new_mod_set = dict_to_object(mod_set_dict)
+    assert isinstance(new_mod_set, ModifierSet)
+
+
+def test_dict_to_object_cie_sky():
+    """Test the dict_to_object method with Sky objects."""
+    sky_obj = CIE(38.186734, 270.410387)
+    sky_dict = sky_obj.to_dict()
+    new_sky = dict_to_object(sky_dict)
+    assert isinstance(new_sky, CIE)
+
+
+def test_dict_to_object_sky_mtx():
+    """Test the dict_to_object method with SkyMatrix objects."""
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sky_mtx_obj = SkyMatrix(wea)
+    sky_mtx_dict = sky_mtx_obj.to_dict()
+    new_sky_mtx = dict_to_object(sky_mtx_dict)
+    assert isinstance(new_sky_mtx, SkyMatrix)
+
+
+def test_dict_to_object_sensor_grid():
+    """Test the dict_to_object method with SensorGrid objects."""
+    sensors = [Sensor((0, 0, 0), (0, 0, 1)), Sensor((0, 0, 10), (0, 0, 1))]
+    sg_obj = SensorGrid('sg_1', sensors)
+    sg_dict = sg_obj.to_dict()
+    new_sg = dict_to_object(sg_dict)
+    assert isinstance(new_sg, SensorGrid)
+
+
+def test_dict_to_object_view():
+    """Test the dict_to_object method with View objects."""
+    v_obj = View('test_view', (0, 0, 10), (0, 1, 0), (0, 0, 1), 'l', 240, 300, -10, -25)
+    v_dict = v_obj.to_dict()
+    new_v = dict_to_object(v_dict)
+    assert isinstance(new_v, View)

--- a/tests/material_glass_test.py
+++ b/tests/material_glass_test.py
@@ -9,7 +9,7 @@ def test_glass():
     assert gl.r_transmissivity == 0
     assert gl.g_transmissivity == 0
     assert gl.b_transmissivity == 0
-    assert gl.refraction_index == None
+    assert gl.refraction_index is None
     assert gl.to_radiance(
         minimal=True) == 'void glass test_glass 0 0 3 0.0 0.0 0.0'
 

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -389,17 +389,17 @@ def test_writer_to_rad_folder():
     model_folder = ModelFolder(folder)
 
     ap_dir = model_folder.aperture_folder(full=True)
-    assert os.path.isfile(os.path.join(ap_dir, '{}.rad'.format(model.identifier)))
-    assert os.path.isfile(os.path.join(ap_dir, '{}.mat'.format(model.identifier)))
-    assert os.path.isfile(os.path.join(ap_dir, '{}.blk'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(ap_dir, 'aperture.rad'))
+    assert os.path.isfile(os.path.join(ap_dir, 'aperture.mat'))
+    assert os.path.isfile(os.path.join(ap_dir, 'aperture.blk'))
 
     scene_dir = model_folder.scene_folder(full=True)
-    assert os.path.isfile(os.path.join(scene_dir, '{}_envelope.rad'.format(model.identifier)))
-    assert os.path.isfile(os.path.join(scene_dir, '{}_envelope.mat'.format(model.identifier)))
-    assert os.path.isfile(os.path.join(scene_dir, '{}_envelope.blk'.format(model.identifier)))
-    assert os.path.isfile(os.path.join(scene_dir, '{}_shades.rad'.format(model.identifier)))
-    assert os.path.isfile(os.path.join(scene_dir, '{}_shades.mat'.format(model.identifier)))
-    assert os.path.isfile(os.path.join(scene_dir, '{}_shades.blk'.format(model.identifier)))
+    assert os.path.isfile(os.path.join(scene_dir, 'envelope.rad'))
+    assert os.path.isfile(os.path.join(scene_dir, 'envelope.mat'))
+    assert os.path.isfile(os.path.join(scene_dir, 'envelope.blk'))
+    assert os.path.isfile(os.path.join(scene_dir, 'shades.rad'))
+    assert os.path.isfile(os.path.join(scene_dir, 'shades.mat'))
+    assert os.path.isfile(os.path.join(scene_dir, 'shades.blk'))
 
     # clean up the folder
     nukedir(folder, rmdir=True)
@@ -443,12 +443,12 @@ def test_writer_to_rad_folder_dynamic():
     north_face = room[1]
     north_face.overhang(0.25, indoor=False)
     door_verts = [Point3D(2, 10, 0.1), Point3D(1, 10, 0.1),
-                    Point3D(1, 10, 2.5), Point3D(2, 10, 2.5)]
+                  Point3D(1, 10, 2.5), Point3D(2, 10, 2.5)]
     door = Door('Front_Door', Face3D(door_verts))
     north_face.add_door(door)
 
     aperture_verts = [Point3D(4.5, 10, 1), Point3D(2.5, 10, 1),
-                        Point3D(2.5, 10, 2.5), Point3D(4.5, 10, 2.5)]
+                      Point3D(2.5, 10, 2.5), Point3D(4.5, 10, 2.5)]
     aperture = Aperture('Front_Aperture', Face3D(aperture_verts))
     triple_pane = Glass.from_single_transmittance('custom_triple_pane_0.3', 0.3)
     aperture.properties.radiance.modifier = triple_pane

--- a/tests/modifier_set_test.py
+++ b/tests/modifier_set_test.py
@@ -68,7 +68,7 @@ def test_setting_modifier():
     opaque_material_1 = Plastic.from_single_reflectance('test_opaque', 0.5)
     opaque_material_2 = Plastic.from_single_reflectance('test_opaque', 0.45)
     opaque_material_3 = Plastic.from_single_reflectance('test_opaque', 0.55)
-    
+
     default_set.wall_set.exterior_modifier = opaque_material_1
     assert default_set.wall_set.exterior_modifier == opaque_material_1
     assert len(default_set.modified_modifiers_unique) == 1

--- a/tests/sensorgrid_test.py
+++ b/tests/sensorgrid_test.py
@@ -94,5 +94,5 @@ def test_split_grid():
     assert len(info) == 6
     for i in range(6 - 1):
         assert info[i]['count'] == 4
-    
+
     assert info[-1]['count'] == 1


### PR DESCRIPTION
This commit adds a dictutil module to the package, with a dict_to_object method that can re-serialize any dictionary produced from the library back into a honeybee-radiance Python object.  We have implemented similar methods in honeybee-core and honeybee-energy and they have been very useful for keep in the JSON re-serialization code clean on the plugin side of things.

Given that the putil module already handles a lot of these re-serialization issues across honeybee-radiance, I didn't need to add much code in order to enable a package-wide re-serialization function.  I only needed to check the case of a few key top-level assets (ModifierSet, SensorGrid, View) and add a module to re-serialize all of the lightsource objects.

Once we merge this in, I will add the radiance re-serialization functionality into the Grasshopper plugin.

@mostaphaRoudsari , If you can take a quick look over the changes, it's always helpful. But there's nothing here that is outside the norm of what's been implemented on the other packages.

I'm also taking the opportunity of this PR to close a few small issues that were open:

Resolves #172
Resolves #192
 