### PR TITLE
feat(model): Add sensor_grid and views under ModelRadianceProperties

### DIFF
--- a/honeybee_radiance/properties/_base.py
+++ b/honeybee_radiance/properties/_base.py
@@ -207,7 +207,7 @@ class _DynamicRadianceProperties(_RadianceProperties):
     @property
     def dynamic_group_identifier(self):
         """Get or set a text string for the dynamic_group_identifier.
-        
+
         Objects sharing the same dynamic_group_identifier will have their
         states change in unison. If None, the object is assumed to be static.
         """
@@ -226,7 +226,7 @@ class _DynamicRadianceProperties(_RadianceProperties):
     @property
     def states(self):
         """Get or set an array of radiance states assigned to this object.
-    
+
         These cannot be set unless there is also a dynamic_group_identifier for
         the object.
         """
@@ -240,8 +240,8 @@ class _DynamicRadianceProperties(_RadianceProperties):
             try:
                 self._states = [self._check_state(st) for st in value]
             except (ValueError, TypeError):
-                raise TypeError('Expected iterable for Object states. ' \
-                    'Got  {}.'.format(type(value)))
+                raise TypeError('Expected iterable for Object states. '
+                                'Got  {}.'.format(type(value)))
         else:
             self._states = []
 
@@ -263,7 +263,7 @@ class _DynamicRadianceProperties(_RadianceProperties):
             state: A Radiance state object to add to the this object.
         """
         assert self._dynamic_group_identifier is not None, 'Object must have ' \
-                'a dynamic_group_identifier to assign states.'
+            'a dynamic_group_identifier to assign states.'
         self._states.append(self._check_state(state))
 
     def move(self, moving_vec):

--- a/honeybee_radiance/properties/room.py
+++ b/honeybee_radiance/properties/room.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """Room Radiance Properties."""
 from ..sensorgrid import SensorGrid
+from ..view import View
 from ..modifierset import ModifierSet
 from ..lib.modifiersets import generic_modifier_set_visible
 
@@ -54,9 +55,10 @@ class RoomRadianceProperties(object):
 
     def generate_sensor_grid(self, x_dim, y_dim=None, offset=1.0):
         """Get a radiance SensorGrid generated from this Room's floors.
-    
-        The output will also include a Mesh3D object with faces that align with
-        the positions of the SensorGrid.
+
+        The output grid will have this room referenced in their room_identifier
+        property. It will also include a Mesh3D object with faces that align
+        with the grid positions under the grid's mesh property.
 
         Note that the x_dim and y_dim refer to dimensions within the XY coordinate
         system of the floor faces's planes. So rotating the planes of the floor faces
@@ -71,12 +73,8 @@ class RoomRadianceProperties(object):
                 the floor.
 
         Returns:
-            A tuple with the following two values.
-
-            * sensor_grid -- A honeybee_radiance SensorGrid generated from the
-                floors of the room.
-
-            * mesh_grid -- A ladybug_geometry Mesh3D that aligns with the sensor_grid.
+            A honeybee_radiance SensorGrid generated from the floors of the room.
+            Will be None if the Room has no floors
 
         Usage:
 
@@ -84,17 +82,81 @@ class RoomRadianceProperties(object):
 
             from honeybee.room import Room
             room = Room.from_box(3.0, 6.0, 3.2, 180)
-            sensor_grid, mesh_grid = room.properties.radiance.generate_grid(0.5, 0.5, 1)
+            south_face = room[3]
+            south_face.apertures_by_ratio(0.4, 0.01)
+            sensor_grid = room.properties.radiance.generate_grid(0.5, 0.5, 1)
         """
         floor_grid = self.host.generate_grid(x_dim, y_dim, offset)
         if floor_grid is None:
-            return None, None
-        base_poss = [(pt.x, pt.y, pt.z) for pt in floor_grid.face_centroids]
-        base_dirs = [(vec.x, vec.y, vec.z) for vec in floor_grid.face_normals]
-        sensor_grid = SensorGrid.from_position_and_direction(
-            self.host.identifier, base_poss, base_dirs)
+            return None
+        sensor_grid = SensorGrid.from_mesh3d(self.host.identifier, floor_grid)
         sensor_grid.room_identifier = self.host.identifier
-        return sensor_grid, floor_grid
+        return sensor_grid
+
+    def generate_view(self, direction, up_vector=(0, 0, 1), type='v', h_size=60,
+                      v_size=60, shift=None, lift=None):
+        """Get a single view in the center of the room facing a given direction.
+
+        Note that the view will be located at the center of the bounding box
+        around the room geometry and not the volume centroid. Also note that
+        the view may not lie inside the room if the room is highly concave.
+
+        The output view will have this room referenced in their room_identifier
+        property.
+
+        Args:
+            direction: Set the view direction (-vd) vector to (x, y, z). The
+                length of this vector indicates the focal distance as needed by
+                the pixel depth of field (-pd) in rpict.
+            up_vector: Set the view up (-vu) vector (vertical direction) to
+                (x, y, z) default: (0, 0, 1).
+            type: A single character for the view type (-vt). Choose from the following.
+
+                * v - Perspective
+                * h - Hemispherical fisheye
+                * l - Parallel
+                * c - Cylindrical panorama
+                * a - Angular fisheye
+                * s - Planisphere [stereographic] projection
+
+                For more detailed description about view types check rpict manual
+                page: (http://radsite.lbl.gov/radiance/man_html/rpict.1.html)
+            h_size: Set the view horizontal size (-vh). For a perspective
+                projection (including fisheye views), val is the horizontal field
+                of view (in degrees). For a parallel projection, val is the view
+                width in world coordinates.
+            v_size: Set the view vertical size (-vv). For a perspective
+                projection (including fisheye views), val is the horizontal field
+                of view (in degrees). For a parallel projection, val is the view
+                width in world coordinates.
+            shift: Set the view shift (-vs). This is the amount the actual
+                image will be shifted to the right of the specified view. This
+                option is useful for generating skewed perspectives or rendering
+                an image a piece at a time. A value of 1 means that the rendered
+                image starts just to the right of the normal view. A value of -1
+                would be to the left. Larger or fractional values are permitted
+                as well.
+            lift: Set the view lift (-vl) to a value. This is the amount the
+                actual image will be lifted up from the specified view.
+
+        Returns:
+            A honeybee_radiance View generated in the center of the Room.
+
+        Usage:
+
+        .. code-block:: python
+
+            from honeybee.room import Room
+            room = Room.from_box(3.0, 6.0, 3.2, 180)
+            south_face = room[3]
+            south_face.apertures_by_ratio(0.4, 0.01)
+            view = room.properties.radiance.generate_view((0, -1, 0))
+        """
+        pos = (self.host.center.x, self.host.center.y, self.host.center.z)
+        view = View(self.host.identifier, pos, direction, up_vector, type,
+                    h_size, v_size, shift, lift)
+        view.room_identifier = self.host.identifier
+        return view
 
     @classmethod
     def from_dict(cls, data, host):

--- a/honeybee_radiance/sensor.py
+++ b/honeybee_radiance/sensor.py
@@ -2,6 +2,10 @@
 from __future__ import division
 import honeybee.typing as typing
 
+import ladybug_geometry.geometry3d.pointvector as pv
+
+import math
+
 
 class Sensor(object):
     """A radiance sensor.
@@ -19,10 +23,8 @@ class Sensor(object):
 
     def __init__(self, pos=None, dir=None):
         """Create a sensor."""
-        self._pos = typing.tuple_with_length(pos) if pos is not None \
-            else (0, 0, 0)
-        self._dir = typing.tuple_with_length(dir) if dir is not None \
-            else (0, 0, 1)
+        self.pos = pos
+        self.dir = dir
 
     @classmethod
     def from_dict(cls, sensor_dict):
@@ -49,13 +51,75 @@ class Sensor(object):
 
     @property
     def pos(self):
-        """Get the position of the sensor as a tuple of 3 (x, y, z) numbers."""
+        """Get or set the position of the sensor as a tuple of 3 (x, y, z) numbers."""
         return self._pos
+
+    @pos.setter
+    def pos(self, value):
+        self._pos = typing.tuple_with_length(value) if value is not None else (0, 0, 0)
 
     @property
     def dir(self):
-        """Get the dir of the sensor as a tuple of 3 (x, y, z) numbers."""
+        """Get or set the dir of the sensor as a tuple of 3 (x, y, z) numbers."""
         return self._dir
+
+    @dir.setter
+    def dir(self, value):
+        self._dir = typing.tuple_with_length(value) if value is not None else (0, 0, 1)
+
+    def move(self, moving_vec):
+        """Move this sensor along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the sensor.
+        """
+        self.pos = tuple(pv.Point3D(*self.pos).move(moving_vec))
+
+    def rotate(self, angle, axis, origin):
+        """Rotate this sensor by a certain angle around an axis and origin.
+
+        Args:
+            angle: An angle for rotation in degrees.
+            axis: Rotation axis as a Vector3D.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        rad_angle = math.radians(angle)
+        self.pos = tuple(pv.Point3D(*self.pos).rotate(axis, rad_angle, origin))
+        self.dir = tuple(pv.Vector3D(*self.dir).rotate(axis, rad_angle))
+
+    def rotate_xy(self, angle, origin):
+        """Rotate this sensor counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        rad_angle = math.radians(angle)
+        self.pos = tuple(pv.Point3D(*self.pos).rotate_xy(rad_angle, origin))
+        self.dir = tuple(pv.Vector3D(*self.dir).rotate_xy(rad_angle))
+
+    def reflect(self, plane):
+        """Reflect this sensor across a plane.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        self.pos = tuple(pv.Point3D(*self.pos).reflect(plane.n, plane.o))
+        self.dir = tuple(pv.Vector3D(*self.dir).reflect(plane.n))
+
+    def scale(self, factor, origin=None):
+        """Scale this sensor by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        self.pos = tuple(pv.Point3D(*self.pos).scale(factor, origin))
 
     def duplicate(self):
         """Duplicate the sensor."""
@@ -84,16 +148,18 @@ class Sensor(object):
         """
         return {'pos': self.pos, 'dir': self.dir}
 
-    def __eq__(self, value):
-        if not isinstance(value, Sensor):
-            return False
-        return self.pos == value.pos and self.dir == value.dir
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.pos), hash(self.dir))
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Sensor) and self.__key() == other.__key()
 
     def __ne__(self, value):
         return not self.__eq__(value)
-
-    def ToString(self):
-        return self.__repr__()
 
     def __repr__(self):
         """Get the string representation of the sensor grid."""

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -234,9 +234,10 @@ def model_to_rad_folder(model, folder=None, folder_type=2, config_file=None,
                         minimal=False):
     r"""Write a honeybee model to a rad folder.
 
-    The rad files in the resulting folders will include all geometry
-    (Rooms, Faces, Shades, Apertures, Doors), all modifiers, and all states
-    of dynamic objects.
+    The rad files in the resulting folders will include all geometry (Rooms, Faces,
+    Shades, Apertures, Doors), all modifiers, and all states of dynamic objects.
+    It also includes any SensorGrids and Views that are assigned to the model's
+    radiance properties.
 
     Args:
         model: A honeybee Model for which radiance folder will be written.
@@ -321,6 +322,20 @@ def model_to_rad_folder(model, folder=None, folder_type=2, config_file=None,
         bsdf_name = os.path.split(bdf_mod.bsdf_file)[-1]
         new_bsdf_path = os.path.join(bsdf_folder, bsdf_name)
         shutil.copy(bdf_mod.bsdf_file, new_bsdf_path)
+
+    # write the assigned sensor grids and views into the correct folder
+    grid_dir = model_folder.grid_folder(full=True)
+    for grid in model.properties.radiance.sensor_grids:
+        grid.to_file(grid_dir)
+        info_file = os.path.join(grid_dir, '{}.json'.format(grid.identifier))
+        with open(info_file, 'w') as fp:
+            json.dump(grid.info_dict(model), fp, indent=4)
+    view_dir = model_folder.view_folder(full=True)
+    for view in model.properties.radiance.views:
+        view.to_file(view_dir)
+        info_file = os.path.join(view_dir, '{}.json'.format(view.identifier))
+        with open(info_file, 'w') as fp:
+            json.dump(view.info_dict(model), fp, indent=4)
 
     return folder
 

--- a/tests/lightpath_test.py
+++ b/tests/lightpath_test.py
@@ -47,7 +47,7 @@ def test_grid_and_view_info_dict():
     south_ap2 = room2[3].apertures[0]
     south_ap2.properties.radiance.dynamic_group_identifier = 'SouthWindow2'
 
-    sensor_grid, mesh_grid = room1.properties.radiance.generate_sensor_grid(0.5, 0.5, 1)
+    sensor_grid = room1.properties.radiance.generate_sensor_grid(0.5, 0.5, 1)
 
     assert isinstance(sensor_grid, SensorGrid)
     assert sensor_grid.room_identifier == room1.identifier

--- a/tests/room_extend_test.py
+++ b/tests/room_extend_test.py
@@ -50,7 +50,7 @@ def test_set_modifier_set():
     room.properties.radiance.modifier_set = insect_screen_set
     assert room[1].apertures[0].properties.radiance.modifier == \
         generic_exterior_window_insect_screen_solar
-    
+
     with pytest.raises(AttributeError):
         room[1].properties.radiance.modifier.r_reflectance = 0.3
     with pytest.raises(AttributeError):

--- a/tests/sensor_test.py
+++ b/tests/sensor_test.py
@@ -1,10 +1,14 @@
 """Test sensor class."""
 from honeybee_radiance.sensor import Sensor
+import ladybug_geometry.geometry3d.pointvector as pv
+from ladybug_geometry.geometry3d.plane import Plane
 import pytest
 
 
 def test_default_values():
     sensor = Sensor()
+    str(sensor)  # test the string representation
+    hash(sensor)  # test the hash-ability
     assert sensor.pos == (0, 0, 0)
     assert sensor.dir == (0, 0, 1)
 
@@ -13,15 +17,6 @@ def test_assign_values():
     sensor = Sensor((0, 0, 10), (0, 0, -1))
     assert sensor.pos == (0, 0, 10)
     assert sensor.dir == (0, 0, -1)
-
-
-def test_updating_values():
-    sensor = Sensor()
-    # sensor is immutable - hence no assignment
-    with pytest.raises(AttributeError):
-        sensor.location = (0, 0, 10)
-    with pytest.raises(AttributeError):
-        sensor.dir = (0, 0, 20)
 
 
 def test_invalid_input():
@@ -35,10 +30,65 @@ def test_converting_string():
     assert sensor.dir == (0, 0, -1)
 
 
+def test_move():
+    sensor = Sensor((0, 0, 10), (0, 0, -1))
+    sensor.move(pv.Vector3D(10, 20, 30))
+
+    assert sensor.pos == (10, 20, 40)
+    assert sensor.dir == (0, 0, -1)
+
+
+def test_rotate():
+    sensor = Sensor((0, 0, 0), (1, 0, 0))
+    sensor.rotate(90, pv.Vector3D(0, 1, 1), pv.Point3D(0, 0, 20))
+    assert round(sensor.pos[0], 3) == -14.142
+    assert round(sensor.pos[1]) == -10
+    assert round(sensor.pos[2]) == 10
+    assert round(sensor.dir[0], 1) == 0.0
+    assert round(sensor.dir[1], 3) == 0.707
+    assert round(sensor.dir[2], 3) == -0.707
+
+
+def test_rotate_xy():
+    sensor = Sensor((1, 0, 2), (2, 0, 0))
+    sensor.rotate_xy(90, pv.Point3D(0, 0, 0))
+
+    assert round(sensor.pos[0]) == 0
+    assert round(sensor.pos[1]) == 1
+    assert round(sensor.pos[2]) == 2
+    assert round(sensor.dir[0]) == 0
+    assert round(sensor.dir[1]) == 2
+    assert round(sensor.dir[2]) == 0
+
+
+def test_reflect():
+    sensor = Sensor((1, 0, 2), (2, 0, 0))
+    sensor.reflect(Plane(pv.Vector3D(1, 0, 0), pv.Point3D(0, 0, 0)))
+
+    assert round(sensor.pos[0]) == -1
+    assert round(sensor.pos[1]) == 0
+    assert round(sensor.pos[2]) == 2
+    assert round(sensor.dir[0]) == -2
+    assert round(sensor.dir[1]) == 0
+    assert round(sensor.dir[2]) == 0
+
+
+def test_scale():
+    sensor = Sensor((1, 0, 2), (1, 0, 0))
+    sensor.scale(2)
+
+    assert round(sensor.pos[0]) == 2
+    assert round(sensor.pos[1]) == 0
+    assert round(sensor.pos[2]) == 4
+    assert round(sensor.dir[0]) == 1
+    assert round(sensor.dir[1]) == 0
+    assert round(sensor.dir[2]) == 0
+
+
 def test_to_and_from_dict():
     sensor = Sensor()
     sensor_dict = sensor.to_dict()
-    assert sensor_dict == {'pos': (0, 0, 0), 'dir': (0,  0, 1)}
+    assert sensor_dict == {'pos': (0, 0, 0), 'dir': (0, 0, 1)}
 
     sensor_from = Sensor.from_dict(sensor_dict)
     assert sensor_from == sensor

--- a/tests/sensorgrid_test.py
+++ b/tests/sensorgrid_test.py
@@ -1,6 +1,11 @@
 """Test SensorGrid class."""
 from honeybee_radiance.sensor import Sensor
 from honeybee_radiance.sensorgrid import SensorGrid
+import ladybug_geometry.geometry3d.pointvector as pv
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry2d.pointvector import Point2D
+from ladybug_geometry.geometry2d.mesh import Mesh2D
+from ladybug_geometry.geometry3d.mesh import Mesh3D
 import pytest
 
 
@@ -9,6 +14,9 @@ sensors = [Sensor((0, 0, 0), (0, 0, 1)), Sensor((0, 0, 10), (0, 0, 1))]
 
 def test_creation():
     sg = SensorGrid('sg_1', sensors)
+    str(sg)  # test string representation
+    hash(sg)  # test hashability
+
     assert sg.identifier == 'sg_1'
     assert len(sg) == 2
     assert sg[0] == sensors[0]
@@ -27,10 +35,10 @@ def test_invalid_input():
         sg = SensorGrid('sg_1', ((0, 0, 0, 0, 0, 1),))
 
 
-def test_from_planar_grid():
+def test_from_planar_positions():
     positions = [[0, 0, 0], [0, 0, 5], [0, 0, 10]]
     plane_normal = [0, 0, 1]
-    sg = SensorGrid.from_planar_grid('test_grid', positions, plane_normal)
+    sg = SensorGrid.from_planar_positions('test_grid', positions, plane_normal)
     assert len(sg) == 3
     for sensor in sg:
         assert sensor.dir == (0, 0, 1)
@@ -45,6 +53,17 @@ def test_from_loc_dir():
         list(sensor.dir) == directions[count]
 
 
+def test_from_mesh3d():
+    mesh_2d = Mesh2D.from_grid(Point2D(1, 1), 8, 2, 0.25, 1)
+    mesh = Mesh3D.from_mesh2d(mesh_2d)
+    sg = SensorGrid.from_mesh3d('sg_1', mesh)
+
+    assert len(sg.sensors) == 16
+    assert len(sg.mesh.vertices) == 27
+    assert len(sg.mesh.faces) == 16
+    assert mesh.area == 4
+
+
 def test_from_file():
     sensor_grid = SensorGrid.from_file('./tests/assets/test_points.pts')
     assert sensor_grid.identifier == 'test_points'
@@ -53,6 +72,72 @@ def test_from_file():
     assert len(sensor_grid) == 3
     assert sensor_grid[1].to_radiance() == '0.2 0.3 0.4 0.5 0.6 0.7'
     assert sensor_grid[2].to_radiance() == '-10.0 -5.0 0.0 -50.0 -60.0 -70.0'
+
+
+def test_move():
+    sensor = Sensor((0, 0, 10), (0, 0, -1))
+    sensors = [Sensor((0, 0, 0), (0, 0, 1)), Sensor((0, 0, 10), (0, 0, 1)), sensor]
+    sg = SensorGrid('sg_1', sensors)
+    sg.move(pv.Vector3D(10, 20, 30))
+
+    assert sensor.pos == (10, 20, 40)
+    assert sensor.dir == (0, 0, -1)
+
+
+def test_rotate():
+    sensor = Sensor((0, 0, 0), (1, 0, 0))
+    sensors = [Sensor((0, 0, 0), (0, 0, 1)), Sensor((0, 0, 10), (0, 0, 1)), sensor]
+    sg = SensorGrid('sg_1', sensors)
+    sg.rotate(90, pv.Vector3D(0, 1, 1), pv.Point3D(0, 0, 20))
+
+    assert round(sensor.pos[0], 3) == -14.142
+    assert round(sensor.pos[1]) == -10
+    assert round(sensor.pos[2]) == 10
+    assert round(sensor.dir[0], 1) == 0.0
+    assert round(sensor.dir[1], 3) == 0.707
+    assert round(sensor.dir[2], 3) == -0.707
+
+
+def test_rotate_xy():
+    sensor = Sensor((1, 0, 2), (2, 0, 0))
+    sensors = [Sensor((0, 0, 0), (0, 0, 1)), Sensor((0, 0, 10), (0, 0, 1)), sensor]
+    sg = SensorGrid('sg_1', sensors)
+    sg.rotate_xy(90, pv.Point3D(0, 0, 0))
+
+    assert round(sensor.pos[0]) == 0
+    assert round(sensor.pos[1]) == 1
+    assert round(sensor.pos[2]) == 2
+    assert round(sensor.dir[0]) == 0
+    assert round(sensor.dir[1]) == 2
+    assert round(sensor.dir[2]) == 0
+
+
+def test_reflect():
+    sensor = Sensor((1, 0, 2), (2, 0, 0))
+    sensors = [Sensor((0, 0, 0), (0, 0, 1)), Sensor((0, 0, 10), (0, 0, 1)), sensor]
+    sg = SensorGrid('sg_1', sensors)
+    sg.reflect(Plane(pv.Vector3D(1, 0, 0), pv.Point3D(0, 0, 0)))
+
+    assert round(sensor.pos[0]) == -1
+    assert round(sensor.pos[1]) == 0
+    assert round(sensor.pos[2]) == 2
+    assert round(sensor.dir[0]) == -2
+    assert round(sensor.dir[1]) == 0
+    assert round(sensor.dir[2]) == 0
+
+
+def test_scale():
+    sensor = Sensor((1, 0, 2), (1, 0, 0))
+    sensors = [Sensor((0, 0, 0), (0, 0, 1)), Sensor((0, 0, 10), (0, 0, 1)), sensor]
+    sg = SensorGrid('sg_1', sensors)
+    sg.scale(2)
+
+    assert round(sensor.pos[0]) == 2
+    assert round(sensor.pos[1]) == 0
+    assert round(sensor.pos[2]) == 4
+    assert round(sensor.dir[0]) == 1
+    assert round(sensor.dir[1]) == 0
+    assert round(sensor.dir[2]) == 0
 
 
 def test_to_radiance():
@@ -68,13 +153,14 @@ def test_to_and_from_dict():
         'type': 'SensorGrid',
         'identifier': 'sg',
         'sensors': [
-            {'pos': (0, 0, 0), 'dir': (0,  0, 1)},
-            {'pos': (0, 0, 10), 'dir': (0,  0, 1)}
+            {'pos': (0, 0, 0), 'dir': (0, 0, 1)},
+            {'pos': (0, 0, 10), 'dir': (0, 0, 1)}
         ]
     }
 
     sensor_from = SensorGrid.from_dict(sg_dict)
     assert sensor_from == sg
+    assert sg_dict == sensor_from.to_dict()
 
 
 def test_split_single_grid():


### PR DESCRIPTION
This commit adds several improvements around the SensorGrid and View classes:

* Include SensorGrids and Views as properties under ModelRadianceProperties
* Write SensorGrid and View files as part of the Model.to.rad_folder method
* Add ability to move, rotate, scale reflect sensor grids + views
* Ensure that the grids + views get moved, rotated, scaled whenever the Model is transformed or the units system is changed
* Added a property to the SensorGrid class to optionally store the mesh information for better visualization

Resolves https://github.com/ladybug-tools/honeybee-radiance/issues/230
Resolves https://github.com/ladybug-tools/honeybee-radiance/issues/229
Resolves https://github.com/ladybug-tools/honeybee-radiance/issues/100