### PR TITLE
fix(docker): add honeybee-schema and update Radiance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ python:
 
 before_install:
 # install Radiance
-- wget https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_5.5.2_Linux.zip
-- unzip Radiance_5.5.2_Linux.zip
-- tar -xzvf radiance-Linux.tar.gz
-- sudo cp -r radiance-Linux/usr/local/radiance/bin/* /usr/local/bin
+- wget https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_5.3a.fc2a2610_Linux.zip
+- unzip Radiance_5.3a.fc2a2610_Linux.zip
+- tar -xzvf radiance-5.3.fc2a261076-Linux.tar.gz
+- sudo cp -r radiance-5.3.fc2a261076-Linux/usr/local/radiance/bin/* /usr/local/bin
 - sudo mkdir /usr/local/lib/ray
-- sudo cp -r radiance-Linux/usr/local/radiance/lib/* /usr/local/lib/ray
+- sudo cp -r radiance-5.3.fc2a261076-Linux/usr/local/radiance/lib/* /usr/local/lib/ray
 
 install:
   - pip install -r dev-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:eoan
 
-MAINTAINER Ladybug Tools info@ladybug.tools
+LABEL maintainer="Ladybug Tools" email="info@ladybug.tools"
 
 # Install core software deps
 RUN apt-get update && \
@@ -21,7 +21,7 @@ WORKDIR /home/ladybugbot
 # Install radiance
 ENV RAYPATH=/home/ladybugbot/lib
 ENV PATH="/home/ladybugbot/bin:${PATH}"
-RUN curl -L https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_5.5.2_Linux.zip --output radiance.zip \
+RUN curl -L https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_5.3a.fc2a2610_Linux.zip --output radiance.zip \
 && unzip -p radiance.zip | tar xz \
 && mkdir bin \
 && mkdir lib \
@@ -33,8 +33,8 @@ RUN curl -L https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_
 # Install honeybee-radiance cli
 ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
 COPY . honeybee-radiance
-RUN pip3 install setuptools
-RUN pip3 install ./honeybee-radiance[cli]
+RUN pip3 install setuptools wheel \
+    && pip3 install pydantic==1.5.1 honeybee-schema ./honeybee-radiance[cli]
 
 # Set workdir
 RUN mkdir -p /home/ladybugbot/run


### PR DESCRIPTION
Similar to honeybee-energy docker we have to explicitly add pydantic and honeybee-schema to pip install.

I also updated Radiance to the latest version which is required for annual studies.