### PR TITLE
fix(writer): Ensure Apertures remain black even when static

### DIFF
--- a/honeybee_radiance/cli/translate.py
+++ b/honeybee_radiance/cli/translate.py
@@ -31,9 +31,6 @@ def translate():
 @click.option('--folder', help='Folder on this computer, into which the Radiance '
               'folders will be written. If None, the files will be output in the'
               'same location as the model_json.', default=None, show_default=True)
-@click.option('--folder-type', help='An integer between 0-2 to note the type of '
-              'folders to be written out with the Model.\n0: grid-based\n1: view-based'
-              '\n2: includes both views and grids', default=2, show_default=True)
 @click.option('--config-file', help='An optional config file path to modify the '
               'default folder names. If None, folder.cfg in honeybee-radiance-folder '
               'will be used.', default=None, show_default=True)
@@ -43,7 +40,7 @@ def translate():
 @click.option('--log-file', help='Optional log file to output the path of the radiance '
               'folder generated from the model. By default this will be printed '
               'to stdout', type=click.File('w'), default='-')
-def model_to_rad_folder(model_json, folder, folder_type, config_file, minimal, log_file):
+def model_to_rad_folder(model_json, folder, config_file, minimal, log_file):
     """Translate a Model JSON file into a Radiance Folder.
     \n
     Args:
@@ -64,7 +61,7 @@ def model_to_rad_folder(model_json, folder, folder_type, config_file, minimal, l
         model = Model.from_dict(data)
 
         # translate the model to a radiance folder
-        rad_fold = model.to.rad_folder(model, folder, folder_type, config_file, minimal)
+        rad_fold = model.to.rad_folder(model, folder, config_file, minimal)
         log_file.write(rad_fold)
     except Exception as e:
         _logger.exception('Model translation failed.\n{}'.format(e))

--- a/honeybee_radiance/properties/model.py
+++ b/honeybee_radiance/properties/model.py
@@ -501,6 +501,40 @@ class ModelRadianceProperties(object):
             return False
         return True
 
+    def check_duplicate_sensor_grid_display_names(self, raise_exception=True):
+        """Check that there are no duplicate SensorGrid display_names in the model."""
+        grid_display_names = set()
+        duplicate_display_names = set()
+        for grid in self.sensor_grids:
+            if grid.display_name not in grid_display_names:
+                grid_display_names.add(grid.display_name)
+            else:
+                duplicate_display_names.add(grid.display_name)
+        if len(duplicate_display_names) != 0:
+            if raise_exception:
+                raise ValueError(
+                    'The model has the following duplicated sensor grid '
+                    'display_names:\n{}'.format('\n'.join(duplicate_display_names)))
+            return False
+        return True
+
+    def check_duplicate_view_display_names(self, raise_exception=True):
+        """Check that there are no duplicate View display_names in the model."""
+        view_display_names = set()
+        duplicate_display_names = set()
+        for view in self.views:
+            if view.display_name not in view_display_names:
+                view_display_names.add(view.display_name)
+            else:
+                duplicate_display_names.add(view.display_name)
+        if len(duplicate_display_names) != 0:
+            if raise_exception:
+                raise ValueError(
+                    'The model has the following duplicated view '
+                    'display_names:\n{}'.format('\n'.join(duplicate_display_names)))
+            return False
+        return True
+
     def check_sensor_grid_rooms_in_model(self, raise_exception=True):
         """Check that the room_identifiers of SenorGrids are in the model."""
         grid_ids = [grid.room_identifier for grid in self.sensor_grids]

--- a/honeybee_radiance/sensorgrid.py
+++ b/honeybee_radiance/sensorgrid.py
@@ -187,7 +187,7 @@ class SensorGrid(object):
 
     @identifier.setter
     def identifier(self, n):
-        self._identifier = typing.valid_rad_string(n)
+        self._identifier = typing.valid_rad_string(n, 'sensor grid identifier')
 
     @property
     def display_name(self):
@@ -201,10 +201,7 @@ class SensorGrid(object):
 
     @display_name.setter
     def display_name(self, value):
-        try:
-            self._display_name = str(value)
-        except UnicodeEncodeError:  # Python 2 machine lacking the character set
-            self._display_name = value  # keep it as unicode
+        self._display_name = typing.valid_rad_string(value, 'sensor grid display_name')
 
     @property
     def sensors(self):
@@ -318,18 +315,18 @@ class SensorGrid(object):
 
         Args:
             folder: Target folder.
-            file_name: Optional file name without extension. (Default: self.identifier)
+            file_name: Optional file name without extension. (Default: self.display_name)
             mkdir: A boolean to indicate if the folder should be created in case it
                 doesn't exist already (Default: False).
 
         Returns:
             Full path to newly created file.
         """
-        identifier = file_name or self.identifier + '.pts'
-        if not identifier.endswith('.pts'):
-            identifier += '.pts'
+        display_name = file_name or self.display_name + '.pts'
+        if not display_name.endswith('.pts'):
+            display_name += '.pts'
         return futil.write_to_file_by_name(
-            folder, identifier, self.to_radiance() + '\n', mkdir)
+            folder, display_name, self.to_radiance() + '\n', mkdir)
 
     def to_files(self, folder, count, base_name=None, mkdir=False):
         """Split this sensor grid and write them to several files.
@@ -338,7 +335,7 @@ class SensorGrid(object):
             folder: Target folder.
             count: Number of files.
             base_name: Optional text for a unique base_name for sensor files.
-                (Default: self.identifier)
+                (Default: self.display_name)
             mkdir: A boolean to indicate if the folder should be created in case it
                 doesn't exist already (Default: False).
 
@@ -347,14 +344,14 @@ class SensorGrid(object):
             to the grid.
         """
         count = typing.int_in_range(count, 1, input_name='file count')
-        base_name = base_name or self.identifier
+        base_name = base_name or self.display_name
         if count == 1 or self.count == 0:
             full_path = self.to_file(folder, base_name, mkdir)
             return [
-                {'name': base_name if not self.identifier.endswith('.pts')
-                    else self.identifier.replace('.pts', ''),
-                 'path': self.identifier + '.pts'
-                    if not self.identifier.endswith('.pts') else self.identifier,
+                {'name': base_name if not self.display_name.endswith('.pts')
+                    else self.display_name.replace('.pts', ''),
+                 'path': self.display_name + '.pts'
+                    if not self.display_name.endswith('.pts') else self.display_name,
                  'full_path': full_path,
                  'count': self.count}
             ]

--- a/honeybee_radiance/view.py
+++ b/honeybee_radiance/view.py
@@ -143,7 +143,7 @@ class View(object):
 
     @identifier.setter
     def identifier(self, n):
-        self._identifier = typing.valid_rad_string(n)
+        self._identifier = typing.valid_rad_string(n, 'view identifier')
 
     @property
     def display_name(self):
@@ -157,10 +157,7 @@ class View(object):
 
     @display_name.setter
     def display_name(self, value):
-        try:
-            self._display_name = str(value)
-        except UnicodeEncodeError:  # Python 2 machine lacking the character set
-            self._display_name = value  # keep it as unicode
+        self._display_name = typing.valid_rad_string(value, 'view display_name')
 
     @property
     def is_fisheye(self):
@@ -664,6 +661,7 @@ class View(object):
             _n_view._aft_clip = self._aft_clip
             _n_view._room_identifier = self._room_identifier
             _n_view._light_path = self._light_path
+            _n_view.display_name = '%s_%d' % (self.display_name, view_count)
 
             # add the new view to views list
             _views[view_count] = _n_view
@@ -727,7 +725,7 @@ class View(object):
 
         Args:
             folder: Target folder.
-            file_name: Optional file name without extension (Default: self.identifier).
+            file_name: Optional file name without extension (Default: self.display_name).
             mkdir: A boolean to indicate if the folder should be created in case it
                 doesn't exist already (Default: False).
 
@@ -735,10 +733,10 @@ class View(object):
             Full path to newly created file.
         """
 
-        identifier = file_name or self.identifier + '.vf'
+        display_name = file_name or self.display_name + '.vf'
         # add rvu before the view itself
         content = 'rvu ' + self.to_radiance()
-        return futil.write_to_file_by_name(folder, identifier, content, mkdir)
+        return futil.write_to_file_by_name(folder, display_name, content, mkdir)
 
     def move(self, moving_vec):
         """Move this view along a vector.


### PR DESCRIPTION
This commit fixes a bug where static apertures were not being written with a completely black material for their .blk file.

The commit also changes SensorGrids and Views to use their display_name for the .pts file name whenever they are written to file.  In accordance with this change, SensorGrids and Views are now the only objects to have restrictions on acceptable characters within their display_names (an exception will be raised if an unacceptable character is found).  We also now always run a check for duplicate display_names of these objects whenever a model is serialized to rad_folder.

The commit also changes the model.to.rad_folder method to use only the minimal folder structure by default and writes out additional folders as they are needed.

Lastly, I realized that the folder_type input on the model.to.rad_folder method is a bit misleading now that grids and views are assigned to the model.  In other words, I don't want to deal with the case where someone has a view assigned to their model but selects "grids only" as their folder_type.  So I now assume a minimal folder by default (without any grids or views) and I create the grid and view folders if such objects are found within the model.