### PR TITLE
fix(primitive): minimize import to modules

### DIFF
--- a/honeybee_radiance/modifier/material/mirror.py
+++ b/honeybee_radiance/modifier/material/mirror.py
@@ -5,7 +5,10 @@ http://radsite.lbl.gov/radiance/refer/ray.html#Mirror
 from __future__ import division
 from .materialbase import Material
 import honeybee.typing as typing
-from ...primitive import Void, VOID
+from ...primitive import Void
+
+
+VOID = Void()
 
 
 class Mirror(Material):


### PR DESCRIPTION
Importing the object from another module fails on WSL. This change should fix it.