### PR TITLE
fix(sensorgrid): Add base_geometry property for SensorGrid

### DIFF
--- a/honeybee_radiance/modifierset.py
+++ b/honeybee_radiance/modifierset.py
@@ -625,13 +625,13 @@ class ModifierSet(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Radiance Modifier Set: {}'.format(self.identifier)
+        return 'Radiance Modifier Set: {}'.format(self.display_name)
 
 
 @lockable
 class _BaseSet(object):
     """Base class for the sets assigned to Faces.
-    
+
     This includes WallModifierSet, FloorModifierSet, RoofCeilingModifierSet and
     ShadeModifierSet.
 
@@ -726,19 +726,19 @@ class _BaseSet(object):
         attributes = self._slots
         if none_for_defaults:
             if abridged:
-                base = {attr[1:]:getattr(self, attr[1:]).identifier
+                base = {attr[1:]: getattr(self, attr[1:]).identifier
                         if getattr(self, attr) is not None else None
                         for attr in attributes}
             else:
-                base = {attr[1:]:getattr(self, attr[1:]).to_dict()
+                base = {attr[1:]: getattr(self, attr[1:]).to_dict()
                         if getattr(self, attr) is not None else None
                         for attr in attributes}
         else:
             if abridged:
-                base = {attr[1:]:getattr(self, attr[1:]).identifier
+                base = {attr[1:]: getattr(self, attr[1:]).identifier
                         for attr in attributes}
             else:
-                base = {attr[1:]:getattr(self, attr[1:]).to_dict()
+                base = {attr[1:]: getattr(self, attr[1:]).to_dict()
                         for attr in attributes}
 
         base['type'] = self.__class__.__name__ + 'Abridged' if abridged else \
@@ -784,9 +784,9 @@ class _BaseSet(object):
 
     def __repr__(self):
         name = self.__class__.__name__.split('Set')[0]
-        return '{} Modifier Set:\n Exterior: {}\n Interior: {}'.format(
-            name, self.exterior_modifier.identifier, self.interior_modifier.identifier
-        )
+        return '{} Modifier Set: [Exterior: {}] [Interior: {}]'.format(
+            name, self.exterior_modifier.display_name,
+            self.interior_modifier.display_name)
 
 
 @lockable
@@ -966,13 +966,12 @@ class ApertureModifierSet(_BaseSet):
         )
 
     def __repr__(self):
-        return 'Aperture Modifier Set:\n Exterior: {}\n Interior: {}' \
-            '\n Skylight: {}\n Operable: {}'.format(
-            self.window_modifier.identifier,
-            self.interior_modifier.identifier,
-            self.skylight_modifier.identifier,
-            self.operable_modifier.identifier
-        )
+        return 'Aperture Modifier Set: [Exterior: {}] [Interior: {}]' \
+            ' [Skylight: {}] [Operable: {}]'.format(
+                self.window_modifier.display_name,
+                self.interior_modifier.display_name,
+                self.skylight_modifier.display_name,
+                self.operable_modifier.display_name)
 
 
 @lockable
@@ -1087,11 +1086,6 @@ class DoorModifierSet(_BaseSet):
         )
 
     def __repr__(self):
-        return 'Door Modifier Set:\n Exterior: {}\n Interior: {}' \
-            '\n Exterior Glass: {}\n Interior Glass: {}\n Overhead: {}'.format(
-                self.exterior_modifier.identifier,
-                self.interior_modifier.identifier,
-                self.exterior_glass_modifier.identifier,
-                self.interior_glass_modifier.identifier,
-                self.overhead_modifier.identifier
-                )
+        return 'Door Modifier Set: [Exterior: {}] [Interior: {}]'.format(
+                self.exterior_modifier.display_name,
+                self.interior_modifier.display_name)

--- a/honeybee_radiance/properties/_base.py
+++ b/honeybee_radiance/properties/_base.py
@@ -162,7 +162,7 @@ class _RadianceProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Base Radiance Properties:\n host: {}'.format(self.host.identifier)
+        return 'Base Radiance Properties: [host: {}]'.format(self.host.display_name)
 
 
 class _DynamicRadianceProperties(_RadianceProperties):

--- a/honeybee_radiance/properties/aperture.py
+++ b/honeybee_radiance/properties/aperture.py
@@ -194,4 +194,4 @@ class ApertureRadianceProperties(_DynamicRadianceProperties):
         return new_prop
 
     def __repr__(self):
-        return 'Aperture Radiance Properties:\n host: {}'.format(self.host.identifier)
+        return 'Aperture Radiance Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_radiance/properties/door.py
+++ b/honeybee_radiance/properties/door.py
@@ -195,4 +195,4 @@ class DoorRadianceProperties(_DynamicRadianceProperties):
         return new_prop
 
     def __repr__(self):
-        return 'Door Radiance Properties:\n host: {}'.format(self.host.identifier)
+        return 'Door Radiance Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_radiance/properties/face.py
+++ b/honeybee_radiance/properties/face.py
@@ -120,4 +120,4 @@ class FaceRadianceProperties(_RadianceProperties):
         return self._add_modifiers_to_dict(base, abridged)
 
     def __repr__(self):
-        return 'Face Radiance Properties:\n host: {}'.format(self.host.identifier)
+        return 'Face Radiance Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_radiance/properties/model.py
+++ b/honeybee_radiance/properties/model.py
@@ -9,6 +9,7 @@ from ..modifier.material import BSDF
 from ..lib.modifiers import black, generic_context
 
 from honeybee.extensionutil import model_extension_dicts
+from honeybee.checkdup import check_duplicate_identifiers
 from honeybee.boundarycondition import Surface
 
 try:
@@ -435,105 +436,22 @@ class ModelRadianceProperties(object):
 
     def check_duplicate_modifier_identifiers(self, raise_exception=True):
         """Check that there are no duplicate Modifier identifiers in the model."""
-        mod_identifiers = set()
-        duplicate_identifiers = set()
-        for mod in self.modifiers:
-            if mod.identifier not in mod_identifiers:
-                mod_identifiers.add(mod.identifier)
-            else:
-                duplicate_identifiers.add(mod.identifier)
-        if len(duplicate_identifiers) != 0:
-            if raise_exception:
-                raise ValueError(
-                    'The model has the following duplicated modifier '
-                    'identifiers:\n{}'.format('\n'.join(duplicate_identifiers)))
-            return False
-        return True
+        return check_duplicate_identifiers(
+            self.modifiers, raise_exception, 'Radiance Modifier')
 
     def check_duplicate_modifier_set_identifiers(self, raise_exception=True):
         """Check that there are no duplicate ModifierSet identifiers in the model."""
-        mod_set_identifiers = set()
-        duplicate_identifiers = set()
-        for mod_set in self.modifier_sets:
-            if mod_set.identifier not in mod_set_identifiers:
-                mod_set_identifiers.add(mod_set.identifier)
-            else:
-                duplicate_identifiers.add(mod_set.identifier)
-        if len(duplicate_identifiers) != 0:
-            if raise_exception:
-                raise ValueError(
-                    'The model has the following duplicated ModifierSet '
-                    'identifiers:\n{}'.format('\n'.join(duplicate_identifiers)))
-            return False
-        return True
+        return check_duplicate_identifiers(
+            self.modifier_sets, raise_exception, 'ModifierSet')
 
     def check_duplicate_sensor_grid_identifiers(self, raise_exception=True):
         """Check that there are no duplicate SensorGrid identifiers in the model."""
-        grid_identifiers = set()
-        duplicate_identifiers = set()
-        for grid in self.sensor_grids:
-            if grid.identifier not in grid_identifiers:
-                grid_identifiers.add(grid.identifier)
-            else:
-                duplicate_identifiers.add(grid.identifier)
-        if len(duplicate_identifiers) != 0:
-            if raise_exception:
-                raise ValueError(
-                    'The model has the following duplicated sensor grid '
-                    'identifiers:\n{}'.format('\n'.join(duplicate_identifiers)))
-            return False
-        return True
+        return check_duplicate_identifiers(
+            self.sensor_grids, raise_exception, 'SensorGrid')
 
     def check_duplicate_view_identifiers(self, raise_exception=True):
         """Check that there are no duplicate View identifiers in the model."""
-        view_identifiers = set()
-        duplicate_identifiers = set()
-        for view in self.views:
-            if view.identifier not in view_identifiers:
-                view_identifiers.add(view.identifier)
-            else:
-                duplicate_identifiers.add(view.identifier)
-        if len(duplicate_identifiers) != 0:
-            if raise_exception:
-                raise ValueError(
-                    'The model has the following duplicated view '
-                    'identifiers:\n{}'.format('\n'.join(duplicate_identifiers)))
-            return False
-        return True
-
-    def check_duplicate_sensor_grid_display_names(self, raise_exception=True):
-        """Check that there are no duplicate SensorGrid display_names in the model."""
-        grid_display_names = set()
-        duplicate_display_names = set()
-        for grid in self.sensor_grids:
-            if grid.display_name not in grid_display_names:
-                grid_display_names.add(grid.display_name)
-            else:
-                duplicate_display_names.add(grid.display_name)
-        if len(duplicate_display_names) != 0:
-            if raise_exception:
-                raise ValueError(
-                    'The model has the following duplicated sensor grid '
-                    'display_names:\n{}'.format('\n'.join(duplicate_display_names)))
-            return False
-        return True
-
-    def check_duplicate_view_display_names(self, raise_exception=True):
-        """Check that there are no duplicate View display_names in the model."""
-        view_display_names = set()
-        duplicate_display_names = set()
-        for view in self.views:
-            if view.display_name not in view_display_names:
-                view_display_names.add(view.display_name)
-            else:
-                duplicate_display_names.add(view.display_name)
-        if len(duplicate_display_names) != 0:
-            if raise_exception:
-                raise ValueError(
-                    'The model has the following duplicated view '
-                    'display_names:\n{}'.format('\n'.join(duplicate_display_names)))
-            return False
-        return True
+        return check_duplicate_identifiers(self.views, raise_exception, 'View')
 
     def check_sensor_grid_rooms_in_model(self, raise_exception=True):
         """Check that the room_identifiers of SenorGrids are in the model."""
@@ -809,4 +727,4 @@ class ModelRadianceProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Model Radiance Properties:\n host: {}'.format(self.host.identifier)
+        return 'Model Radiance Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_radiance/properties/room.py
+++ b/honeybee_radiance/properties/room.py
@@ -5,6 +5,8 @@ from ..view import View
 from ..modifierset import ModifierSet
 from ..lib.modifiersets import generic_modifier_set_visible
 
+from honeybee.facetype import Floor
+
 
 class RoomRadianceProperties(object):
     """Radiance Properties for Honeybee Room.
@@ -91,6 +93,10 @@ class RoomRadianceProperties(object):
             return None
         sensor_grid = SensorGrid.from_mesh3d(self.host.identifier, floor_grid)
         sensor_grid.room_identifier = self.host.identifier
+        sensor_grid.display_name = self.host.display_name
+        sensor_grid.base_geometry = \
+            tuple(face.geometry.move(face.normal.reverse() * offset)
+                  for face in self.host.faces if isinstance(face.type, Floor))
         return sensor_grid
 
     def generate_view(self, direction, up_vector=(0, 0, 1), type='v', h_size=60,
@@ -156,6 +162,7 @@ class RoomRadianceProperties(object):
         view = View(self.host.identifier, pos, direction, up_vector, type,
                     h_size, v_size, shift, lift)
         view.room_identifier = self.host.identifier
+        view.display_name = self.host.display_name
         return view
 
     @classmethod
@@ -239,4 +246,4 @@ class RoomRadianceProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Room Radiance Properties:\n host: {}'.format(self.host.identifier)
+        return 'Room Radiance Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_radiance/view.py
+++ b/honeybee_radiance/view.py
@@ -157,7 +157,10 @@ class View(object):
 
     @display_name.setter
     def display_name(self, value):
-        self._display_name = typing.valid_rad_string(value, 'view display_name')
+        try:
+            self._display_name = str(value)
+        except UnicodeEncodeError:  # Python 2 machine lacking the character set
+            self._display_name = value  # keep it as unicode
 
     @property
     def is_fisheye(self):
@@ -410,8 +413,8 @@ class View(object):
             assert isinstance(l_path, (tuple, list)), 'Expected list or tuple for ' \
                 'light_path. Got {}.'.format(type(l_path))
             for ap_list in l_path:
-                assert isinstance(ap_list, (tuple, list)), 'Expected list or tuple for ' \
-                    'light_path sub-list. Got {}.'.format(type(ap_list))
+                assert isinstance(ap_list, (tuple, list)), 'Expected list or tuple ' \
+                    'for light_path sub-list. Got {}.'.format(type(ap_list))
                 for ap in ap_list:
                     assert isinstance(ap, str), 'Expected text for light_path ' \
                         'aperture group identifier. Got {}.'.format(type(ap))
@@ -661,7 +664,10 @@ class View(object):
             _n_view._aft_clip = self._aft_clip
             _n_view._room_identifier = self._room_identifier
             _n_view._light_path = self._light_path
-            _n_view.display_name = '%s_%d' % (self.display_name, view_count)
+            try:
+                _n_view.display_name = '%s_%d' % (self.display_name, view_count)
+            except UnicodeEncodeError:  # character no found on machine
+                pass
 
             # add the new view to views list
             _views[view_count] = _n_view
@@ -725,7 +731,7 @@ class View(object):
 
         Args:
             folder: Target folder.
-            file_name: Optional file name without extension (Default: self.display_name).
+            file_name: Optional file name without extension (Default: self.identifier).
             mkdir: A boolean to indicate if the folder should be created in case it
                 doesn't exist already (Default: False).
 
@@ -733,10 +739,10 @@ class View(object):
             Full path to newly created file.
         """
 
-        display_name = file_name or self.display_name + '.vf'
+        identifier = file_name or self.identifier + '.vf'
         # add rvu before the view itself
         content = 'rvu ' + self.to_radiance()
-        return futil.write_to_file_by_name(folder, display_name, content, mkdir)
+        return futil.write_to_file_by_name(folder, identifier, content, mkdir)
 
     def move(self, moving_vec):
         """Move this view along a vector.

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -293,7 +293,8 @@ def model_to_rad_folder(model, folder=None, config_file=None, minimal=False):
                 raise NotImplementedError('Dynamic interior apertures are not currently'
                                           ' supported by Model.to.rad_folder.')
             else:
-                st_d = _write_dynamic_subface_files(folder, out_subfolder, group, minimal)
+                st_d = _write_dynamic_subface_files(
+                    folder, out_subfolder, group, minimal)
                 _write_mtx_files(folder, out_subfolder, group, st_d, minimal)
                 ext_dict[group.identifier] = st_d
         _write_dynamic_json(folder, out_subfolder, ext_dict)
@@ -337,15 +338,14 @@ def model_to_rad_folder(model, folder=None, config_file=None, minimal=False):
     if len(grids) != 0:
         grids_info = []
         preparedir(grid_dir)
-        model.properties.radiance.check_duplicate_sensor_grid_display_names()
         for grid in grids:
             grid.to_file(grid_dir)
-            info_file = os.path.join(grid_dir, '{}.json'.format(grid.display_name))
+            info_file = os.path.join(grid_dir, '{}.json'.format(grid.identifier))
             with open(info_file, 'w') as fp:
                 json.dump(grid.info_dict(model), fp, indent=4)
 
             grid_info = {
-                'name': grid.display_name, 'count': grid.count
+                'name': grid.identifier, 'count': grid.count
             }
             grids_info.append(grid_info)
 
@@ -359,17 +359,16 @@ def model_to_rad_folder(model, folder=None, config_file=None, minimal=False):
     if len(views) != 0:
         views_info = []
         preparedir(view_dir)
-        model.properties.radiance.check_duplicate_view_display_names()
         for view in views:
             view.to_file(view_dir)
-            info_file = os.path.join(view_dir, '{}.json'.format(view.display_name))
+            info_file = os.path.join(view_dir, '{}.json'.format(view.identifier))
             with open(info_file, 'w') as fp:
                 json.dump(view.info_dict(model), fp, indent=4)
 
             # TODO: see if it make sense to use to_dict here instead of only taking the
             # name
             view_info = {
-                'name': view.display_name
+                'name': view.identifier
             }
             views_info.append(view_info)
 
@@ -458,7 +457,7 @@ def _write_mtx_files(folder, sub_folder, group, states_json_list, minimal=False)
 
     # loop through all states and write out the .rad files for them
     tmxt_valid = False
-    for state_i, st_dict in enumerate(states_json_list):
+    for state_i, _ in enumerate(states_json_list):
         tmtx_bsdf = group.tmxt_bsdf(state_i)
         if tmtx_bsdf is not None:  # it's a valid state for 3-phase
             tmxt_valid = True


### PR DESCRIPTION
The base_geometry  will be useful for visualization purposes.

I am also putting back the older behavior of the SensorGrid and View identifiers. So identifiers are now used to specify the filenames in the model folder (instead of the display_name).  In accordance with this, I am going to get rid of the addition of UUID text whenever a user specifies a name for a sensor grid, view, or modifier on the Grasshopper interface.  While this will almost certainly result in ID conflicts at some point, there are usually not that many modifiers or grids in a model that the user won't be able to do some conflict resolution.  Geometry, on the other hand, doesn't seem to be worth the risk of un-resolvable ID collisions.  So I'll always give this a unique ID when it's created.

CC: @devngc