### PR TITLE
fix(docker): reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ LABEL maintainer="Ladybug Tools" email="info@ladybug.tools"
 ARG radiance_version
 
 ENV WORKDIR='/home/ladybugbot'
-ENV RAYPATH='${WORKDIR}/lib'
+ENV RUNDIR="${WORKDIR}/run"
+ENV LIBRARYDIR="${WORKDIR}/honeybee-radiance"
+ENV RAYPATH="${WORKDIR}/lib"
 ENV PATH="${WORKDIR}/.local/bin:${RAYPATH}:${PATH}"
 
 RUN apt-get update \
@@ -23,7 +25,15 @@ COPY radiance-${radiance_version}-Linux/usr/local/radiance/bin ${WORKDIR}/bin
 COPY radiance-${radiance_version}-Linux/usr/local/radiance/lib ${WORKDIR}/lib
 
 # Install honeybee-radiance
-COPY . honeybee-radiance
+COPY honeybee_radiance ${LIBRARYDIR}/honeybee_radiance
+COPY .git ${LIBRARYDIR}/.git
+COPY README.md ${LIBRARYDIR}
+COPY requirements.txt ${LIBRARYDIR}
+COPY setup.py ${LIBRARYDIR}
+COPY setup.cfg ${LIBRARYDIR}
+COPY LICENSE ${LIBRARYDIR}
+
+# Switch user back to modify packages
 USER root
 RUN pip3 install --no-cache-dir setuptools wheel \
     && pip3 install --no-cache-dir ./honeybee-radiance \
@@ -33,5 +43,5 @@ RUN pip3 install --no-cache-dir setuptools wheel \
 
 USER ladybugbot
 # Set workdir
-RUN mkdir -p /home/ladybugbot/run
-WORKDIR /home/ladybugbot/run
+RUN mkdir -p ${RUNDIR}
+WORKDIR ${RUNDIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN adduser ladybugbot --uid 1000 --disabled-password --gecos ""
 USER ladybugbot
 WORKDIR ${WORKDIR}
 
-# Expects a decomressed radiance folder in the build context
+# Expects a decompressed radiance folder in the build context
 COPY radiance-${radiance_version}-Linux/usr/local/radiance/bin ${WORKDIR}/bin
 COPY radiance-${radiance_version}-Linux/usr/local/radiance/lib ${WORKDIR}/lib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN pip3 install --no-cache-dir setuptools wheel \
     && pip3 install --no-cache-dir ./honeybee-radiance \
     && apt-get -y --purge remove git \
     && apt-get -y clean \
-    && apt-get -y autoremove
+    && apt-get -y autoremove \
+    && rm -rf ${LIBRARYDIR}/.git
 
 USER ladybugbot
 # Set workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,20 @@
-FROM python:3.7
+FROM python:3.7-slim
 
 LABEL maintainer="Ladybug Tools" email="info@ladybug.tools"
+
+ARG radiance_version
+
+ENV WORKDIR='/home/ladybugbot'
+ENV RAYPATH='${WORKDIR}/lib'
+ENV PATH="${RAYPATH}:${PATH}"
 
 # Create non-root user
 RUN adduser ladybugbot --uid 1000 --disabled-password --gecos ""
 USER ladybugbot
-WORKDIR /home/ladybugbot
+WORKDIR ${WORKDIR}
 
-# Install radiance
-ENV RAYPATH=/home/ladybugbot/lib
-ENV PATH="/home/ladybugbot/bin:${PATH}"
-RUN curl -L https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_5.3a.fc2a2610_Linux.zip --output radiance.zip \
-&& unzip -p radiance.zip | tar xz \
-&& mkdir bin \
-&& mkdir lib \
-&& mv ./radiance-5.3.fc2a261076-Linux/usr/local/radiance/bin/* /home/ladybugbot/bin \
-&& mv ./radiance-5.3.fc2a261076-Linux/usr/local/radiance/lib/* /home/ladybugbot/lib \
-&& rm -rf radiance-5.3.fc2a261076-Linux \
-&& rm radiance.zip
+COPY radiance-${radiance_version}-Linux/usr/local/radiance/bin ${WORKDIR}/bin
+COPY radiance-${radiance_version}-Linux/usr/local/radiance/lib ${WORKDIR}/lib
 
 # Install honeybee-radiance
 ENV PATH="/home/ladybugbot/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,22 +6,32 @@ ARG radiance_version
 
 ENV WORKDIR='/home/ladybugbot'
 ENV RAYPATH='${WORKDIR}/lib'
-ENV PATH="${RAYPATH}:${PATH}"
+ENV PATH="${WORKDIR}/.local/bin:${RAYPATH}:${PATH}"
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
 RUN adduser ladybugbot --uid 1000 --disabled-password --gecos ""
 USER ladybugbot
 WORKDIR ${WORKDIR}
 
+# Expects a decomressed radiance folder in the build context
 COPY radiance-${radiance_version}-Linux/usr/local/radiance/bin ${WORKDIR}/bin
 COPY radiance-${radiance_version}-Linux/usr/local/radiance/lib ${WORKDIR}/lib
 
 # Install honeybee-radiance
-ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
 COPY . honeybee-radiance
-RUN pip3 install setuptools wheel \
-    && pip3 install ./honeybee-radiance
+USER root
+RUN pip3 install --no-cache-dir setuptools wheel \
+    && pip3 install --no-cache-dir ./honeybee-radiance \
+    && apt-get -y --purge remove git \
+    && apt-get -y clean \
+    && apt-get -y autoremove
 
+USER ladybugbot
 # Set workdir
 RUN mkdir -p /home/ladybugbot/run
 WORKDIR /home/ladybugbot/run

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,15 +14,20 @@ echo "PyPi Deployment..."
 echo "Building distribution"
 python setup.py sdist bdist_wheel
 echo "Pushing new version to PyPi"
-twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 
+twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
 
+export radiance_version='5.3a.fc2a2610'
+
+curl -L "https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_${radiance_version}_Linux.zip" --output radiance.zip
+
+unzip -p radiance.zip | tar xz
 
 echo "Docker Deployment..."
 echo "Login to Docker"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-docker build . -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION 
+docker build . -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION --build-arg radiance_version=${radiance_version}
 docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
 
 docker push $CONTAINER_NAME:latest
-docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION 
+docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION


### PR DESCRIPTION
# What
- Reduce image size

# Why
- To enable faster pulls

# Notes
@mostaphaRoudsari I see that this is built in `deploy.sh` but I'm not sure where in the CI process this gets called so I'm not positive that `curl` is available. As long as it is, it should be fine.

The changes here reduce uncompressed image size `1.02GB` -> `0.33GB`.
