### PR TITLE
fix(deploy): normalize radiance name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM python:3.7-slim
 
 LABEL maintainer="Ladybug Tools" email="info@ladybug.tools"
 
-ARG radiance_version
-
 ENV WORKDIR='/home/ladybugbot'
 ENV RUNDIR="${WORKDIR}/run"
 ENV LIBRARYDIR="${WORKDIR}/honeybee-radiance"
@@ -21,8 +19,8 @@ USER ladybugbot
 WORKDIR ${WORKDIR}
 
 # Expects a decompressed radiance folder in the build context
-COPY radiance-${radiance_version}-Linux/usr/local/radiance/bin ${WORKDIR}/bin
-COPY radiance-${radiance_version}-Linux/usr/local/radiance/lib ${WORKDIR}/lib
+COPY radiance/usr/local/radiance/bin ${WORKDIR}/bin
+COPY radiance/usr/local/radiance/lib ${WORKDIR}/lib
 
 # Install honeybee-radiance
 COPY honeybee_radiance ${LIBRARYDIR}/honeybee_radiance

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,15 +18,16 @@ twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
 
 export radiance_version='5.3a.fc2a2610'
 
-curl -L "https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_${radiance_version}_Linux.zip" --output radiance.zip
-
-unzip -p radiance.zip | tar xz
 
 echo "Docker Deployment..."
 echo "Login to Docker"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-docker build . -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION --build-arg radiance_version=${radiance_version}
+curl -L "https://ladybug-tools-releases.nyc3.digitaloceanspaces.com/Radiance_5.3a.fc2a2610_Linux.zip" --output radiance.zip
+unzip -p radiance.zip | tar xz
+mv radiance-*-Linux radiance
+
+docker build . -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION
 docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
 
 docker push $CONTAINER_NAME:latest

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,9 +16,6 @@ python setup.py sdist bdist_wheel
 echo "Pushing new version to PyPi"
 twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
 
-export radiance_version='5.3a.fc2a2610'
-
-
 echo "Docker Deployment..."
 echo "Login to Docker"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
# What
- Handle different radiance hashes in archive name

# Why
- So that the docker build works

# Notes
There's a slight difference in the hash length that is used in the .zip vs the .tar.gz of radiance that is needed for the image build. `5.3.fc2a261076` vs `5.3.fc2a2610`. So the build arg that was used before would get the .zip but not find the correct folder from the .tar.gz. This normalizes the name by renaming the untarred archive to just be `radiance/`.

I tested this on my fork [here](https://github.com/tymokvo/honeybee-radiance/runs/1982783390?check_suite_focus=true) and it seems to work.