### PR TITLE
Restructure annual daylight metric files

### DIFF
--- a/honeybee_radiance/cli/postprocess.py
+++ b/honeybee_radiance/cli/postprocess.py
@@ -1,6 +1,7 @@
 """honeybee radiance daylight postprocessing commands."""
 import click
 import sys
+import os
 import logging
 from honeybee_radiance.postprocess.annualdaylight import metrics_to_folder
 
@@ -106,7 +107,7 @@ def sum_matrix_rows(input_matrix, output):
 @click.option(
     '--schedule', '-sch', help='Path to an annual schedule file. Values should be 0-1 '
     'separated by new line. If not provided an 8-5 annual schedule will be created.',
-    type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True)
+    type=click.Path(exists=False, file_okay=True, dir_okay=False, resolve_path=True)
 )
 @click.option(
     '--threshold', '-t', help='Threshold illuminance level for daylight autonomy.',
@@ -152,9 +153,12 @@ def annual_metrics(
         sensor grid.
 
     """
-    if schedule:
+    # optional input - only check if the file exist otherwise ignore
+    if schedule and os.path.isfile(schedule):
         with open(schedule) as hourly_schedule:
             schedule = [int(float(v)) for v in hourly_schedule]
+    else:
+        schedule = None
 
     try:
         metrics_to_folder(

--- a/honeybee_radiance/postprocess/annualdaylight.py
+++ b/honeybee_radiance/postprocess/annualdaylight.py
@@ -185,13 +185,17 @@ def metrics_to_files(
         os.makedirs(output_folder)
 
     grid_name = grid_name or os.path.split(ill_file)[-1][-4:]
-    da = os.path.join(output_folder, '%s.da' % grid_name).replace('\\', '/')
-    cda = os.path.join(output_folder, '%s.cda' % grid_name).replace('\\', '/')
-    udi = os.path.join(output_folder, '%s.udi' % grid_name).replace('\\', '/')
+    da = os.path.join(output_folder, 'da', '%s.da' % grid_name).replace('\\', '/')
+    cda = os.path.join(output_folder, 'cda', '%s.cda' % grid_name).replace('\\', '/')
+    udi = os.path.join(output_folder, 'udi', '%s.udi' % grid_name).replace('\\', '/')
     udi_lower = \
-        os.path.join(output_folder, '%s_lower.udi' % grid_name).replace('\\', '/')
+        os.path.join(
+            output_folder, 'udi_lower', '%s_lower.udi' % grid_name
+        ).replace('\\', '/')
     udi_upper = \
-        os.path.join(output_folder, '%s_upper.udi' % grid_name).replace('\\', '/')
+        os.path.join(
+            output_folder, 'udi_upper', '%s_upper.udi' % grid_name
+        ).replace('\\', '/')
 
     for file_path in [da, cda, udi, udi_upper, udi_lower]:
         folder = os.path.dirname(file_path)
@@ -322,5 +326,11 @@ def metrics_to_folder(
             ill_file, occ_pattern, metrics_folder, threshold, min_t,
             max_t, grid['full_id']
         )
+
+    # copy info.json to all results folders
+    for folder_name in ['da', 'cda', 'udi_lower', 'udi', 'udi_upper']:
+        grid_info = os.path.join(metrics_folder, folder_name, 'grids_info.json')
+        with open(grid_info, 'w') as outf:
+            json.dump(grids, outf)
 
     return metrics_folder


### PR DESCRIPTION
With this change every metric will be generated under a separate subfolder.

The change also adds the filtered information for grids_info to each subfolder. This file can be used by handlers to ensure the order of the outputs will match the order of the input grids.
