### PR TITLE
docs(cli): Improve CLI documentation structure

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,6 +1,0 @@
-Honeybee Radiance Command Line Interface
-========================================
-
-.. click:: honeybee_radiance.cli:radiance
-   :prog: honeybee_radiance
-   :show-nested:

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -1,0 +1,7 @@
+CLI Docs
+========
+
+Installation
+------------
+
+To check if the command line interface is installed correctly use `honeybee-radiance --help`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,6 +229,250 @@ autodoc_default_options = {
 
 autodoc_member_order = 'groupwise'
 
+# -- CLI documentation  -------------------------------------------------------
+"""Improves the CLI documentation section.
+
+In order to have separate html pages for each module inside library\\cli
+additional documentation reST files(.rst) need to be generated in docs\\cli folder.
+
+Note:
+    This process assumes that each cli module represent a group of subcommands.
+    Use hash tables below to address special cases.
+"""
+# Activate this CLI documentation process
+custom_cli_docs = True
+
+# Repository/library hash table.
+# If respository not found in table, the module name will be extracted from the
+# modules.rst file in the project folder.
+# Format: {repository_name: library_name}
+ht_repo_lib = {}
+
+# Library/command hash table.
+# Created to address CLI tool names that differ from their library name beyond
+# the underscore(_) to dash(-) difference.
+# Format: {library_name: tool_name}
+ht_lib_tool = {}
+
+# Cli_file/cli_group hash table.
+# Created to address CLI file names that differ from the included CLI group name
+# Format: {
+#    library_name_1: {CLI_filename_1: group_name_1,
+#                     CLI_filename_2: group_name_2
+#                    },
+#    library_name_2: {CLI_filename_3: group_name_3,
+#                     CLI_filename_4: group_name_4
+#                    }
+# }
+ht_cli_file_group = {
+    'honeybee_radiance': {'mtx': 'mtxop',
+                          'postprocess': 'post_process'
+                          }
+}
+
+
+# Specify if existing reSt files found in docs//cli folder will be overwritten.
+cli_overwrite = False
+
+
+def create_cli_files():
+    """Generate additional files required by sphinx to build well structured
+     CLI documentation pages.
+
+    The process consists in generating reST files with sphinx-click directives
+    for each click group detected in the library's cli folder and updating
+    the index.rst file to include a list of the click groups found.
+    """
+
+    # Get CLI data from library
+    proj_folder = os.path.dirname(__file__)
+    result = get_cli_data(proj_folder)
+    if not result:
+        return
+
+    all_groups, lib_name, tool_name = result
+
+    # Prepare docs folder and reST files to create
+    doc_folder = os.path.join(proj_folder, 'cli')
+    if not os.path.isdir(doc_folder):
+        os.mkdir(doc_folder)
+
+    # Exclude CLI groups if corresponding reST file detected in docs/cli
+    new_groups = [name for name in all_groups
+                  if name + ".rst" not in os.listdir(doc_folder)]
+
+    if not cli_overwrite and not new_groups:
+        print("[CLI]: No new CLI files created.")
+        return
+
+    # Create CLI reST files for each module(command group) found.
+    click_groups = all_groups if cli_overwrite else new_groups
+    result = write_cli_files(click_groups, lib_name, tool_name, doc_folder)
+    if not result:
+        print("[CLI]: Something went wrong during CLI docs generation")
+
+    # Update/Create index file with command group section included
+    update_cli_index(os.path.join(doc_folder, 'index.rst'), all_groups)
+
+
+def get_cli_data(project_folder):
+    """Retrieve CLI data found inside a specified respository.
+
+    Args:
+        project_folder: the documentation path that contains the files to
+        extract CLI data from.
+
+    Returns:
+        A tuple with three elements.
+
+        -   module_names:
+            A list with the names of the CLI modules found in the repository.
+
+        -   lib_name: The name of the library found in the repository.
+
+        -   tool_name: The name of the command line tool that is used for this
+            library.
+    """
+    print("[CLI data]: Retrieveing CLI data from {}".format(project_folder))
+
+    # Check in hash table for a library name based on repository name
+    repo_path = os.path.abspath(os.path.join(project_folder, os.pardir))
+    repo_name = os.path.split(repo_path)[1]
+
+    # Look up the library name in hashtable
+    lib_name = ht_repo_lib[repo_name] if repo_name in ht_repo_lib else None
+    # Otherwise exract library name from modules.rst file (from heading)
+    if not lib_name:
+        modules_file = os.path.join(os.path.join(project_folder, 'modules.rst'))
+        with open(modules_file, 'r') as mod_file:
+            lines = mod_file.readlines()
+        lib_name = lines[0][0:-1]
+
+    # Check in hash table for a command line tool name that is different
+    # from its library name beyond the underscore(_) to dash(-) difference.
+    tool_name = ht_lib_tool[
+        lib_name] if lib_name in ht_lib_tool else lib_name.replace("_", "-")
+
+    lib_path = os.path.abspath(os.path.join(repo_path, lib_name))
+    if not os.path.isdir(lib_path):
+        print("[CLI data]: Cannot find library path")
+        return None
+
+    cli_path = os.path.join(lib_path, 'cli')
+    if not os.path.isdir(lib_path):
+        print("[CLI data]: No CLI library found")
+        return None
+
+    # Generate a list with the module source files(.py).
+    module_names = [os.path.splitext(file)[0] for file in os.listdir(cli_path)
+                    if os.path.splitext(file)[1] == ".py"]
+
+    # Remove files that aren't a cli module
+    discard_names = ["__init__", "util"]
+    module_names = [name for name in module_names if name not in discard_names]
+
+    if not module_names:
+        print("[CLI data]: No CLI modules detected in /cli folder.")
+        return None
+
+    # Return library data
+    return module_names, lib_name, tool_name
+
+
+def write_cli_files(click_group_files, library, tool, doc_folder):
+    """Writes a reST file with CLI directives for each click group provided.
+
+    Args:
+        click_group_files: A list containing the names of the CLI files that
+            rst files wil be generated for.
+        library: The name of the library the click groups belong to. For
+            example ``honeybee_energy``, ``dragonfly`` or ``honeybee_radiance``
+            are possible library names.
+        tool: The command line tool name for the specified library. For
+            instance ``honeybee-energy`` is the CLI tool used for the
+            honeybee_energy library.
+        doc_folder: The path where the CLI documentation files will be saved.
+    """
+
+    # Creating missing CLI reST files
+    print("[CLI files]: Creating ({}) CLI rst files: {}...".format(
+        len(click_group_files), click_group_files))
+
+    # Retrieve valid group names where the file name and CLI group name don't
+    # match
+    group_names = list.copy(click_group_files)
+    if library in ht_cli_file_group:
+        ht_file_group = ht_cli_file_group[library]
+        group_names = [ht_file_group[
+            name] if name in ht_file_group else name for name in group_names]
+
+    # Write sphinx-click directive with options for each CLI group
+    for file, group in zip(click_group_files, group_names):
+        cli_content = ["{}\n".format(file),
+                       "{}\n".format("=" * len(file)),
+                       "\n",
+                       ".. click:: {}.cli.{}:{}\n".format(
+                           library, file, group),
+                       "   :prog: {} {}\n".format(tool, group),
+                       "   :show-nested:\n"
+                       ]
+
+        # Create CLI group reST file
+        with open(os.path.join(doc_folder, file + ".rst"), 'w') as group_file:
+            group_file.writelines(cli_content)
+
+    return True
+
+
+def update_cli_index(index_path, group_filenames):
+    """Create or update the index.rst file inside the docs\\cli folder to include
+    links to the click groups found.
+
+    Args:
+        index_path: index.rst file path to be updated or created from scratch.
+        group_filenames: Name of the click groups to include in the
+            index \'Commands\' section.
+    """
+
+    print("[CLI index]: Updating index.rst file...")
+
+    # Include exisitng index.rst data if present
+    cli_content = []
+    if os.path.isfile(index_path):
+        with open(index_path, 'r') as index_file:
+            lines = index_file.readlines()
+        cli_content = lines[:lines.index("Commands\n")
+                            ] if "Commands\n" in lines else lines
+    else:
+        # Otherwise create a "CLI" heading
+        cli_content = ["CLI\n", "===\n", "\n"]
+
+    # Add 'Commands' section with directive and options
+    cli_content += ["\n"
+                    "Commands\n",
+                    "--------\n",
+                    ".. toctree::\n",
+                    "   :maxdepth: 1\n",
+                    "\n"
+                    ]
+
+    # Add sub-command groups to content
+    for group in group_filenames:
+        cli_content.append("   {}\n".format(group))
+
+    # Append section to file
+    with open(index_path, 'w') as index_file:
+        index_file.writelines(cli_content)
+
+    return True
+
+
+# Custom CLI docs function call.
+if custom_cli_docs:
+    create_cli_files()
+
+# -----------------------------------------------------------------------------
+
 
 def setup(app):
     """Run custom code with access to the Sphinx application object

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,8 +236,9 @@ In order to have separate html pages for each module inside library\\cli
 additional documentation reST files(.rst) need to be generated in docs\\cli folder.
 
 Note:
-    This process assumes that each cli module represent a group of subcommands.
-    Use hash tables below to address special cases.
+    This process assumes that each CLI module represent a group of subcommands.
+    Important: Use hash tables below to address special cases such as
+    command group name different from their module file name.
 """
 # Activate this CLI documentation process
 custom_cli_docs = True
@@ -379,16 +380,16 @@ def get_cli_data(project_folder):
     return module_names, lib_name, tool_name
 
 
-def write_cli_files(click_group_files, library, tool, doc_folder):
+def write_cli_files(group_filenames, lib_name, tool_name, doc_folder):
     """Writes a reST file with CLI directives for each click group provided.
 
     Args:
-        click_group_files: A list containing the names of the CLI files that
-            rst files wil be generated for.
-        library: The name of the library the click groups belong to. For
+        group_filenames: A list containing the names of the CLI files that
+            rst files will be generated for.
+        lib_name: The name of the library the click groups belong to. For
             example ``honeybee_energy``, ``dragonfly`` or ``honeybee_radiance``
             are possible library names.
-        tool: The command line tool name for the specified library. For
+        tool_name: The command line tool name for the specified library. For
             instance ``honeybee-energy`` is the CLI tool used for the
             honeybee_energy library.
         doc_folder: The path where the CLI documentation files will be saved.
@@ -396,24 +397,24 @@ def write_cli_files(click_group_files, library, tool, doc_folder):
 
     # Creating missing CLI reST files
     print("[CLI files]: Creating ({}) CLI rst files: {}...".format(
-        len(click_group_files), click_group_files))
+        len(group_filenames), group_filenames))
 
     # Retrieve valid group names where the file name and CLI group name don't
     # match
-    group_names = list.copy(click_group_files)
-    if library in ht_cli_file_group:
-        ht_file_group = ht_cli_file_group[library]
+    group_names = list.copy(group_filenames)
+    if lib_name in ht_cli_file_group:
+        ht_file_group = ht_cli_file_group[lib_name]
         group_names = [ht_file_group[
             name] if name in ht_file_group else name for name in group_names]
 
     # Write sphinx-click directive with options for each CLI group
-    for file, group in zip(click_group_files, group_names):
+    for file, group in zip(group_filenames, group_names):
         cli_content = ["{}\n".format(file),
                        "{}\n".format("=" * len(file)),
                        "\n",
                        ".. click:: {}.cli.{}:{}\n".format(
-                           library, file, group),
-                       "   :prog: {} {}\n".format(tool, group),
+                           lib_name, file, group),
+                       "   :prog: {} {}\n".format(tool_name, group),
                        "   :show-nested:\n"
                        ]
 
@@ -457,8 +458,8 @@ def update_cli_index(index_path, group_filenames):
                     ]
 
     # Add sub-command groups to content
-    for group in group_filenames:
-        cli_content.append("   {}\n".format(group))
+    for file in group_filenames:
+        cli_content.append("   {}\n".format(file))
 
     # Append section to file
     with open(index_path, 'w') as index_file:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,19 +15,29 @@ Installation
 
 To check if the command line interface is installed correctly use ``honeybee-radiance --help``.
 
-CLI Documentation
-==================
 
-For command line interface documentation see `this page <cli.html>`_.
+CLI Docs
+=============
+
+For command line interface documentation and API documentation see the pages below.
+
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
-.. include:: modules.rst
+   cli/index
+
+
+honeybee_radiance
+=================
+
+.. toctree::
+   :maxdepth: 4
+
+   modules
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/honeybee_radiance/lightsource/sky/_skybase.py
+++ b/honeybee_radiance/lightsource/sky/_skybase.py
@@ -85,6 +85,7 @@ class _SkyDome(object):
 
     def to_file(self, folder, name=None, mkdir=False):
         """Write sky hemisphere to a sky_hemisphere.rad Radiance file.
+
         Args:
             folder: Target folder.
             name: File name.

--- a/honeybee_radiance/lightsource/sky/cie.py
+++ b/honeybee_radiance/lightsource/sky/cie.py
@@ -22,17 +22,19 @@ class CIE(_PointInTime):
             Radiance convention. In Radiance the azimuth degrees are measured in west of
             South.
         sky_type: An integer between 0..5 to indicate CIE Sky Type.
+
             * 0 = Sunny with sun. Sunny sky with sun. In addition to the sky distribution
-            function, a source description of the sun is generated.
+              function, a source description of the sun is generated.
             * 1 = Sunny without sun. Sunny sky without sun. The sky distribution will
-            correspond to a standard CIE clear day.
+              correspond to a standard CIE clear day.
             * 2 = Intermediate with sun. In addition to the sky distribution, a (somewhat
-            subdued) sun is generated.
+              subdued) sun is generated.
             * 3 = Intermediate without sun. The sky will correspond to a standard CIE
-            intermediate day.
+              intermediate day.
             * 4 = Cloudy sky. The sky distribution will correspond to a standard CIE
-            overcast day.
+              overcast day.
             * 5 = Uniform cloudy sky. The sky distribution will be completely uniform.
+
         ground_reflectance: Average ground reflectance (Default: 0.2).
 
     Properties:
@@ -101,16 +103,17 @@ class CIE(_PointInTime):
         An integer between 0 and 5 to indicate CIE Sky Type.
 
         * 0 = Sunny with sun. Sunny sky with sun. In addition to the sky distribution
-        function, a source description of the sun is generated.
+          function, a source description of the sun is generated.
         * 1 = Sunny without sun. Sunny sky without sun. The sky distribution will
-        correspond to a standard CIE clear day.
+          correspond to a standard CIE clear day.
         * 2 = Intermediate with sun. In addition to the sky distribution, a (somewhat
-        subdued) sun is generated.
+          subdued) sun is generated.
         * 3 = Intermediate without sun. The sky will correspond to a standard CIE
-        intermediate day.
+          intermediate day.
         * 4 = Cloudy sky. The sky distribution will correspond to a standard CIE
-        overcast day.
+          overcast day.
         * 5 = Uniform cloudy sky. The sky distribution will be completely uniform.
+
         """
         return self._sky_type
 
@@ -129,16 +132,17 @@ class CIE(_PointInTime):
         """Sky type in Radiance format.
 
         * +s = Sunny with sun. Sunny sky with sun. In addition to the sky distribution
-        function, a source description of the sun is generated.
+          function, a source description of the sun is generated.
         * -s = Sunny without sun. Sunny sky without sun. The sky distribution will
-        correspond to a standard CIE clear day.
+          correspond to a standard CIE clear day.
         * +i = Intermediate with sun. In addition to the sky distribution, a (somewhat
-        subdued) sun is generated.
+          subdued) sun is generated.
         * -i = Intermediate without sun. The sky will correspond to a standard CIE
-        intermediate day.
+          intermediate day.
         * -c = Cloudy sky. The sky distribution will correspond to a standard CIE
-        overcast day.
+          overcast day.
         * -u = Uniform cloudy sky. The sky distribution will be completely uniform.
+
         """
         return self.SKYTYPES[self.sky_type][0]
 
@@ -156,18 +160,20 @@ class CIE(_PointInTime):
             day: An intger between 1 to 28-31 depending on the input month.
             hour: A float number larger or equal to 0 and smaller than 24.
             sky_type: An integer between 0..5 to indicate CIE Sky Type.
+
                 * 0 = Sunny with sun. Sunny sky with sun. In addition to the sky
-                    distribution function, a source description of the sun is generated.
+                  distribution function, a source description of the sun is generated.
                 * 1 = Sunny without sun. Sunny sky without sun. The sky distribution will
-                    correspond to a standard CIE clear day.
+                  correspond to a standard CIE clear day.
                 * 2 = Intermediate with sun. In addition to the sky distribution, a
-                    (somewhat subdued) sun is generated.
+                  (somewhat subdued) sun is generated.
                 * 3 = Intermediate without sun. The sky will correspond to a standard CIE
-                    intermediate day.
+                  intermediate day.
                 * 4 = Cloudy sky. The sky distribution will correspond to a standard CIE
-                    overcast day.
+                  overcast day.
                 * 5 = Uniform cloudy sky. The sky distribution will be completely
-                    uniform.
+                  uniform.
+
             north_angle: North angle in degrees. A number between -360 and 360 for the
                 counterclockwise difference between the North and the positive Y-axis in
                 degrees. 90 is West and 270 is East (Default: 0).
@@ -189,18 +195,20 @@ class CIE(_PointInTime):
             day: An intger between 1 to 28-31 depending on the input month.
             hour: A float number larger or equal to 0 and smaller than 24.
             sky_type: An integer between 0..5 to indicate CIE Sky Type.
+
                 * 0 = Sunny with sun. Sunny sky with sun. In addition to the sky
-                    distribution function, a source description of the sun is generated.
+                  distribution function, a source description of the sun is generated.
                 * 1 = Sunny without sun. Sunny sky without sun. The sky distribution will
-                    correspond to a standard CIE clear day.
+                  correspond to a standard CIE clear day.
                 * 2 = Intermediate with sun. In addition to the sky distribution, a
-                    (somewhat subdued) sun is generated.
+                  (somewhat subdued) sun is generated.
                 * 3 = Intermediate without sun. The sky will correspond to a standard CIE
-                    intermediate day.
+                  intermediate day.
                 * 4 = Cloudy sky. The sky distribution will correspond to a standard CIE
-                    overcast day.
+                  overcast day.
                 * 5 = Uniform cloudy sky. The sky distribution will be completely
-                    uniform.
+                  uniform.
+
             north_angle: North angle in degrees. A number between -360 and 360 for the
                 counterclockwise difference between the North and the positive Y-axis in
                 degrees. 90 is West and 270 is East (Default: 0).


### PR DESCRIPTION
Hi @chriswmackey,

Here is my first pass to this library. This one has a a few unique things and thought would be a good one to start with before we move on to the rest of the libraries. 

1.  **CLI group names:**
The main issue here is that there are two CLI groups (mtx and postprocess) where the filenames differ from the group names. To address this I created a hash table where each library can include `rst_filename: group_name` pairs for these special cases. This means that if future CLI groups fall in this special case they will need to be added to the hash table for the group documentation to be generated properly. If we don't want to rely on people adding them to the hash table manually we could possibly automate this by reading the file with the CLI code and extract the name of the group from there. May be overkill to do this for every group documented on every library, specially if this is only useful for a handful of times so clearly there is a trade off to consider with this approach. Hope this is clear and happy to show the code if you need more details.

2.  **Installation section:** 
I have included the Installation section inside the CLI Docs to be consistent with what we used in honeybee-energy. I just copied the information that was include in the main page. If there is any other information we want to include here, please let me know, happy to add it!

3. **Warnings during documentation build:**
A couple of warnings we can fix here or in a future PR:
- honeybee-radiance\docs\cli\mtx.rst. From what I gathered this seems to be triggered somehow inside the mtx.py file by the `/` and  `*` options within the `@click.options` decorator. Seems like these special characters are creating some conflicts. The rendered html is showing these two options in link format. Tried escaping them ('\\') but the forward slash is still giving me some trouble, also not sure this escaping affects the code or not.  Please let me know what do you think, I can look deeper into it if the result is not acceptable.

- honeybee-radiance lightsource\sky\CIE.py . These are some some lists formatting issues, can be easily corrected but not sure I should touch this file in this PR.
 
Sorry @chriswmackey for the long list in something that should be pretty straightforward, the good news is that the other two libraries I updated are issue-less! :)
