### PR TITLE
fix(translate): Permit the use of a pkl file for Honeybee Model

### DIFF
--- a/honeybee_radiance/cli/translate.py
+++ b/honeybee_radiance/cli/translate.py
@@ -51,19 +51,15 @@ def model_to_rad_folder(model_json, folder, view, grid, config_file, minimal, lo
 
     \b
     Args:
-        model_json: Full path to a Model JSON file.
+        model_json: Full path to a Model JSON file (HBJSON) or a Model pkl (HBpkl) file.
     """
     try:
         # set the default folder if it's not specified
         if folder is None:
             folder = os.path.dirname(os.path.abspath(model_json))
 
-        # re-serialize the Model to Python
-        with open(model_json) as json_file:
-            data = json.load(json_file)
-        model = Model.from_dict(data)
-
-        # translate the model to a radiance folder
+        # re-serialize the Model and translate the model to a radiance folder
+        model = Model.from_file(model_json)
         rad_fold = model.to.rad_folder(
             model, folder, config_file, minimal, views=view, grids=grid
         )
@@ -98,15 +94,11 @@ def model_to_rad(model_json, blk, minimal, output_file):
 
     \b
     Args:
-        model_json: Full path to a Model JSON file.
+        model_json: Full path to a Model JSON file (HBJSON) or a Model pkl (HBpkl) file.
     """
     try:
-        # re-serialize the Model to Python
-        with open(model_json) as json_file:
-            data = json.load(json_file)
-        model = Model.from_dict(data)
-
-        # translate the model to a rad string
+        # re-serialize the Model and translate the model to a rad string
+        model = Model.from_file(model_json)
         model_str, modifier_str = model.to.rad(model, blk, minimal)
         rad_str_list = ['# ========  MODEL MODIFIERS ========', modifier_str,
                         '# ========  MODEL GEOMETRY ========', model_str]
@@ -141,13 +133,11 @@ def model_radiant_enclosure_info(model_json, folder, log_file):
 
     \b
     Args:
-        model_json: Full path to a Model JSON file.
+        model_json: Full path to a Model JSON file (HBJSON) or a Model pkl (HBpkl) file.
     """
     try:
-        # re-serialize the Model JSON
-        with open(model_json) as json_file:
-            data = json.load(json_file)
-        model = Model.from_dict(data)
+        # re-serialize the Model
+        model = Model.from_file(model_json)
 
         # set the default folder if it's not specified
         if folder is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-honeybee-core==1.42.16
+honeybee-core==1.43.0
 honeybee-radiance-folder==2.5.0
 honeybee-radiance-command==1.2.1
 honeybee-standards==2.0.0


### PR DESCRIPTION
Just enabling the model-to-rad-folder command to accept pkl files instead of JSON means that practically all Radiance recipes can accept much larger models without maxing our memory.

I think we will still use HBJSON for the majority of cases but I can see that this will be handy for the edge cases.