### PR TITLE
fix(postprocess): Simplify the naming convention of output files

### DIFF
--- a/honeybee_radiance/postprocess/annualdaylight.py
+++ b/honeybee_radiance/postprocess/annualdaylight.py
@@ -189,13 +189,9 @@ def metrics_to_files(
     cda = os.path.join(output_folder, 'cda', '%s.cda' % grid_name).replace('\\', '/')
     udi = os.path.join(output_folder, 'udi', '%s.udi' % grid_name).replace('\\', '/')
     udi_lower = \
-        os.path.join(
-            output_folder, 'udi_lower', '%s_lower.udi' % grid_name
-        ).replace('\\', '/')
+        os.path.join(output_folder, 'udi_lower', '%s.udi' % grid_name).replace('\\', '/')
     udi_upper = \
-        os.path.join(
-            output_folder, 'udi_upper', '%s_upper.udi' % grid_name
-        ).replace('\\', '/')
+        os.path.join(output_folder, 'udi_upper', '%s.udi' % grid_name).replace('\\', '/')
 
     for file_path in [da, cda, udi, udi_upper, udi_lower]:
         folder = os.path.dirname(file_path)


### PR DESCRIPTION
It will simplify the handlers a lot if they always follow the same convention of the the files bearing the grid name but the parent folder bears the metric name.

This commit fixes the issue reported here:
https://discourse.ladybug.tools/t/hb-1-2-0-udi-low-and-udi-up-not-outputting-any-results/13740

CC: @mostapharoudsari