### PR TITLE
Improve group by identifier

### DIFF
--- a/honeybee_radiance/sensorgrid.py
+++ b/honeybee_radiance/sensorgrid.py
@@ -38,6 +38,7 @@ class SensorGrid(object):
         * mesh
         * base_geometry
         * group_identifier
+        * full_identifier
 
     """
 
@@ -318,6 +319,15 @@ class SensorGrid(object):
                     for key in identifier_key.split('/')
                 )
         self._group_identifier = identifier_key
+
+    @property
+    def full_identifier(self):
+        """Get full identifier for a sensor grid.
+
+        For a sensor grid with group identifier it will be group_identifier/identifier
+        """
+        return self.identifier if not self.group_identifier \
+            else '%s/%s' % (self.group_identifier, self.identifier)
 
     @property
     def light_path(self):

--- a/honeybee_radiance/view.py
+++ b/honeybee_radiance/view.py
@@ -74,6 +74,7 @@ class View(object):
         * room_identifier
         * light_path
         * group_identifier
+        * full_identifier
 
     Usage:
 
@@ -422,6 +423,15 @@ class View(object):
                     for key in identifier_key.split('/')
                 )
         self._group_identifier = identifier_key
+
+    @property
+    def full_identifier(self):
+        """Get full identifier for view.
+
+        For a view with group identifier it will be group_identifier/identifier
+        """
+        return self.identifier if not self.group_identifier \
+            else '%s/%s' % (self.group_identifier, self.identifier)
 
     @property
     def light_path(self):

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -439,7 +439,7 @@ def _write_sensor_grids(folder, model, grids_filter):
                 'identifier': identifier,
                 'count': grid.count,
                 'group': grid.group_identifier or '',
-                'source': _get_full_id(grid),
+                'full_id': _get_full_id(grid),
                 'start_ln': start_line[identifier]
             }
 
@@ -777,11 +777,16 @@ def _group_by_identifier(sensor_grids):
     """Group sensor grids if they have the same identifier."""
     group_func = lambda grid: grid.identifier  # noqa: E731
 
-    sensor_grids = sorted(sensor_grids, key=group_func)
+    ordered_sensor_grids = sorted(sensor_grids, key=group_func)
+
+    # check if there is any duplicated identifiers
+    ids = {grid.identifier for grid in sensor_grids}
+    if len(list(ids)) == len(sensor_grids):
+        # there is no duplicated identifier - return the original list
+        return sensor_grids
+
     updated_grids = []
-    # for g in sensor_grids:
-    #     print(g.identifier)
-    for identifier, grids in itertools.groupby(sensor_grids, group_func):
+    for identifier, grids in itertools.groupby(ordered_sensor_grids, group_func):
         grids = list(grids)
         if len(grids) > 1:
             # merge grids into one

--- a/tests/cli/translate_cli_test.py
+++ b/tests/cli/translate_cli_test.py
@@ -93,7 +93,7 @@ def test_model_to_rad_folder_model_grid_info():
             "identifier": "perimeter",
             "count": 300,
             "group": "",
-            "source": "perimeter",
+            "full_id": "perimeter",
             "start_ln": 0,
         },
         {
@@ -101,7 +101,7 @@ def test_model_to_rad_folder_model_grid_info():
             "identifier": "perimeter",
             "count": 220,
             "group": "",
-            "source": "perimeter",
+            "full_id": "perimeter",
             "start_ln": 300,
         },
         {
@@ -109,7 +109,7 @@ def test_model_to_rad_folder_model_grid_info():
             "identifier": "core",
             "count": 640,
             "group": "",
-            "source": "core",
+            "full_id": "core",
             "start_ln": 0,
         },
     ]


### PR DESCRIPTION
Use full identifier instead of identifier to avoid merging sensor grids that are part of different groups.