### PR TITLE
fix(sky): Add methods to serialize skies from strings

### DIFF
--- a/honeybee_radiance/lightsource/dictutil.py
+++ b/honeybee_radiance/lightsource/dictutil.py
@@ -28,18 +28,18 @@ def dict_to_light_source(light_source_dict, raise_exception=True):
     """Get a Python object of any light source from a dictionary.
 
     Args:
-        load_dict: A dictionary of any Honeybee energy load. Note
+        light_source_dict: A dictionary of any Honeybee Radiance light source. Note
             that this should be a non-abridged dictionary to be valid.
         raise_exception: Boolean to note whether an excpetion should be raised
-            if the object is not identified as a load. Default: True.
+            if the object is not identified as a light source. Default: True.
 
     Returns:
-        A Python object derived from the input load_dict.
+        A Python object derived from the input light_source_dict.
     """
     try:  # get the type key from the dictionary
         light_type = light_source_dict['type']
     except KeyError:
-        raise ValueError('Load dictionary lacks required "type" key.')
+        raise ValueError('Light source dictionary lacks required "type" key.')
 
     try:
         return LIGHT_SOURCE_TYPES[light_type].from_dict(light_source_dict)

--- a/honeybee_radiance/lightsource/sky/_skybase.py
+++ b/honeybee_radiance/lightsource/sky/_skybase.py
@@ -175,7 +175,3 @@ class _PointInTime(_SkyDome):
             'ground_hemisphere': self.ground_hemisphere.to_dict(),
             'sky_hemisphere': self.sky_hemisphere.to_dict()
         }
-
-    def ToString(self):
-        """Overwrite .NET ToString."""
-        return self.__repr__()

--- a/honeybee_radiance/lightsource/sky/strutil.py
+++ b/honeybee_radiance/lightsource/sky/strutil.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+"""Utilities to convert sky strings to Python objects."""
+from honeybee_radiance.lightsource.sky.certainirradiance import CertainIrradiance
+from honeybee_radiance.lightsource.sky.cie import CIE
+from honeybee_radiance.lightsource.sky.climatebased import ClimateBased
+
+SKY_TYPES = {
+    'irradiance': CertainIrradiance,
+    'illuminance': CertainIrradiance,
+    'cie': CIE,
+    'climate-based': ClimateBased
+}
+
+
+def string_to_sky(sky_string, raise_exception=True):
+    """Get a Python object of any sky from a string representation.
+
+    Args:
+        sky_string: A text string representing a CIE, ClimateBased, or CertainIrradiance
+            sky. This can be a minimal representation of the sky (eg.
+            "cie -alt 71.6 -az 185.2 -type 0"). Or it can be a detailed specification of
+            time and location (eg. "cie 21 Jun 12:00 -lat 41.78 -lon -87.75 -type 0").
+        raise_exception: Boolean to note whether an excpetion should be raised
+            if the object is not identified as a sky. Default: True.
+
+    Returns:
+        A Python object derived from the input sky_string.
+    """
+    sky_type = sky_string.lower().split(' ')[0].strip()
+    try:
+        return SKY_TYPES[sky_type].from_string(sky_string)
+    except KeyError:
+        if raise_exception:
+            raise ValueError('{} is not a recognized radiance Sky type'.format(sky_type))

--- a/honeybee_radiance/lightsource/sunpath.py
+++ b/honeybee_radiance/lightsource/sunpath.py
@@ -70,7 +70,7 @@ class Sunpath(object):
 
     def _solar_calc(self, hoys, wea, output_type, leap_year=False,
                     reverse_vectors=False):
-        """Calculate ."""
+        """Calculate sun vectors and radiance values from the properties."""
         solar_calc = LBSunpath.from_location(self.location, self.north)
         solar_calc.is_leap_year = leap_year
 

--- a/tests/cli/sky_cli_test.py
+++ b/tests/cli/sky_cli_test.py
@@ -1,9 +1,55 @@
 """Test sky subcommands."""
 
 from click.testing import CliRunner
-from honeybee_radiance.cli.sky import sky_with_certain_illum, sky_dome
+from honeybee_radiance.cli.sky import sky_cie, sky_climate_based, \
+    sky_with_certain_irrad, sky_with_certain_illum, sky_dome
 import uuid
 import os
+
+
+def test_sky_cie():
+    folder = './tests/assets/temp'
+    runner = CliRunner()
+
+    name = str(uuid.uuid4()) + '.sky'
+    args = ['21', 'Jun', '12:00', '-lat', '41.78', '-lon', '-87.75',
+            '-type', '2', '--folder', folder, '--name', name]
+    result = runner.invoke(sky_cie, args)
+    assert result.exit_code == 0
+    assert os.path.isfile(os.path.join(folder, name))
+
+    args = ['-alt', '45', '-az', '180', '-type', '2', '--folder', folder, '--name', name]
+    result = runner.invoke(sky_cie, args)
+    assert result.exit_code == 0
+
+
+def test_sky_climate_based():
+    folder = './tests/assets/temp'
+    runner = CliRunner()
+
+    name = str(uuid.uuid4()) + '.sky'
+    cb_s = 'ClimateBased, 21 Jun 12:00, lat:41.78, lon:-87.75, dni:800, dhi:120'
+    args = ['21', 'Jun', '12:00', '-lat', '41.78', '-lon', '-87.75',
+            '-dni', '800', '-dhi', '120', '--folder', folder, '--name', name]
+    result = runner.invoke(sky_climate_based, args)
+    assert result.exit_code == 0
+    assert os.path.isfile(os.path.join(folder, name))
+
+    args = ['-alt', '45', '-az', '180', '-dni', '800', '-dhi', '120',
+            '--folder', folder, '--name', name]
+    result = runner.invoke(sky_climate_based, args)
+    assert result.exit_code == 0
+
+
+def test_sky_with_certain_irrad():
+    folder = './tests/assets/temp'
+    runner = CliRunner()
+
+    name = str(uuid.uuid4()) + '.sky'
+    result = runner.invoke(
+        sky_with_certain_irrad, ['800', '-g', '0.3', '--folder', folder, '--name', name])
+    assert result.exit_code == 0
+    assert os.path.isfile(os.path.join(folder, name))
 
 
 def test_illuminance_sky():

--- a/tests/sky_certain_irradiance_test.py
+++ b/tests/sky_certain_irradiance_test.py
@@ -1,5 +1,6 @@
 from honeybee_radiance.lightsource.sky.certainirradiance import CertainIrradiance
 import os
+import sys
 
 
 def test_check_defaults():
@@ -45,6 +46,18 @@ def test_to_and_from_dict():
     sky_from_dict = CertainIrradiance.from_dict(sky.to_dict())
 
     assert sky == sky_from_dict
+
+
+def test_to_and_from_string():
+    sky_string = 'irradiance 800'
+    sky = CertainIrradiance.from_string(sky_string)
+
+    sky_from_str = CertainIrradiance.from_string(str(sky))
+    if (sys.version_info >= (3, 7)):
+        assert sky == sky_from_str
+
+    sky_string = 'illuminance 100000'
+    sky = CertainIrradiance.from_string(sky_string)
 
 
 def test_to_file():

--- a/tests/sky_cie_test.py
+++ b/tests/sky_cie_test.py
@@ -1,6 +1,7 @@
 from honeybee_radiance.lightsource.sky import CIE
 from ladybug.location import Location
 import os
+import sys
 
 
 def test_check_defaults():
@@ -75,6 +76,18 @@ def test_to_and_from_dict():
     sky_from_dict = CIE.from_dict(sky.to_dict())
 
     assert sky == sky_from_dict
+
+
+def test_to_and_from_string():
+    sky_string = 'cie 21 Jun 12:00 -lat 41.78 -lon -87.75 -type 2'
+    sky = CIE.from_string(sky_string)
+
+    sky_from_str = CIE.from_string(str(sky))
+    if (sys.version_info >= (3, 7)):
+        assert sky == sky_from_str
+
+    sky_string = 'cie -alt 35 -az 185 -type 0'
+    sky = CIE.from_string(sky_string)
 
 
 def test_to_file():

--- a/tests/sky_climatebased_test.py
+++ b/tests/sky_climatebased_test.py
@@ -3,6 +3,7 @@ from ladybug.location import Location
 from ladybug.wea import Wea
 from ladybug.epw import EPW
 import os
+import sys
 
 
 def test_check_defaults():
@@ -68,11 +69,36 @@ def test_from_epw():
     assert sky.diffuse_horizontal_irradiance == 87
 
 
+def test_from_monthly_average():
+    wea = './tests/assets/wea/denver.wea'
+    wea = Wea.from_file(wea)
+    sky1 = ClimateBased.from_wea_monthly_average(wea, 1, 8)
+
+    epw = './tests/assets/epw/denver.epw'
+    epw = EPW(epw)
+    sky2 = ClimateBased.from_epw_monthly_average(epw, 1, 8)
+    assert sky1.direct_normal_irradiance == sky2.direct_normal_irradiance
+    assert sky1.diffuse_horizontal_irradiance == sky2.diffuse_horizontal_irradiance
+
+
 def test_to_and_from_dict():
     sky = ClimateBased(38.186734, 270.410387, 702, 225)
     sky_from_dict = ClimateBased.from_dict(sky.to_dict())
 
     assert sky == sky_from_dict
+
+
+def test_to_and_from_string():
+    sky_string = 'climate-based 21 Jun 12:00 -lat 41.78 -lon -87.75 -tz -6 ' \
+        ' -dni 800 -dhi 120 -n 0 -g 0.2'
+    sky = ClimateBased.from_string(sky_string)
+    sky_from_str = ClimateBased.from_string(str(sky))
+
+    if (sys.version_info >= (3, 7)):
+        assert sky == sky_from_str
+
+    sky_string = 'climate-based -alt 71.6 -az 185.2 -dni 800 -dhi 120'
+    sky = ClimateBased.from_string(sky_string)
 
 
 def test_to_file():


### PR DESCRIPTION
These can be used within all sky-based recipes so that we don't need a different recipe for each sky type. The new `honeybee-radiance sky from-string` command provides a single function to process any sky string into a sky file for recipes.

@mostaphaRoudsari , if you have any comments on the string representations, please let me know and I am happy to adjust them. I might merge this tomorrow so that [I can begin addressing this other schema issue](https://github.com/ladybug-tools/honeybee-schema/issues/204).

CC: @devngc 