### PR TITLE
fix(modifer): Allow support for capitalized 'type' key in dictionaries

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-click==7.1.2
 coverage==5.5
 coveralls==1.7.0;python_version<'3.0'
 coveralls==2.2.0;python_version>='3.6'

--- a/honeybee_radiance/lib/_loadmodifiers.py
+++ b/honeybee_radiance/lib/_loadmodifiers.py
@@ -15,7 +15,7 @@ _loaded_modifiers = {}
 with open(folders.defaults_file) as json_file:
     default_data = json.load(json_file)['modifiers']
 for mod_dict in default_data:
-    m_class = modifier_class_from_type_string(mod_dict['type'].lower())
+    m_class = modifier_class_from_type_string(mod_dict['type'])
     mod = m_class.from_dict(mod_dict)
     mod.lock()
     _loaded_modifiers[mod_dict['identifier']] = mod
@@ -26,7 +26,7 @@ _default_mods = set(list(_loaded_modifiers.keys()))
 def load_modifier_object(mod_dict):
     """Load a modifier object from a dictionary and add it to the library dict."""
     try:
-        m_class = modifier_class_from_type_string(mod_dict['type'].lower())
+        m_class = modifier_class_from_type_string(mod_dict['type'])
         mod = m_class.from_dict(mod_dict)
         mod.lock()
         assert mod_dict['identifier'] not in _default_mods, 'Cannot overwrite ' \

--- a/honeybee_radiance/modifier/material/antimatter.py
+++ b/honeybee_radiance/modifier/material/antimatter.py
@@ -32,7 +32,7 @@ class Antimatter(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/ashik2.py
+++ b/honeybee_radiance/modifier/material/ashik2.py
@@ -29,7 +29,7 @@ class Ashik2(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/brtdfunc.py
+++ b/honeybee_radiance/modifier/material/brtdfunc.py
@@ -59,7 +59,7 @@ class BRTDfunc(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/bsdf.py
+++ b/honeybee_radiance/modifier/material/bsdf.py
@@ -294,12 +294,7 @@ class BSDF(Material):
             "dependencies": []
             }
         """
-        assert 'type' in primitive_dict, 'Input dictionary is missing "type".'
-        if primitive_dict['type'] != 'BSDF':
-            raise ValueError(
-                'Type must be %s not %s.' % ('BSDF', primitive_dict['type'])
-            )
-
+        cls._dict_type_check(cls.__name__, primitive_dict)
         modifier, dependencies = cls.filter_dict_input(primitive_dict)
         values = primitive_dict['values'][0]
         extra_values = primitive_dict['values'][2]
@@ -353,10 +348,10 @@ class BSDF(Material):
             {
             "modifier": {},  # material modifier (Default: None)
             "type": "BSDF",  # Material type
-            "identifier": string,  # Material identifer
-            "display_name": string  # Material display name
+            "identifier": "",  # Material identifer
+            "display_name": ""  # Material display name
             "up_orientation": [number, number, number],
-            "thickness": number,  # default: 0
+            "thickness": float,  # default: 0
             "function_file": string,  # default: '.'
             "transform": string,  # default: None
             "bsdf_data": string,  # bsdf file data as string
@@ -365,12 +360,8 @@ class BSDF(Material):
             "diffuse_transmittance": [number, number, number]  # optional
             }
         """
-        assert 'type' in data, 'Input dictionary is missing "type".'
-        if data['type'] != 'BSDF':
-            raise ValueError(
-                'Type must be %s not %s.' % ('BSDF', data['type'])
-            )
-        modifier, dependencies = Material.filter_dict_input(data)
+        cls._dict_type_check(cls.__name__, data)
+        modifier, dependencies = cls.filter_dict_input(data)
 
         # check folder and create it if it does not exist
         folder = os.path.join(folders.default_simulation_folder, 'BSDF') \

--- a/honeybee_radiance/modifier/material/dielectric.py
+++ b/honeybee_radiance/modifier/material/dielectric.py
@@ -31,7 +31,7 @@ class Dielectric(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/glass.py
+++ b/honeybee_radiance/modifier/material/glass.py
@@ -266,10 +266,7 @@ class Glass(Material):
             "dependencies": []
             }
         """
-        assert 'type' in primitive_dict, 'Input dictionary is missing "type".'
-        if primitive_dict['type'] != 'glass':
-            raise ValueError('Type must be glass not %s.' % primitive_dict['type'])
-
+        cls._dict_type_check(cls.__name__, primitive_dict)
         modifier, dependencies = cls.filter_dict_input(primitive_dict)
         values = primitive_dict['values'][2]
         refraction_index = values[3] if len(values) == 4 else None
@@ -301,9 +298,9 @@ class Glass(Material):
         .. code-block:: python
 
             {
-            "type": "glass",
+            "type": "Glass",
             "identifier": "",  # Material identifier
-            "display_name": string  # Material display name
+            "display_name": "",  # Material display name
             "r_transmissivity": float,  # Transmissivity for red
             "g_transmissivity": float,  # Transmissivity for green
             "b_transmissivity": float,  # Transmissivity for blue
@@ -312,11 +309,8 @@ class Glass(Material):
             "dependencies": []
             }
         """
-        assert 'type' in data, 'Input dictionary is missing "type".'
-        if data['type'] != 'glass':
-            raise ValueError('Type must be glass not %s.' % data['type'])
-
-        modifier, dependencies = Material.filter_dict_input(data)
+        cls._dict_type_check(cls.__name__, data)
+        modifier, dependencies = cls.filter_dict_input(data)
 
         new_obj = cls(identifier=data["identifier"],
                       r_transmissivity=data["r_transmissivity"],
@@ -332,14 +326,14 @@ class Glass(Material):
     def to_dict(self):
         """Translate this object to a dictionary."""
         base = {
-            "modifier": self.modifier.to_dict(),
-            "type": "glass",
-            "identifier": self.identifier,
-            "r_transmissivity": self.r_transmissivity,
-            "g_transmissivity": self.g_transmissivity,
-            "b_transmissivity": self.b_transmissivity,
-            "refraction_index": self.refraction_index,
-            "dependencies": [dp.to_dict() for dp in self.dependencies]
+            'modifier': self.modifier.to_dict(),
+            'type': 'Glass',
+            'identifier': self.identifier,
+            'r_transmissivity': self.r_transmissivity,
+            'g_transmissivity': self.g_transmissivity,
+            'b_transmissivity': self.b_transmissivity,
+            'refraction_index': self.refraction_index,
+            'dependencies': [dp.to_dict() for dp in self.dependencies]
         }
         if self._display_name is not None:
             base['display_name'] = self.display_name

--- a/honeybee_radiance/modifier/material/glow.py
+++ b/honeybee_radiance/modifier/material/glow.py
@@ -167,13 +167,7 @@ class Glow(Material):
             "dependencies": []
             }
         """
-        assert 'type' in primitive_dict, 'Input dictionary is missing "type".'
-        if primitive_dict['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (
-                    cls.__name__.lower(), primitive_dict['type'])
-            )
-
+        cls._dict_type_check(cls.__name__, primitive_dict)
         modifier, dependencies = cls.filter_dict_input(primitive_dict)
         values = primitive_dict['values'][2]
 
@@ -189,7 +183,7 @@ class Glow(Material):
         if 'display_name' in primitive_dict and primitive_dict['display_name'] is not None:
             cls_.display_name = primitive_dict['display_name']
 
-        # this might look r_emittanceundant but it is NOT. see glass for explanation.
+        # this might look redundant but it is NOT. see glass for explanation.
         cls_.values = primitive_dict['values']
         return cls_
 
@@ -203,9 +197,9 @@ class Glow(Material):
         .. code-block:: python
 
             {
-            "type": "glow",  # primitive type
+            "type": "Glow",  # primitive type
             "identifier": "",  # Material identifier
-            "display_name": string  # Material display name
+            "display_name": "",  # Material display name
             "r_emittance": float,  # A positive value for the Red channel of the glow
             "g_emittance": float,  # A positive value for the Green channel of the glow
             "b_emittance": float,  # A positive value for the Blue channel of the glow
@@ -214,13 +208,8 @@ class Glow(Material):
             "dependencies: []
             }
         """
-        assert 'type' in data, 'Input dictionary is missing "type".'
-        if data['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (cls.__name__.lower(),
-                                             data['type'])
-            )
-        modifier, dependencies = Material.filter_dict_input(data)
+        cls._dict_type_check(cls.__name__, data)
+        modifier, dependencies = cls.filter_dict_input(data)
 
         new_obj = cls(identifier=data['identifier'],
                       r_emittance=data['r_emittance'],
@@ -237,7 +226,7 @@ class Glow(Material):
         """Translate this object to a dictionary."""
         base = {
             'modifier': self.modifier.to_dict(),
-            'type': self.__class__.__name__.lower(),
+            'type': 'Glow',
             'identifier': self.identifier,
             'r_emittance': self.r_emittance,
             'g_emittance': self.g_emittance,

--- a/honeybee_radiance/modifier/material/illum.py
+++ b/honeybee_radiance/modifier/material/illum.py
@@ -29,7 +29,7 @@ class Illum(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/interface.py
+++ b/honeybee_radiance/modifier/material/interface.py
@@ -27,7 +27,7 @@ class Interface(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/light.py
+++ b/honeybee_radiance/modifier/material/light.py
@@ -130,13 +130,7 @@ class Light(Material):
             "dependencies": []
             }
         """
-        assert 'type' in primitive_dict, 'Input dictionary is missing "type".'
-        if primitive_dict['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (
-                    cls.__name__.lower(), primitive_dict['type'])
-            )
-
+        cls._dict_type_check(cls.__name__, primitive_dict)
         modifier, dependencies = cls.filter_dict_input(primitive_dict)
         values = primitive_dict['values'][2]
 
@@ -165,9 +159,9 @@ class Light(Material):
         .. code-block:: python
 
             {
-            "type": "light",  # primitive type
+            "type": "Light",  # primitive type
             "identifier": "",  # Material identifier
-            "display_name": string  # Material display name
+            "display_name": ""  # Material display name
             "r_emittance": float,  # A positive value for the Red channel of the glow
             "g_emittance": float,  # A positive value for the Green channel of the glow
             "b_emittance": float,  # A positive value for the Blue channel of the glow
@@ -175,13 +169,8 @@ class Light(Material):
             "dependencies: []
             }
         """
-        assert 'type' in data, 'Input dictionary is missing "type".'
-        if data['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (cls.__name__.lower(),
-                                             data['type'])
-            )
-        modifier, dependencies = Material.filter_dict_input(data)
+        cls._dict_type_check(cls.__name__, data)
+        modifier, dependencies = cls.filter_dict_input(data)
 
         new_obj = cls(identifier=data["identifier"],
                       r_emittance=data["r_emittance"],
@@ -197,7 +186,7 @@ class Light(Material):
         """Translate this object to a dictionary."""
         base = {
             'modifier': self.modifier.to_dict(),
-            'type': self.__class__.__name__.lower(),
+            'type': 'Light',
             'identifier': self.identifier,
             'r_emittance': self.r_emittance,
             'g_emittance': self.g_emittance,

--- a/honeybee_radiance/modifier/material/materialbase.py
+++ b/honeybee_radiance/modifier/material/materialbase.py
@@ -27,3 +27,10 @@ class Material(Modifier):
     def is_material(self):
         """Get a boolean noting whether this object is a material modifier."""
         return True
+
+    @staticmethod
+    def _dict_type_check(class_name, data):
+        """Check that the 'type' key of a material dict suits the class."""
+        assert 'type' in data, 'Input dictionary is missing "type".'
+        if data['type'].lower() != class_name.lower():
+            raise ValueError('Type must be %s not %s.' % (class_name, data['type']))

--- a/honeybee_radiance/modifier/material/metal2.py
+++ b/honeybee_radiance/modifier/material/metal2.py
@@ -19,7 +19,7 @@ class Metal2(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/metdata.py
+++ b/honeybee_radiance/modifier/material/metdata.py
@@ -19,7 +19,7 @@ class Metdata(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/metfunc.py
+++ b/honeybee_radiance/modifier/material/metfunc.py
@@ -19,7 +19,7 @@ class Metfunc(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/mirror.py
+++ b/honeybee_radiance/modifier/material/mirror.py
@@ -20,7 +20,7 @@ class Mirror(Material):
     flat surfaces such as polygons and rings. The arguments are simply the
     RGB reflectance values, which should be between 0 and 1.
 
-    An optional string argument may be used like the illum type to specify a different
+    An optional string argument may be used (like the illum type) to specify a different
     material to be used for shading non-source rays. If this alternate material is given
     as "void", then the mirror surface will be invisible. Using "void" is only
     appropriate if the surface hides other (more detailed) geometry with the same
@@ -37,7 +37,7 @@ class Mirror(Material):
         b_reflectance: Reflectance for blue. The value should be between 0 and 1
             (Default: 1).
         modifier: Material modifier (Default: None).
-        alternate_material: An optional material may be used like the illum type to
+        alternate_material: An optional material (like the illum type) used to
             specify a different material to be used for shading non-source rays.
             If None, this will keep the alternat_material as mirror. If this alternate
             material is given as "void", then the mirror surface will be invisible.
@@ -213,13 +213,7 @@ class Mirror(Material):
             "dependencies": []
             }
         """
-        assert 'type' in primitive_dict, 'Input dictionary is missing "type".'
-        if primitive_dict['type'] != cls.__name__.lower():
-            raise ValueError('Type must be %s not %s.' % (
-                    cls.__name__.lower(), primitive_dict['type']
-                )
-            )
-
+        cls._dict_type_check(cls.__name__, primitive_dict)
         modifier, dependencies = cls.filter_dict_input(primitive_dict)
         if len(primitive_dict['values'][0]) == 1:
             # find name
@@ -274,9 +268,9 @@ class Mirror(Material):
         .. code-block:: python
 
             {
-            "type": "mirror",  # Material type
+            "type": "Mirror",  # Material type
             "identifier": "",  # Material identifier
-            "display_name": string  # Material display name
+            "display_name": "",  # Material display name
             "r_reflectance": float,  # Reflectance for red
             "g_reflectance": float,  # Reflectance for green
             "b_reflectance": float,  # Reflectance for blue
@@ -285,12 +279,8 @@ class Mirror(Material):
             "dependencies": []
             }
         """
-        assert 'type' in data, 'Input dictionary is missing "type".'
-        if data['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (cls.__name__.lower(), data['type'])
-            )
-        modifier, dependencies = Material.filter_dict_input(data)
+        cls._dict_type_check(cls.__name__, data)
+        modifier, dependencies = cls.filter_dict_input(data)
         if 'alternate_material' in data and data['alternate_material']:
             # alternate material
             if data['alternate_material'] == 'void':
@@ -320,7 +310,7 @@ class Mirror(Material):
         """Translate this object to a dictionary."""
         base = {
             'modifier': self.modifier.to_dict(),
-            'type': self.__class__.__name__.lower(),
+            'type': 'Mirror',
             'identifier': self.identifier,
             'r_reflectance': self.r_reflectance,
             'g_reflectance': self.g_reflectance,

--- a/honeybee_radiance/modifier/material/mist.py
+++ b/honeybee_radiance/modifier/material/mist.py
@@ -64,7 +64,7 @@ class Mist(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/plasdata.py
+++ b/honeybee_radiance/modifier/material/plasdata.py
@@ -36,7 +36,7 @@ class Plasdata(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/plasfunc.py
+++ b/honeybee_radiance/modifier/material/plasfunc.py
@@ -37,7 +37,7 @@ class Plasfunc(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/plastic.py
+++ b/honeybee_radiance/modifier/material/plastic.py
@@ -201,19 +201,14 @@ class Plastic(Material):
 
             {
             "modifier": {},  # primitive modifier (Default: None)
-            "type": string,  # primitive type
+            "type": "",  # primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
             "values": [],  # values
             "dependencies": []
             }
         """
-        assert 'type' in primitive_dict, 'Input dictionary is missing "type".'
-        if primitive_dict['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (cls.__name__.lower(), primitive_dict['type'])
-            )
-
+        cls._dict_type_check(cls.__name__, primitive_dict)
         modifier, dependencies = cls.filter_dict_input(primitive_dict)
         values = primitive_dict['values'][2]
         cls_ = cls(
@@ -244,9 +239,9 @@ class Plastic(Material):
         .. code-block:: python
 
             {
-            "type": string,  # Material type
+            "type": "",  # Material type
             "identifier": "",  # Material identifier
-            "display_name": string  # Material display name
+            "display_name": "",  # Material display name
             "r_reflectance": float,  # Reflectance for red
             "g_reflectance": float,  # Reflectance for green
             "b_reflectance": float,  # Reflectance for blue
@@ -256,12 +251,8 @@ class Plastic(Material):
             "dependencies": []
             }
         """
-        assert 'type' in data, 'Input dictionary is missing "type".'
-        if data['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (cls.__name__.lower(), data['type'])
-            )
-        modifier, dependencies = Material.filter_dict_input(data)
+        cls._dict_type_check(cls.__name__, data)
+        modifier, dependencies = cls.filter_dict_input(data)
 
         new_obj = cls(identifier=data["identifier"],
                       r_reflectance=data["r_reflectance"],
@@ -279,7 +270,7 @@ class Plastic(Material):
         """Translate this object to a dictionary."""
         base = {
             'modifier': self.modifier.to_dict(),
-            'type': self.__class__.__name__.lower(),
+            'type': self.__class__.__name__,
             'identifier': self.identifier,
             'r_reflectance': self.r_reflectance,
             'g_reflectance': self.g_reflectance,

--- a/honeybee_radiance/modifier/material/plastic2.py
+++ b/honeybee_radiance/modifier/material/plastic2.py
@@ -36,7 +36,7 @@ class Plastic2(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/prism1.py
+++ b/honeybee_radiance/modifier/material/prism1.py
@@ -35,7 +35,7 @@ class Prism1(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/prism2.py
+++ b/honeybee_radiance/modifier/material/prism2.py
@@ -26,7 +26,7 @@ class Prism2(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/spotlight.py
+++ b/honeybee_radiance/modifier/material/spotlight.py
@@ -28,7 +28,7 @@ class Spotlight(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/trans.py
+++ b/honeybee_radiance/modifier/material/trans.py
@@ -263,8 +263,7 @@ class Trans(Material):
     @classmethod
     def from_single_reflectance(
         cls, identifier, rgb_reflectance=0.0, specularity=0.0, roughness=0.0,
-        transmitted_diff=0.0, transmitted_spec=0.0, modifier=None,
-            dependencies=None):
+        transmitted_diff=0.0, transmitted_spec=0.0, modifier=None, dependencies=None):
         """Create trans material with single reflectance value.
 
         Args:
@@ -288,11 +287,11 @@ class Trans(Material):
                 argument is only useful for defining advanced primitives where the
                 primitive is defined based on other primitives. (Default: [])
         """
-        return cls(identifier, r_reflectance=rgb_reflectance, g_reflectance=rgb_reflectance,
-                   b_reflectance=rgb_reflectance, specularity=specularity,
-                   roughness=roughness, transmitted_diff=transmitted_diff,
-                   transmitted_spec=transmitted_spec, modifier=modifier,
-                   dependencies=dependencies)
+        return cls(
+            identifier, r_reflectance=rgb_reflectance, g_reflectance=rgb_reflectance,
+            b_reflectance=rgb_reflectance, specularity=specularity, roughness=roughness,
+            transmitted_diff=transmitted_diff, transmitted_spec=transmitted_spec,
+            modifier=modifier, dependencies=dependencies)
 
     @classmethod
     def from_primitive_dict(cls, primitive_dict):
@@ -312,15 +311,8 @@ class Trans(Material):
             "dependencies": []
             }
         """
-        assert 'type' in primitive_dict, 'Input dictionary is missing "type".'
-        if primitive_dict['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (
-                    cls.__name__.lower(), primitive_dict['type'])
-            )
-
+        cls._dict_type_check(cls.__name__, primitive_dict)
         modifier, dependencies = cls.filter_dict_input(primitive_dict)
-
         values = primitive_dict['values'][2]
 
         cls_ = cls(
@@ -351,9 +343,9 @@ class Trans(Material):
         .. code-block:: python
 
             {
-            "type": "trans",  # Material type
-            "identifier": "", // Material identifier
-            "display_name": string  # Material display name
+            "type": "Trans",  # Material type
+            "identifier": "", # Material identifier
+            "display_name": "",  # Material display name
             "r_reflectance": float,  # Reflectance for red
             "g_reflectance": float,  # Reflectance for green
             "b_reflectance": float,  # Reflectance for blue
@@ -365,13 +357,8 @@ class Trans(Material):
             "modifier": {},  # Material modifier (Default: None)
             }
         """
-        assert 'type' in data, 'Input dictionary is missing "type".'
-        if data['type'] != cls.__name__.lower():
-            raise ValueError(
-                'Type must be %s not %s.' % (cls.__name__.lower(),
-                                             data['type'])
-            )
-        modifier, dependencies = Material.filter_dict_input(data)
+        cls._dict_type_check(cls.__name__, data)
+        modifier, dependencies = cls.filter_dict_input(data)
 
         new_obj = cls(
             identifier=data["identifier"],
@@ -392,7 +379,7 @@ class Trans(Material):
         """Translate this object to a dictionary."""
         base = {
             'modifier': self.modifier.to_dict(),
-            'type': self.__class__.__name__.lower(),
+            'type': 'Trans',
             'identifier': self.identifier,
             'r_reflectance': self.r_reflectance,
             'g_reflectance': self.g_reflectance,

--- a/honeybee_radiance/modifier/material/trans2.py
+++ b/honeybee_radiance/modifier/material/trans2.py
@@ -27,7 +27,7 @@ class Trans2(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/transdata.py
+++ b/honeybee_radiance/modifier/material/transdata.py
@@ -28,7 +28,7 @@ class Transdata(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/material/transfunc.py
+++ b/honeybee_radiance/modifier/material/transfunc.py
@@ -31,7 +31,7 @@ class Transfunc(Material):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/mixture/mixdata.py
+++ b/honeybee_radiance/modifier/mixture/mixdata.py
@@ -27,7 +27,7 @@ class Mixdata(Mixture):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/mixture/mixfunc.py
+++ b/honeybee_radiance/modifier/mixture/mixfunc.py
@@ -32,7 +32,7 @@ class Mixfunc(Mixture):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/mixture/mixpict.py
+++ b/honeybee_radiance/modifier/mixture/mixpict.py
@@ -30,7 +30,7 @@ class Mixpict(Mixture):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/mixture/mixtext.py
+++ b/honeybee_radiance/modifier/mixture/mixtext.py
@@ -44,7 +44,7 @@ class Mixtext(Mixture):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/pattern/brightdata.py
+++ b/honeybee_radiance/modifier/pattern/brightdata.py
@@ -27,7 +27,7 @@ class Brightdata(Pattern):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/pattern/brightfunc.py
+++ b/honeybee_radiance/modifier/pattern/brightfunc.py
@@ -25,7 +25,7 @@ class Brightfunc(Pattern):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/pattern/brighttext.py
+++ b/honeybee_radiance/modifier/pattern/brighttext.py
@@ -59,7 +59,7 @@ class Brighttext(Pattern):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/pattern/colordata.py
+++ b/honeybee_radiance/modifier/pattern/colordata.py
@@ -34,7 +34,7 @@ class Colordata(Pattern):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/pattern/colorfunc.py
+++ b/honeybee_radiance/modifier/pattern/colorfunc.py
@@ -25,7 +25,7 @@ class Colorfunc(Pattern):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/pattern/colorpict.py
+++ b/honeybee_radiance/modifier/pattern/colorpict.py
@@ -31,7 +31,7 @@ class Colorpict(Pattern):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/modifier/pattern/colortext.py
+++ b/honeybee_radiance/modifier/pattern/colortext.py
@@ -51,7 +51,7 @@ class Colortext(Pattern):
         modifier: Modifier. It can be primitive, mixture, texture or pattern.
             (Default: None).
         values: An array 3 arrays for primitive data. Each of the 3 sub-arrays
-            refer to a line number in the radiance primitve definitions and the
+            refer to a line number in the radiance primitive definitions and the
             values in each array correspond to values occurring within each line.
         is_opaque: A boolean to indicate whether this primitive is opaque.
         dependencies: A list of primitives that this primitive depends on. This

--- a/honeybee_radiance/mutil.py
+++ b/honeybee_radiance/mutil.py
@@ -17,26 +17,27 @@ def modifier_class_from_type_string(type_string):
 
     Args:
         type_string: Text for the name of a modifier module/class. This should
-            usually be lowercase and should be the same as the 'type' key used
-            in the dictionary representation of the modifier.
+            be the same as the 'type' key used in the dictionary representation
+            of the modifier.
     """
     _mapper = {'bsdf': 'BSDF', 'BSDF': 'BSDF',
                'brtdfunc': 'BRTDfunc', 'BRTDfunc': 'BRTDfunc'}
-    if type_string == 'void':
+    lower_str = type_string.lower()
+    if lower_str == 'void':
         return Void
-    elif type_string in Primitive.MATERIALTYPES:
+    elif lower_str in Primitive.MATERIALTYPES:
         target_module = material
-    elif type_string in Primitive.MIXTURETYPES:
+    elif lower_str in Primitive.MIXTURETYPES:
         target_module = mixture
-    elif type_string in Primitive.PATTERNTYPES:
+    elif lower_str in Primitive.PATTERNTYPES:
         target_module = pattern
-    elif type_string in Primitive.TEXTURETYPES:
+    elif lower_str in Primitive.TEXTURETYPES:
         target_module = texture
     else:
         raise ValueError('%s is not a Radiance modifier.' % type_string)
 
-    class_name = type_string.capitalize() if type_string not in _mapper \
-        else _mapper[type_string]
+    class_name = lower_str.capitalize() if lower_str not in _mapper \
+        else _mapper[lower_str]
 
     return getattr(target_module, class_name)
 

--- a/honeybee_radiance/primitive.py
+++ b/honeybee_radiance/primitive.py
@@ -206,7 +206,7 @@ class Primitive(object):
 
             {
             "modifier": {},  # primitive modifier (Default: None)
-            "type": "custom",  # primitive type
+            "type": "",  # lowercase string for the primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
             "values": [],  # values
@@ -241,7 +241,7 @@ class Primitive(object):
 
             {
             "modifier": {},  # primitive modifier (Default: None)
-            "type": "custom",  # primitive type
+            "type": "",  # lowercase string for the primitive type
             "identifier": "",  # primitive identifier
             "display_name": "",  # primitive display name
             "values": [],  # values
@@ -252,7 +252,10 @@ class Primitive(object):
 
     @property
     def type(self):
-        """Get or set a string for the primitive type."""
+        """Get or set a string for the primitive type.
+
+        This should always be lower case in order to match the radiance convention.
+        """
         return self._type
 
     @type.setter
@@ -304,9 +307,10 @@ class Primitive(object):
 
     @property
     def values(self):
-        """Get or set the values of the current primitive as a dictionary.
+        """Get or set the values of the current primitive as a list of three lists.
 
-        The keys of this dictionary should be integers between 0 and 2.
+        Each sub-list represents a line of the primitive's radiance representation
+        and contain the properties that define the primitive.
 
         Usage:
 
@@ -314,11 +318,10 @@ class Primitive(object):
 
             # This will erase all values except the first line, which has 9 custom items
             primitive.values = [
-                [0.5, 0.5, 0.5, "/usr/oakfloor.pic", ".", "frac(U)", "frac(V)",
-                 "-s", 1.1667],
+                [0.5, 0.5, 0.5, "/usr/oak.pic", ".", "frac(U)", "frac(V)", "-s", 1.1667],
                 [],
                 []
-                ]
+            ]
         """
         self._update_values()
         return self._values

--- a/tests/material_glass_test.py
+++ b/tests/material_glass_test.py
@@ -82,7 +82,7 @@ def test_from_string():
 def test_from_dict_w_modifier():
     glass_mod = {
         "identifier": "test_glass_mod",
-        "type": "glass",
+        "type": "Glass",
         "r_transmissivity": 0.4,
         "g_transmissivity": 0.5,
         "b_transmissivity": 0.6,
@@ -93,7 +93,7 @@ def test_from_dict_w_modifier():
 
     glass_dict = {
         "identifier": "test_glass",
-        "type": "glass",
+        "type": "Glass",
         "r_transmissivity": 0.1,
         "g_transmissivity": 0.2,
         "b_transmissivity": 0.3,

--- a/tests/material_glow_test.py
+++ b/tests/material_glow_test.py
@@ -71,7 +71,7 @@ def test_to_dict():
     assert mdict['b_emittance'] == 100000
     assert mdict['g_emittance'] == 100000
     assert mdict['max_radius'] == 0
-    assert mdict['type'] == 'glow'
+    assert mdict['type'] == 'Glow'
     assert 'modifier' not in mdict or mdict['modifier'] is None
 
 

--- a/tests/material_light_test.py
+++ b/tests/material_light_test.py
@@ -53,7 +53,7 @@ def test_from_string():
 def test_from_dict_w_modifier():
     glass_mod = {
         "identifier": "test_glass_mod",
-        "type": "glass",
+        "type": "Glass",
         "r_transmissivity": 0.4,
         "g_transmissivity": 0.5,
         "b_transmissivity": 0.6,
@@ -64,7 +64,7 @@ def test_from_dict_w_modifier():
 
     light_dict = {
         "identifier": "test_light",
-        "type": "light",
+        "type": "Light",
         "r_emittance": 0.1,
         "g_emittance": 0.2,
         "b_emittance": 0.3,
@@ -92,6 +92,6 @@ def test_to_dict():
     assert mdict['r_emittance'] == 100000
     assert mdict['b_emittance'] == 100000
     assert mdict['g_emittance'] == 100000
-    assert mdict['type'] == 'light'
+    assert mdict['type'] == 'Light'
     assert 'modifier' not in mdict or mdict['modifier'] is None
 

--- a/tests/material_metal_test.py
+++ b/tests/material_metal_test.py
@@ -86,7 +86,7 @@ def test_from_string():
 def test_from_dict_w_modifier():
     glass_mod = {
         "identifier": "test_glass_mod",
-        "type": "glass",
+        "type": "Glass",
         "r_transmissivity": 0.4,
         "g_transmissivity": 0.5,
         "b_transmissivity": 0.6,
@@ -97,7 +97,7 @@ def test_from_dict_w_modifier():
 
     plastic_dict = {
         "identifier": "test_metal",
-        "type": "metal",
+        "type": "Metal",
         "r_reflectance": 0.1,
         "g_reflectance": 0.2,
         "b_reflectance": 0.3,

--- a/tests/material_plastic_test.py
+++ b/tests/material_plastic_test.py
@@ -90,7 +90,7 @@ def test_from_string():
 def test_from_dict_w_modifier():
     glass_mod = {
         "identifier": "test_glass_mod",
-        "type": "glass",
+        "type": "Glass",
         "r_transmissivity": 0.4,
         "g_transmissivity": 0.5,
         "b_transmissivity": 0.6,
@@ -101,7 +101,7 @@ def test_from_dict_w_modifier():
 
     plastic_dict = {
         "identifier": "test_plastic",
-        "type": "plastic",
+        "type": "Plastic",
         "r_reflectance": 0.1,
         "g_reflectance": 0.2,
         "b_reflectance": 0.3,


### PR DESCRIPTION
This is a precursor to addressing this issue:
https://github.com/ladybug-tools/honeybee-schema/issues/204

I am also taking the opportunity to fix a lot of incorrect docstrings. And get rid of the unnecessary click in dev-requirements (we already get it with ladybug-core and the requirements)