### PR TITLE
feat(raytrace): Add command for PIT ray-tracing w/ post-processing

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,11 @@ update_configs:
   - package_manager: "python"
     directory: "/"
     update_schedule: "live"
+    ignored_updates:
+      - match:
+          dependency_name: "Sphinx"
+      - match:
+          dependency_name: "sphinx-click"
     automerged_updates:
       - match:
           dependency_type: "all"

--- a/tests/cli/raytrace_test.py
+++ b/tests/cli/raytrace_test.py
@@ -1,0 +1,38 @@
+"""Test cli translate module."""
+import os
+import json
+
+from click.testing import CliRunner
+
+from ladybug.futil import nukedir
+
+from honeybee_radiance.cli.raytrace import rtrace_with_df_post_process, \
+    rtrace_with_pit_post_process
+
+
+def test_rtrace_with_df_post_process():
+    runner = CliRunner()
+    input_oct = './tests/assets/octree/scene.oct'
+    input_grid = './tests/assets/grid/sensor_grid_merge_0000.pts'
+    cmd_args = [input_oct, input_grid, '--rad-params', '"-ab 10 -ad 1433 -I"',
+                '--rad-params-locked', '"-I"', '--output', 'grid.res',
+                '--sky-illum', '1000', '--dry-run']
+
+    result = runner.invoke(rtrace_with_df_post_process, cmd_args)
+    assert result.exit_code == 0
+    cmd_output = result.output
+    assert '17900/1000' in cmd_output
+
+
+def test_rtrace_with_pit_post_process():
+    runner = CliRunner()
+    input_oct = './tests/assets/octree/scene.oct'
+    input_grid = './tests/assets/grid/sensor_grid_merge_0000.pts'
+    cmd_args = [input_oct, input_grid, '--rad-params', '-ab 2 -aa 0.1 -ad 2048 -ar 64',
+                '--rad-params-locked', '-h',
+                '--output', 'grid.res', '--metric', 'illuminance', '--dry-run']
+
+    result = runner.invoke(rtrace_with_pit_post_process, cmd_args)
+    assert result.exit_code == 0
+    cmd_output = result.output
+    assert '*179' in cmd_output


### PR DESCRIPTION
I am also taking the opportunity to stop dependabot from updating Sphinx as it keeps breaking things.

I am pretty sure that I did this correctly since the daylight-factor command provided a pretty clear example. And I used honeybee-plus library to figure out what the specific type of rcalc should be for the different metrics (eg. illuminace, vs. irradiance vs. luminance). The output of the test that I added seems to be correct.

I hope that you don't mid that I just merge this, @mostaphaRoudsari , so that I can continue making the recipe.