### PR TITLE
fix(bsdf): Always include bsdf in Model-Rad-Folder for now

### DIFF
--- a/honeybee_radiance/modifier/material/bsdf.py
+++ b/honeybee_radiance/modifier/material/bsdf.py
@@ -10,15 +10,6 @@ from honeybee.config import folders
 import honeybee.typing as typing
 import ladybug_geometry.geometry3d.pointvector as pv
 
-import gzip
-try:
-    from io import BytesIO as StringIO
-except ImportError:
-    try:  # python 2
-        from cStringIO import StringIO
-    except ImportError:  # IronPython
-        from StringIO import StringIO
-
 
 class BSDF(Material):
     """Radiance BSDF material.
@@ -310,7 +301,8 @@ class BSDF(Material):
             angle_basis=None,
             dependencies=dependencies
         )
-        if 'display_name' in primitive_dict and primitive_dict['display_name'] is not None:
+        if 'display_name' in primitive_dict and \
+                primitive_dict['display_name'] is not None:
             cls_.display_name = primitive_dict['display_name']
 
         # this might look redundant but it is NOT. see glass for explanation.

--- a/honeybee_radiance/writer.py
+++ b/honeybee_radiance/writer.py
@@ -338,8 +338,8 @@ def model_to_rad_folder(
     # copy all bsdfs into the bsdf folder
     bsdf_folder = model_folder.bsdf_folder(full=True)
     bsdf_mods = model.properties.radiance.bsdf_modifiers
+    preparedir(bsdf_folder)
     if len(bsdf_mods) != 0:
-        preparedir(bsdf_folder)
         for bdf_mod in bsdf_mods:
             bsdf_name = os.path.split(bdf_mod.bsdf_file)[-1]
             new_bsdf_path = os.path.join(bsdf_folder, bsdf_name)


### PR DESCRIPTION
We will need this as a workaround for now while optional artifacts are not fully supported in queenbee.

I'm also removing unused dependencies from the bsdf module.