### PR TITLE
feat(dynamic): Unique glow modifier per aperture group

### DIFF
--- a/honeybee_radiance/dynamic/group.py
+++ b/honeybee_radiance/dynamic/group.py
@@ -381,11 +381,14 @@ class DynamicSubFaceGroup(DynamicShadeGroup):
                 in a minimal format (with spaces instead of line breaks). Default: False.
         """
         states = self.states_by_index(state_index)
+        # create unique glow modifier for aperture group
+        unique_glow = white_glow.duplicate()
+        unique_glow.identifier = 'white_glow_{}'.format(self.identifier)
         # get rad strings for the white_glow modifier and geometry.
         state_str = ['# VMTX representation for "{}"'.format(self.identifier),
-                     white_glow.to_radiance(minimal)]
+                     unique_glow.to_radiance(minimal)]
         for state in states:
-            state_str.append(state.vmtx_to_radiance(minimal))
+            state_str.append(state.vmtx_to_radiance(unique_glow, minimal))
         return '\n\n'.join(state_str)
 
     def dmtx_to_radiance(self, state_index, minimal=False):

--- a/honeybee_radiance/dynamic/state.py
+++ b/honeybee_radiance/dynamic/state.py
@@ -579,8 +579,7 @@ class RadianceSubFaceState(_RadianceState):
         The resulting string lacks modifiers and only includes the vmtx_geometry.
 
         Args:
-            modifier: A modifier (only identifier) assigned to the vmtx_geometry.
-                Default: white_glow.
+            modifier: A modifier object assigned to the vmtx_geometry. Default: white_glow.
             minimal: Boolean to note whether the radiance string should be written
                 in a minimal format (with spaces instead of line breaks). Default: False.
         """

--- a/honeybee_radiance/dynamic/state.py
+++ b/honeybee_radiance/dynamic/state.py
@@ -573,18 +573,20 @@ class RadianceSubFaceState(_RadianceState):
         if self._dmtx_geometry:
             self._dmtx_geometry = self._dmtx_geometry.scale(factor, origin)
 
-    def vmtx_to_radiance(self, minimal=False):
+    def vmtx_to_radiance(self, modifier=white_glow, minimal=False):
         """Generate a RAD string representation of this state's vmtx.
 
         The resulting string lacks modifiers and only includes the vmtx_geometry.
 
         Args:
+            modifier: A modifier (only identifier) assigned to the vmtx_geometry.
+                Default: white_glow.
             minimal: Boolean to note whether the radiance string should be written
                 in a minimal format (with spaces instead of line breaks). Default: False.
         """
         assert self.has_parent, 'State must have a parent to use vmtx_to_radiance.'
         vmtx_poly = Polygon(self.parent.identifier,
-                            self.vmtx_geometry.vertices, white_glow)
+                            self.vmtx_geometry.vertices, modifier)
         return vmtx_poly.to_radiance(minimal, False, False)
 
     def dmtx_to_radiance(self, minimal=False):


### PR DESCRIPTION
A unique modifier is needed for each aperture group when calculating multiple view matrices is one go. This replaces the default "white_glow" with a glow modifier with a unique name for the given aperture group.