### PR TITLE
feat(cli): Add command to get standards folder as ModelEnergyProperties

### DIFF
--- a/honeybee_radiance/cli/lib.py
+++ b/honeybee_radiance/cli/lib.py
@@ -1,12 +1,17 @@
 """honeybee radiance standards library commands."""
 import click
 import sys
+import os
 import logging
 import json
 
+from honeybee_radiance.config import folders
 from honeybee_radiance.lib.modifiers import modifier_by_identifier, MODIFIERS
 from honeybee_radiance.lib.modifiersets import modifier_set_by_identifier, \
     MODIFIER_SETS
+
+from honeybee_radiance.lib._loadmodifiers import load_modifiers_from_folder
+from honeybee_radiance.lib._loadmodifiersets import load_modifiersets_from_folder
 
 _logger = logging.getLogger(__name__)
 
@@ -141,6 +146,59 @@ def modifier_sets_by_id(modifier_set_ids, none_defaults, abridged, output_file):
     except Exception as e:
         _logger.exception(
             'Retrieval from modifier set library failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@lib.command('to-model-properties')
+@click.option(
+    '--standards-folder', '-s', default=None, help='A directory containing subfolders '
+    'of resource objects (modifiers, modifiersets) to be loaded as '
+    'ModelRadianceProperties. Note that this standards folder MUST contain these '
+    'subfolders. Each sub-folder can contain JSON files of objects following '
+    'honeybee schema or RAD/MAT files (if appropriate). If None, the honeybee '
+    'default standards folder will be used.',type=click.Path(
+        exists=True, file_okay=False, dir_okay=True, resolve_path=True)
+)
+@click.option(
+    '--output-file', '-f', help='Optional JSON file to output the JSON string of '
+    'the translation. By default this will be printed out to stdout',
+    type=click.File('w'), default='-', show_default=True
+)
+def to_model_properties(standards_folder, output_file):
+    """Translate a lib folder of standards to a JSON of honeybee ModelRadianceProperties.
+
+    This is useful in workflows where one must import everything within a user's
+    standards folder and requires all objects to be in a consistent format.
+    All objects in the resulting ModelRadianceProperties will be abridged and
+    duplicated objects in the folder will be removed such that there
+    is only one of each object.
+    """
+    try:
+        # set the folder to the default standards_folder if unspecified
+        folder = standards_folder if standards_folder is not None else \
+            folders.standards_data_folder
+
+        # load modifiers from the standards folder
+        mod_folder = os.path.join(folder, 'modifiers')
+        all_m = load_modifiers_from_folder(mod_folder)
+
+        # load modifier sets from the standards folder
+        mod_set_folder = os.path.join(folder, 'modifiersets')
+        all_mod_sets, misc_m = load_modifiersets_from_folder(mod_set_folder, all_m)
+        all_mods = set(list(all_m.values()) + misc_m)        
+
+        # add all object dictionaries into one object
+        base = {'type': 'ModelRadianceProperties'}
+        base['modifiers'] = [m.to_dict() for m in all_mods]
+        base['modifier_sets'] = \
+            [ms.to_dict(abridged=True) for ms in all_mod_sets.values()]
+
+        # write out the JSON file
+        output_file.write(json.dumps(base))
+    except Exception as e:
+        _logger.exception('Loading standards to properties failed.\n{}'.format(e))
         sys.exit(1)
     else:
         sys.exit(0)

--- a/honeybee_radiance/cli/view.py
+++ b/honeybee_radiance/cli/view.py
@@ -43,6 +43,14 @@ def view():
     default=True, show_default=True
 )
 @click.option(
+    '--resolution', '-r', default=None, type=int, show_default=True,
+    help='An optional integer for the maximum dimension of the image in pixels. '
+    'Specifying a value here will automatically lower the input --count to ensure '
+    'the resulting images can be combined to meet this dimension. If unspecified, '
+    'the --count will always be respected and the resulting images might not be '
+    'combine-able to meet a specific target dimension.'
+)
+@click.option(
     '--octree', '-oct', help='Octree file for the overture calculation. This must be '
     'specified when the overture is not skipped.', default=None, show_default=True,
     type=click.Path(file_okay=True, dir_okay=False, resolve_path=True)
@@ -60,7 +68,8 @@ def view():
     ' created views. By default the list will be printed out to stdout',
     type=click.File('w'), default='-'
 )
-def split_view(view, count, skip_overture, octree, rad_params, folder, log_file):
+def split_view(view, count, resolution, skip_overture, octree, rad_params,
+               folder, log_file):
     """Split a radiance view file into smaller views based on count.
 
     \b
@@ -72,6 +81,11 @@ def split_view(view, count, skip_overture, octree, rad_params, folder, log_file)
             the first three files will have 5 sensors and the last file will have 6.
     """
     try:
+        # correct the count to meet the target resolution
+        if resolution is not None and resolution % count != 0:
+            while resolution % count != 0:
+                count =  count - 1
+
         # split the view into smaller views
         view_obj = View.from_file(view)
         views = view_obj.grid(y_div_count=count)

--- a/honeybee_radiance/lib/_loadmodifiers.py
+++ b/honeybee_radiance/lib/_loadmodifiers.py
@@ -23,7 +23,7 @@ _default_mods = set(list(_loaded_modifiers.keys()))
 
 
 # then load modifiers from the user-supplied files
-def load_modifier_object(mod_dict):
+def load_modifier_object(mod_dict, user_modifiers):
     """Load a modifier object from a dictionary and add it to the library dict."""
     try:
         m_class = modifier_class_from_type_string(mod_dict['type'])
@@ -31,29 +31,41 @@ def load_modifier_object(mod_dict):
         mod.lock()
         assert mod_dict['identifier'] not in _default_mods, 'Cannot overwrite ' \
             'default modifier "{}".'.format(mod_dict['identifier'])
-        _loaded_modifiers[mod_dict['identifier']] = mod
+        user_modifiers[mod_dict['identifier']] = mod
     except (TypeError, KeyError):
         pass  # not a Honeybee Modifier JSON; possibly a comment
 
 
-for f in os.listdir(folders.modifier_lib):
-    f_path = os.path.join(folders.modifier_lib, f)
-    if os.path.isfile(f_path):
-        if f_path.endswith('.mat') or f_path.endswith('.rad'):
-            with open(f_path) as f:
-                try:
-                    rad_dicts = string_to_dicts(f.read())
-                    for mod_dict in rad_dicts:
-                        mod = dict_to_modifier(mod_dict)
-                        mod.lock()
-                        _loaded_modifiers[mod.identifier] = mod
-                except ValueError:
-                    pass  # empty rad file with no modifiers in them
-        if f_path.endswith('.json'):
-            with open(f_path) as json_file:
-                data = json.load(json_file)
-            if 'type' in data:  # single object
-                load_modifier_object(data)
-            else:  # a collection of several objects
-                for mod_identifier in data:
-                    load_modifier_object(data[mod_identifier])
+def load_modifiers_from_folder(modifier_lib_folder):
+    """Load all of the material layer objects from a modifier standards folder.
+    
+    Args:
+        modifier_lib_folder: Path to a modifiers sub-folder within a
+            honeybee standards folder.
+    """
+    user_modifiers = {}
+    for f in os.listdir(modifier_lib_folder):
+        f_path = os.path.join(modifier_lib_folder, f)
+        if os.path.isfile(f_path):
+            if f_path.endswith('.mat') or f_path.endswith('.rad'):
+                with open(f_path) as f:
+                    try:
+                        rad_dicts = string_to_dicts(f.read())
+                        for mod_dict in rad_dicts:
+                            mod = dict_to_modifier(mod_dict)
+                            mod.lock()
+                            user_modifiers[mod.identifier] = mod
+                    except ValueError:
+                        pass  # empty rad file with no modifiers in them
+            if f_path.endswith('.json'):
+                with open(f_path) as json_file:
+                    data = json.load(json_file)
+                if 'type' in data:  # single object
+                    load_modifier_object(data, user_modifiers)
+                else:  # a collection of several objects
+                    for mod_identifier in data:
+                        load_modifier_object(data[mod_identifier], user_modifiers)
+    return user_modifiers
+
+user_mods = load_modifiers_from_folder(folders.modifier_lib)
+_loaded_modifiers.update(user_mods)

--- a/honeybee_radiance/lib/_loadmodifiersets.py
+++ b/honeybee_radiance/lib/_loadmodifiersets.py
@@ -23,28 +23,46 @@ _default_mod_sets = set(list(_loaded_modifier_sets.keys()))
 
 
 # then load modifier sets from the user-supplied files
-def load_modifier_set_object(mset_dict):
+def load_modifier_set_object(mset_dict, load_mods, mod_sets, misc_mods):
     """Load a modifier set object from a dictionary and add it to the lib dict."""
     try:
         if mset_dict['type'] == 'ModifierSetAbridged':
-            modifierset = ModifierSet.from_dict_abridged(mset_dict, _loaded_modifiers)
+            modifierset = ModifierSet.from_dict_abridged(mset_dict, load_mods)
         else:
             modifierset = ModifierSet.from_dict(mset_dict)
+            misc_mods.extend(modifierset.modified_modifiers)
         modifierset.lock()
         assert mset_dict['identifier'] not in _default_mod_sets, 'Cannot overwrite ' \
             'default modifier set "{}".'.format(mset_dict['identifier'])
-        _loaded_modifier_sets[mset_dict['identifier']] = modifierset
+        mod_sets[mset_dict['identifier']] = modifierset
     except (TypeError, KeyError, ValueError):
         pass  # not a Honeybee ModifierSet JSON; possibly a comment
 
 
-for f in os.listdir(folders.modifierset_lib):
-    f_path = os.path.join(folders.modifierset_lib, f)
-    if os.path.isfile(f_path) and f_path.endswith('.json'):
-        with open(f_path, 'r') as json_file:
-            mod_set_dict = json.load(json_file)
-        if 'type' in mod_set_dict:  # single object
-            load_modifier_set_object(mod_set_dict)
-        else:  # a collection of several objects
-            for mod_set_id in mod_set_dict:
-                load_modifier_set_object(mod_set_dict[mod_set_id])
+def load_modifiersets_from_folder(modifierset_lib_folder, loaded_modifiers):
+    """Load all of the ModifierSet objects from a modifierset standards folder.
+    
+    Args:
+        modifierset_lib_folder: Path to a modifiersets sub-folder within a
+            honeybee standards folder.
+        loaded_modifiers: A dictionary of modifiers that have already
+            been loaded from the library.
+    """
+    mod_sets, misc_mods = {}, []
+    for f in os.listdir(modifierset_lib_folder):
+        f_path = os.path.join(modifierset_lib_folder, f)
+        if os.path.isfile(f_path) and f_path.endswith('.json'):
+            with open(f_path, 'r') as json_file:
+                mod_set_dict = json.load(json_file)
+            if 'type' in mod_set_dict:  # single object
+                load_modifier_set_object(
+                    mod_set_dict, loaded_modifiers, mod_sets, misc_mods)
+            else:  # a collection of several objects
+                for mod_set_id in mod_set_dict:
+                    load_modifier_set_object(
+                        mod_set_dict[mod_set_id], loaded_modifiers, mod_sets, misc_mods)
+    return mod_sets, misc_mods
+
+loaded_m_sets, misc_m = \
+    load_modifiersets_from_folder(folders.modifierset_lib, _loaded_modifiers)
+_loaded_modifier_sets.update(loaded_m_sets)


### PR DESCRIPTION
This should satisfy what @MingboPeng needs in order to load local user-defined standards with the .NET bindings.