### PR TITLE
fix(dc): Ensure that scoeff can run using relative paths

### DIFF
--- a/honeybee_radiance/cli/dc.py
+++ b/honeybee_radiance/cli/dc.py
@@ -2,7 +2,6 @@
 import click
 import sys
 import logging
-import os
 
 from honeybee_radiance.config import folders
 from honeybee_radiance_command.rcontrib import Rcontrib, RcontribOptions
@@ -145,16 +144,16 @@ def rcontrib_command_with_postprocess(
 
 @dc.command('scoeff')
 @click.argument(
-    'octree', type=click.Path(exists=True, file_okay=True, resolve_path=True)
+    'octree', type=click.Path(exists=True, file_okay=True)
 )
 @click.argument(
-    'sensor-grid', type=click.Path(exists=True, file_okay=True, resolve_path=True)
+    'sensor-grid', type=click.Path(exists=True, file_okay=True)
 )
 @click.argument(
-    'sky-dome', type=click.Path(exists=True, file_okay=True, resolve_path=True)
+    'sky-dome', type=click.Path(exists=True, file_okay=True)
 )
 @click.argument(
-    'sky-mtx', type=click.Path(exists=True, file_okay=True, resolve_path=True)
+    'sky-mtx', type=click.Path(exists=True, file_okay=True)
 )
 @click.option(
     '--sensor-count', type=click.INT, show_default=True,
@@ -229,8 +228,8 @@ def rfluxmtx_command_with_postprocess(
         options.update_from_string('-aa 0.0 -faf -y {}'.format(sensor_count))
 
         # create command.
-        cmd_template = 'rfluxmtx {rad_params} - {w}{sky_dome}{w} -i {w}{octree}{w} < ' \
-            '{w}{sensors}{w} | rmtxop -f{output_format} - {w}{sky_mtx}{w}'
+        cmd_template = 'rfluxmtx {rad_params} - "{sky_dome}" -i "{octree}" < ' \
+            '"{sensors}" | rmtxop -f{output_format} - "{sky_mtx}"'
 
         if conversion and conversion.strip():
             if multiply_by != 1:
@@ -244,12 +243,11 @@ def rfluxmtx_command_with_postprocess(
             cmd_template = cmd_template + ' -t '
 
         if output:
-            cmd_template = cmd_template + ' > {output}'.format(output=output)
+            cmd_template = cmd_template + ' > "{output}"'.format(output=output)
 
-        wrapper = '"' if os.name == 'nt' else '\''
         cmd = cmd_template.format(
             rad_params=options.to_radiance(), sky_dome=sky_dome, octree=octree,
-            sensors=sensor_grid, output_format=output_format, sky_mtx=sky_mtx, w=wrapper
+            sensors=sensor_grid, output_format=output_format, sky_mtx=sky_mtx
         )
 
         if dry_run:


### PR DESCRIPTION
It seems that there's an issue in Radiance's `rflumtx` command in that it doesn't pass the file paths in quotes to the `rcotrib` command that is running under the hood (resulting in the `rcontrib` command failing in spite of the input for the `rfluxmtx` command input being valid with all file paths in quotes). Changing this command to use relative paths should provide a workaround for the current recipes but we should probably bring this issue up on the Radiance forum.