### PR TITLE
fix(trans): Fix several of the Trans material properties

### DIFF
--- a/honeybee_radiance/modifier/material/glass.py
+++ b/honeybee_radiance/modifier/material/glass.py
@@ -40,6 +40,7 @@ class Glass(Material):
         * b_transmissivity
         * refraction_index
         * average_transmissivity
+        * average_transmittance
         * values
         * modifier
         * dependencies


### PR DESCRIPTION
It seems that there might have been a bug in the average_transmittance property. I took all of the new properties from page 23 of this Radiance manual:

http://www.jaloxa.eu/resources/radiance/documentation/docs/radiance_cookbook.pdf