### PR TITLE
fix(trans): Add classmethod to create material from average properties

### DIFF
--- a/tests/material_trans_test.py
+++ b/tests/material_trans_test.py
@@ -1,5 +1,6 @@
 from honeybee_radiance.modifier.material import Trans
 
+import pytest
 
 def test_trans():
     tr = Trans('test_trans')
@@ -76,3 +77,41 @@ def test_from_single_value():
     assert tr.r_reflectance == 0.6
     assert tr.g_reflectance == 0.6
     assert tr.b_reflectance == 0.6
+
+
+def test_from_average_properties():
+    tr = Trans.from_average_properties('test', 0.2, 0.5, True, True)
+    assert tr.average_reflectance == pytest.approx(0.2, rel=1e-3)
+    assert tr.average_transmittance == pytest.approx(0.5, rel=1e-3)
+    assert tr.diffuse_reflectance == 0
+    assert tr.diffuse_transmittance == pytest.approx(0.5, rel=1e-3)
+    assert tr.specular_transmittance == 0
+    assert tr.average_reflectance + tr.average_transmittance + \
+        tr.average_absorption == pytest.approx(1, rel=1e-3)
+
+    tr = Trans.from_average_properties('test', 0.2, 0.5, False, True)
+    assert tr.average_reflectance == pytest.approx(0.2, rel=1e-3)
+    assert tr.average_transmittance == pytest.approx(0.5, rel=1e-3)
+    assert tr.diffuse_reflectance == pytest.approx(0.2, rel=1e-3)
+    assert tr.diffuse_transmittance == pytest.approx(0.5, rel=1e-3)
+    assert tr.specular_transmittance == 0
+    assert tr.average_reflectance + tr.average_transmittance + \
+        tr.average_absorption == pytest.approx(1, rel=1e-3)
+
+    tr = Trans.from_average_properties('test', 0.2, 0.5, True, False)
+    assert tr.average_reflectance == pytest.approx(0.2, rel=1e-3)
+    assert tr.average_transmittance == pytest.approx(0.5, rel=1e-3)
+    assert tr.diffuse_reflectance == 0
+    assert tr.diffuse_transmittance == 0
+    assert tr.specular_transmittance == pytest.approx(0.5, rel=1e-3)
+    assert tr.average_reflectance + tr.average_transmittance + \
+        tr.average_absorption == pytest.approx(1, rel=1e-3)
+
+    tr = Trans.from_average_properties('test', 0.2, 0.5, False, False)
+    assert tr.average_reflectance == pytest.approx(0.2, rel=1e-3)
+    assert tr.average_transmittance == pytest.approx(0.5, rel=1e-3)
+    assert tr.diffuse_reflectance == pytest.approx(0.2, rel=1e-3)
+    assert tr.diffuse_transmittance == 0
+    assert tr.specular_transmittance == pytest.approx(0.5, rel=1e-3)
+    assert tr.average_reflectance + tr.average_transmittance + \
+        tr.average_absorption == pytest.approx(1, rel=1e-3)


### PR DESCRIPTION
I've come to realize that I have been using the Trans material wrong for all of these years because the properties in Radiance are not what they initially seem. And they are definitely not what you would get from any product manufacturer. So I am adding this classmethod so that we can actually construct the material from transmittance and reflectance.