### PR TITLE
fix(cli): Enable the simulation of night-time Weas

### DIFF
--- a/honeybee_radiance/cli/dc.py
+++ b/honeybee_radiance/cli/dc.py
@@ -1,6 +1,7 @@
 """honeybee radiance daylight coefficient / contribution commands."""
 import click
 import sys
+import os
 import logging
 
 from honeybee_radiance.config import folders
@@ -94,6 +95,13 @@ def rcontrib_command_with_postprocess(
         modifiers: Path to modifiers file.
     """
     try:
+        # first check to be sure there are sun-up hours; if so, write a blank file
+        if os.path.getsize(modifiers) == 0:
+            if output is not None:
+                with open(output, 'w') as wf:
+                    wf.write('')
+            return
+
         options = RcontribOptions()
         # parse input radiance parameters
         if rad_params:
@@ -225,6 +233,13 @@ def rfluxmtx_command_with_postprocess(
 
     """
     try:
+        # first check to be sure there are sun-up hours; if so, write a blank file
+        if os.path.getsize(sky_mtx) == 0:
+            if output is not None:
+                with open(output, 'w') as wf:
+                    wf.write('')
+            return
+
         options = RfluxmtxOptions()
         # parse input radiance parameters
         if rad_params.strip():

--- a/honeybee_radiance/cli/mtx.py
+++ b/honeybee_radiance/cli/mtx.py
@@ -1,6 +1,7 @@
 """Commands to work with Radiance matrix using rmtxopt and rcollate."""
 import click
 import sys
+import os
 import logging
 
 from honeybee_radiance.config import folders
@@ -12,7 +13,7 @@ from .util import handle_operator
 _logger = logging.getLogger(__name__)
 
 
-@click.group(help='Commands to work with Radiance matrix using rmtxopt.')
+@click.group(help='Commands to work with Radiance matrix using rmtxop.')
 def mtxop():
     pass
 
@@ -58,7 +59,7 @@ def mtxop():
 def two_matrix_operations(
     first_mtx, second_mtx, operator, keep_header, conversion, output_mtx,
     output_format, dry_run
-        ):
+):
     """Operations between two Radiance matrices.
 
     \b
@@ -68,6 +69,13 @@ def two_matrix_operations(
 
     """
     try:
+        # first check to be sure there are sun-up hours; if so, write a blank file
+        if os.path.getsize(first_mtx) == 0 or os.path.getsize(second_mtx) == 0:
+            if output_mtx is not None:
+                with open(output_mtx, 'w') as wf:
+                    wf.write('')
+            return
+
         cmd = 'rmtxop -f{output_format} "{first_mtx}" {operator} "{second_mtx}"'.format(
             output_format=output_format, first_mtx=first_mtx,
             operator=handle_operator(operator), second_mtx=second_mtx
@@ -151,6 +159,14 @@ def three_matrix_operations(
 
     """
     try:
+        # first check to be sure there are sun-up hours; if so, write a blank file
+        if os.path.getsize(first_mtx) == 0 or os.path.getsize(second_mtx) == 0 \
+                or os.path.getsize(third_mtx) == 0:
+            if output_mtx is not None:
+                with open(output_mtx, 'w') as wf:
+                    wf.write('')
+            return
+
         cmd = 'rmtxop -f{output_format} "{first_mtx}" {operator_one} "{second_mtx}" ' \
             ' {operator_two} "{third_mtx}"'.format(
                 output_format=output_format, first_mtx=first_mtx,

--- a/honeybee_radiance/cli/sky.py
+++ b/honeybee_radiance/cli/sky.py
@@ -326,7 +326,11 @@ def sunpath_from_wea_rad(
             print(cmd.to_radiance())
             sys.exit(0)
 
-        run_command(cmd.to_radiance(), env=folders.env)
+        try:
+            run_command(cmd.to_radiance(), env=folders.env)
+        except RuntimeError as e:  # likely a nighttime Wea; write blank .mtx file
+            with open(output, 'w') as wf:
+                wf.write('')
         files = [{'path': os.path.relpath(output, folder), 'full_path': output}]
         log_file.write(json.dumps(files))
 


### PR DESCRIPTION
Some users had pointed out that they were unable to run thermal comfort maps for run periods of just nighttime hours because all of the shortwave radiance calculations were not set up to run with Weas of nighttime hours. This commit fixes this and will just have the commands output blank files when there are no sun-up hours to simulate.