### PR TITLE
fix(octree): Add an option to keep aperture groups as black

### DIFF
--- a/honeybee_radiance/cli/octree.py
+++ b/honeybee_radiance/cli/octree.py
@@ -24,13 +24,19 @@ def octree():
     ' is provided it should be relative to project folder.'
 )
 @click.option(
-    '--default/--black', is_flag=True, default=True, show_default=True,
-    help='Flag to note wheather the octree should be created with black materials.'
+    '--default/--black',  ' /-b', default=True, show_default=True,
+    help='Flag to note whether the octree should be created completely with '
+    'black materials.'
 )
 @click.option(
-    '--include-aperture/--exclude-aperture', is_flag=True, default=True,
+    '--include-aperture/--exclude-aperture',  ' /-xa', default=True,
     show_default=True,
-    help='Flag to note wheather apertures should be included in the octree.'
+    help='Flag to note whether apertures should be included in the octree.'
+)
+@click.option(
+    '--black-groups/--exclude-groups', ' /-xg', default=True, show_default=True,
+    help='Flag to note whether dynamic aperture groups should blacked-out in '
+    'the octree or they should simply be excluded, letting light pass through.'
 )
 @click.option(
     '--add-before', type=click.STRING, multiple=True, default=None, show_default=True,
@@ -45,7 +51,9 @@ def octree():
     help='A flag to show the command without running it.'
 )
 def create_octree_from_folder(
-        folder, output, include_aperture, default, add_before, add_after, dry_run):
+    folder, output, default, include_aperture, black_groups,
+    add_before, add_after, dry_run
+):
     """Generate a static octree from a folder.
 
     folder: Path to a Radiance model folder.
@@ -58,8 +66,14 @@ def create_octree_from_folder(
             try:
                 aperture_files = model_folder.aperture_files()
                 scene_files += aperture_files
-            except FileNotFoundError:
+            except Exception:
                 pass  # no apertures available in the model
+        if black_groups:
+            try:
+                group_files = model_folder.aperture_group_files_black()
+                scene_files += group_files
+            except Exception:
+                pass  # no aperture groups available in the model
         if add_after:
             scene_files += list(add_after)
         if add_before:

--- a/honeybee_radiance/postprocess/electriclight.py
+++ b/honeybee_radiance/postprocess/electriclight.py
@@ -21,7 +21,7 @@ def daylight_control_schedules(
     grids are distributed over the entire floor of the rooms, the resulting schedules
     will be idealized, where light dimming has been optimized to supply the minimum
     illuminance setpoint everywhere in the room.
-    
+
     Args:
         results_folder: The path to the folder containing the annual daylight
             result files.
@@ -51,7 +51,7 @@ def daylight_control_schedules(
             with the off_at_min input below. (Default: 0.2).
         off_at_min: Boolean to note whether lights should switch off completely when
             they get to the minimum power input. (Default: False).
-    
+
     Returns:
         A tuple with two values.
 


### PR DESCRIPTION
I feel like blacked-out apertures is a better default behavior for all of the recipes that aren't capable of modeling dynamic apertures. At least this will make it clear to people when a certain recipe does not support dynamic groups.

It's also the default that I need in the comfort mapping workflows.