### PR TITLE
fix(static apertures): change the default name to __static_apertures__

### DIFF
--- a/honeybee_radiance/cli/multiphase.py
+++ b/honeybee_radiance/cli/multiphase.py
@@ -600,7 +600,7 @@ def prepare_multiphase_command(
             grid_states[grid['identifier']] = {}
             light_paths = [lp[0] for lp in grid['light_path']]
             for light_path in light_paths:
-                if light_path != 'static_apertures':
+                if light_path != '__static_apertures__':
                     grid_states[grid['identifier']][light_path] = \
                         [s['identifier'] for s in states_info[light_path]]
 

--- a/honeybee_radiance/lightpath.py
+++ b/honeybee_radiance/lightpath.py
@@ -2,16 +2,16 @@
 from honeybee.boundarycondition import Surface
 
 
-def light_path_from_room(model, room_identifier, static_name='static_apertures'):
+def light_path_from_room(model, room_identifier, static_name='__static_apertures__'):
     """Get the dynamic aperture groups that need to be simulated for a room in a model.
     
     Args:
         model: A honeybee Model object which will be used to identify the aperture
             groups that are needed to simulate a single room.
-        room_identifier: Text string for the identifer of the Room in the model
+        room_identifier: Text string for the identifier of the Room in the model
             for which the light path will be computed.
         static_name: An optional name to be used to refer to static apertures
-            found within the model. (Default: 'static_apertures').
+            found within the model. (Default: '__static_apertures__').
 
     Returns:
         A list of lists where each sub-list contains the identifiers of the aperture
@@ -43,7 +43,7 @@ def light_path_from_room(model, room_identifier, static_name='static_apertures')
 
         print(light_path_from_room(model, room1.identifier))
 
-        >> [['SouthWindow1'], ['static_apertures', 'NorthWindow2']]
+        >> [['SouthWindow1'], ['__static_apertures__', 'NorthWindow2']]
     """
     # get the Room object from the Model
     room = model.rooms_by_identifier([room_identifier])[0]
@@ -56,7 +56,7 @@ def light_path_from_room(model, room_identifier, static_name='static_apertures')
             if s_face.properties.radiance._dynamic_group_identifier:
                 grp_id = s_face.properties.radiance._dynamic_group_identifier
             else:
-                grp_id = 'static_apertures'
+                grp_id = static_name
             if isinstance(s_face.boundary_condition, Surface):
                 adj_room = s_face.boundary_condition.boundary_condition_objects[-1]
                 adj_rooms.add((grp_id, adj_room))
@@ -78,7 +78,7 @@ def light_path_from_room(model, room_identifier, static_name='static_apertures')
                 if s_face.properties.radiance._dynamic_group_identifier:
                     rm_grp_ids.add(s_face.properties.radiance._dynamic_group_identifier)
                 else:
-                    rm_grp_ids.add('static_apertures')
+                    rm_grp_ids.add(static_name)
         base_grp_id = room_tup[0]
         for g_id in rm_grp_ids:
             if g_id != base_grp_id:  # group has already been accounted for

--- a/honeybee_radiance/sensorgrid.py
+++ b/honeybee_radiance/sensorgrid.py
@@ -419,7 +419,7 @@ class SensorGrid(object):
         """Get or set list of lists for the light path from the grid to the sky.
 
         Each sub-list contains identifiers of aperture groups through which light
-        passes. (eg. [['SouthWindow1'], ['static_apertures', 'NorthWindow2']]).
+        passes. (eg. [['SouthWindow1'], ['__static_apertures__', 'NorthWindow2']]).
         Setting this property will override any auto-calculation of the light
         path from the model upon export to the simulation.
         """

--- a/honeybee_radiance/view.py
+++ b/honeybee_radiance/view.py
@@ -426,7 +426,7 @@ class View(object):
         """Get or set list of lists for the light path from the view to the sky.
 
         Each sub-list contains identifiers of aperture groups through which light
-        passes. (eg. [['SouthWindow1'], ['static_apertures', 'NorthWindow2']]).
+        passes. (eg. [['SouthWindow1'], ['__static_apertures__', 'NorthWindow2']]).
         Setting this property will override any auto-calculation of the light
         path from the model upon export to the simulation.
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 honeybee-core==1.51.22
-honeybee-radiance-folder==2.11.4
+honeybee-radiance-folder==2.11.5
 honeybee-radiance-command==1.22.2
 honeybee-standards==2.0.5

--- a/tests/assets/sample_office/model/folder.cfg
+++ b/tests/assets/sample_office/model/folder.cfg
@@ -1,6 +1,6 @@
 [GLOBAL]
 root = model  # folder name for the root folder
-static_apertures = static_apertures  # aperture group name for static apertures
+static_apertures = __static_apertures__  # aperture group name for static apertures
 
 [APERTURE]
 path = aperture

--- a/tests/lightpath_test.py
+++ b/tests/lightpath_test.py
@@ -26,13 +26,13 @@ def test_light_path_from_room_interior():
 
     lp = light_path_from_room(model, room1.identifier)
     assert ['SouthWindow1'] in lp
-    assert ['static_apertures', 'NorthWindow2'] in lp
+    assert ['__static_apertures__', 'NorthWindow2'] in lp
 
     room1[1].apertures_by_ratio(0.4, 0.01)  # outdoor north window
     lp = light_path_from_room(model, room1.identifier)
     assert ['SouthWindow1'] in lp
-    assert ['static_apertures'] in lp
-    assert ['static_apertures', 'NorthWindow2'] in lp
+    assert ['__static_apertures__'] in lp
+    assert ['__static_apertures__', 'NorthWindow2'] in lp
 
 
 def test_grid_and_view_info_dict():


### PR DESCRIPTION
This will ensure that they are always called the same name in the model, model folder and results folder.