### PR TITLE
fix(dynamic daylight): use full_id instead of identifier

### DIFF
--- a/honeybee_radiance/cli/multiphase.py
+++ b/honeybee_radiance/cli/multiphase.py
@@ -602,14 +602,14 @@ def prepare_multiphase_command(
         grid_states = {}
 
         for grid in grid_info:
-            grid_states[grid['identifier']] = {}
+            grid_states[grid['full_id']] = {}
             try:
                 light_paths = [lp[0] for lp in grid['light_path']]
             except KeyError:
                 light_paths = []
             for light_path in light_paths:
                 if light_path != '__static_apertures__':
-                    grid_states[grid['identifier']][light_path] = \
+                    grid_states[grid['full_id']][light_path] = \
                         [s['identifier'] for s in states_info[light_path]]
 
         grid_states_output = os.path.join(model_folder.folder, 'grid_states.json')

--- a/honeybee_radiance/cli/threephase.py
+++ b/honeybee_radiance/cli/threephase.py
@@ -197,7 +197,7 @@ def three_phase_combinations(
 
         grid_mapper = {}
         for grid in rec_data:
-            grid_mapper[grid['identifier']] = {}
+            grid_mapper[grid['full_id']] = {}
             for apt in grid['aperture_groups']:
                 for group in send_data:
                     if apt in group['aperture_groups']:
@@ -207,7 +207,7 @@ def three_phase_combinations(
                     # this should never happen for a valid radiance folder
                     raise ValueError('Unrecognizable aperture group: %s' % apt)
 
-                grid_mapper[grid['identifier']][apt] = \
+                grid_mapper[grid['full_id']][apt] = \
                     [s['identifier'] for s in states[apt]]
 
         # create all the possible combinations
@@ -223,9 +223,9 @@ def three_phase_combinations(
                         dict(
                             # create an identifier from the mix of grid and state
                             identifier='%s..%s' % (
-                                grid['identifier'], info['identifier']
+                                grid['full_id'], info['identifier']
                             ),
-                            grid_id = grid['identifier'],
+                            grid_id = grid['full_id'],
                             state_id = info['identifier'],
                             tmtx=info['tmtx'],
                             vmtx=vmtx,


### PR DESCRIPTION
Hi, @mikkelkp - I don't dare to merge this in as it might break other functionalities but we should use the `full_id` as the identifier for sensor grids instead of the `identifier`.

Otherwise, we will face issues like this: https://github.com/ladybug-tools/honeybee-radiance-postprocess/pull/67