### PR TITLE
fix(multiphase): Avoid octree creation if light path is filtered out

### DIFF
--- a/honeybee_radiance/cli/multiphase.py
+++ b/honeybee_radiance/cli/multiphase.py
@@ -653,8 +653,7 @@ def prepare_multiphase_command(
 
             for state in states:
                 light_path = state['light_path']
-                if (light_path == '__static_apertures__' and
-                    not light_path in grid_info_dict):
+                if light_path not in grid_info_dict:
                     # in this case we do not want to generate an octree
                     continue
                 


### PR DESCRIPTION
This is a more general solution and not exclusively for static apertures.