### PR TITLE
fix(glass): Ensure tiny transmittance values don't create errors

### DIFF
--- a/honeybee_radiance/modifier/material/glass.py
+++ b/honeybee_radiance/modifier/material/glass.py
@@ -416,8 +416,9 @@ class Glass(Material):
     def _transmissivity_from_transmittance(transmittance):
         """Get transmissivity from a transmittance value"""
         try:
-            return (math.sqrt(0.8402528435 + 0.0072522239 * (transmittance ** 2)) -
-                    0.9166530661) / 0.0036261119 / transmittance
+            tms = (math.sqrt(0.8402528435 + 0.0072522239 * (transmittance ** 2)) -
+                   0.9166530661) / 0.0036261119 / transmittance
+            return tms if tms > 0 else 0
         except ZeroDivisionError:
             return 0
 

--- a/tests/material_glass_test.py
+++ b/tests/material_glass_test.py
@@ -148,3 +148,6 @@ def test_from_single_transmittance():
     assert round(gl.r_transmittance, 2) == 0.4
     assert round(gl.g_transmittance, 2) == 0.4
     assert round(gl.b_transmittance, 2) == 0.4
+
+    gl = Glass.from_single_transmittance('gl_small', 0.0000000001)
+    assert gl.r_transmittance >= 0


### PR DESCRIPTION
It looks like the transmissivity function creates negative values when given very small transmittances. This fixes the issue.