### PR TITLE
fix(multiphase): Remove f-strings from modules

### DIFF
--- a/honeybee_radiance/cli/multiphase.py
+++ b/honeybee_radiance/cli/multiphase.py
@@ -699,8 +699,7 @@ def prepare_multiphase_command(
                 dynamic_mapping[study].append(info)
 
         for study, study_info in dynamic_mapping.items():
-            dynamic_output = \
-                os.path.join(model_folder.folder, f'{study}.json')
+            dynamic_output = os.path.join(model_folder.folder, '%s.json' % study)
             with open(dynamic_output, 'w') as fp:
                 json.dump(study_info, fp, indent=2)
 
@@ -721,8 +720,7 @@ def prepare_multiphase_command(
             for study in phases[phase]:
                 study_type = []
                 dynamic_mapping.append({study: study_type})
-                dynamic_output = \
-                    os.path.join(model_folder.folder, f'{study}.json')
+                dynamic_output = os.path.join(model_folder.folder, '%s.json' % study)
                 with open(dynamic_output, 'w') as fp:
                     json.dump(study_type, fp, indent=2)
 

--- a/honeybee_radiance/cli/octree.py
+++ b/honeybee_radiance/cli/octree.py
@@ -463,39 +463,40 @@ def _generate_octrees_info(state, output_folder='octree', study='two_phase',
         scene_files = state['scene_files']
         octree_name = state['identifier']
         output = os.path.join(
-            output_folder, f'{octree_name}.oct')
+            output_folder, '%s.oct' % octree_name)
         cmd = Oconv(output=output, inputs=scene_files)
         cmd.options.f = True
         commands.append(cmd)
 
-        info['octree'] = f'{octree_name}.oct'
+        info['octree'] = '%s.oct' % octree_name
 
     # direct - don't add them for 5 phase
     if 'scene_files_direct' in state and study != 'five_phase':
         scene_files_direct = state['scene_files_direct']
-        octree_direct_name = f'{state["identifier"]}_direct'
+        octree_direct_name = '%s_direct' % state['identifier']
         output_direct = os.path.join(
-            output_folder, f'{octree_direct_name}.oct')
+            output_folder, '%s.oct' % octree_direct_name)
         cmd = Oconv(output=output_direct,
                     inputs=scene_files_direct)
         cmd.options.f = True
         commands.append(cmd)
 
-        info['octree_direct'] = f'{octree_direct_name}.oct'
+        info['octree_direct'] = '%s.oct' % octree_direct_name
 
     # direct sun - don't add them for 3-phase
     if sun_path and study != 'three_phase':
         scene_files_direct = state['scene_files_direct']
         scene_files_direct_sun = [sun_path] + scene_files_direct
-        octree_direct_sun_name = f'{state["identifier"]}_direct_sun'
+        octree_direct_sun_name = '%s_direct_sun' % state['identifier']
         output_direct = \
-            os.path.join(output_folder, f'{octree_direct_sun_name}.oct')
+            os.path.join(output_folder, '%s.oct' %
+                         octree_direct_sun_name)
         cmd = Oconv(output=output_direct,
                     inputs=scene_files_direct_sun)
         cmd.options.f = True
         commands.append(cmd)
 
-        info['octree_direct_sun'] = f'{octree_direct_sun_name}.oct'
+        info['octree_direct_sun'] = '%s.oct' % octree_direct_sun_name
 
     return info, commands
 


### PR DESCRIPTION
This is used in Grasshopper so we cannot use f-strings.